### PR TITLE
chore: configure multi-module project structure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,18 @@ subprojects {
 
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-web'
+		implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+		implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+		implementation 'org.springframework.boot:spring-boot-starter-actuator'
+		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+		implementation 'org.springframework.boot:spring-boot-starter-security'
 		compileOnly 'org.projectlombok:lombok'
+		annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+		annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+		annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 		annotationProcessor 'org.projectlombok:lombok'
-		runtimeOnly 'com.h2database:h2'
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
+		testImplementation 'org.springframework.security:spring-security-test'
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,45 +4,40 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.3'
 }
 
-group = 'com.oing'
-version = '0.0.1-SNAPSHOT'
-
-java {
-	sourceCompatibility = '17'
-}
-
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
-
 repositories {
 	mavenCentral()
 }
 
-dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
-	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
-	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+subprojects {
+	group = 'com.oing'
+	version = '0.0.1-SNAPSHOT'
+	sourceCompatibility = '17'
+
+	apply plugin: 'java'
+	apply plugin: 'org.springframework.boot'
+	apply plugin: 'io.spring.dependency-management'
+
+	configurations {
+		compileOnly {
+			extendsFrom annotationProcessor
+		}
+	}
+
+	dependencies {
+		implementation 'org.springframework.boot:spring-boot-starter-web'
+		compileOnly 'org.projectlombok:lombok'
+		annotationProcessor 'org.projectlombok:lombok'
+		runtimeOnly 'com.h2database:h2'
+		testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	}
 }
 
-tasks.named('bootBuildImage') {
-	builder = 'paketobuildpacks/builder-jammy-base:latest'
+tasks.named('bootJar') {
+	enabled = false
+}
+
+tasks.named('jar') {
+	enabled = true
 }
 
 tasks.named('test') {

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':member')
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    testImplementation 'org.springframework.security:spring-security-test'
+}
+
+tasks.named('bootJar') {
+    enabled = true
+}
+
+tasks.named('jar') {
+    enabled = true
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -9,19 +9,10 @@ repositories {
 dependencies {
     implementation project(':member')
 
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
-    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
-    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
-    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('bootJar') {

--- a/config/src/main/java/com/oing/ServerApplication.java
+++ b/config/src/main/java/com/oing/ServerApplication.java
@@ -1,4 +1,4 @@
-package com.oing.server;
+package com.oing;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ServerApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ServerApplication.class, args);
+    }
 
 }

--- a/config/src/main/resources/application.yaml
+++ b/config/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:~/oing;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+    username: sa
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        create_empty_composites:
+          enabled: true
+        show_sql: true
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true

--- a/config/src/test/java/com/oing/ServerApplicationTests.java
+++ b/config/src/test/java/com/oing/ServerApplicationTests.java
@@ -1,4 +1,4 @@
-package com.oing.server;
+package com.oing;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ServerApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/member/build.gradle
+++ b/member/build.gradle
@@ -1,0 +1,15 @@
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+
+}
+
+tasks.named('bootJar') {
+    enabled = false
+}
+
+tasks.named('jar') {
+    enabled = true
+}

--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -11,8 +11,4 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/test")
-    public String test() {
-        return memberService.test();
-    }
 }

--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -1,0 +1,18 @@
+package com.oing.controller;
+
+import com.oing.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/test")
+    public String test() {
+        return memberService.test();
+    }
+}

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -5,7 +5,4 @@ import org.springframework.stereotype.Service;
 @Service
 public class MemberService {
 
-    public String test() {
-        return "test";
-    }
 }

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -1,0 +1,11 @@
+package com.oing.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+    public String test() {
+        return "test";
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,4 @@
 rootProject.name = 'server'
+
+include 'config'
+include 'member'


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
모듈 간 의존성을 최소화하고 유지보수 용이성을 향상시키기 위해 멀티모듈을 도입했습니다.

## ➕ 추가/변경된 기능

---
- 멀티모듈 도입: config 모듈과 member 모듈 추가
  - root project의 build.gradle: 모든 하위 프로젝트(subprojects)에 대한 공통 설정을 정의
  - config 모듈의 build.gradle: member 모듈에 대한 의존성을 추가하고, Spring Boot 및 기타 라이브러리에 대한 의존성을 정의
  - member 모듈의 build.gradle 
- 테스트를 위한 `test` API 생성

## 🥺 리뷰어에게 하고싶은 말

---
- 멀티 모듈 처음 도입해봤는데 수정해야 할 부분에 대해 코멘트 남겨주시면 바로 수정하겠습니다.
- 테스트를 위해 `test` API를 만들었는데 해당 PR에 문제가 없다면 merge 전에 `test` API는 삭제하겠습니다.

## 🔗 참조 or 관련된 이슈

---
