### PR TITLE
[OING-23] chore: Jacoco 테스트 커버리지 범위에서 config 모듈 제외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,8 @@ subprojects {
 						fileTree(dir: it, excludes: [
 								// 측정 안하고 싶은 패턴
 								"**/*Application*",
-								"**/*Config*"
+								"**/*Config*",
+								"**/config/*"
 								// Querydsl 관련 제거
 						] + Qdomains)
 					})
@@ -90,7 +91,8 @@ subprojects {
 
 				excludes = [
 						"**.*Application*",
-						"**.*Config*"
+						"**.*Config*",
+						"**.config.*"
 				] + Qdomains
 			}
 		}


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
<img width="500" alt="스크린샷 2023-11-24 오후 4 23 56" src="https://github.com/depromeet/14th-team5-BE/assets/69844138/783cc586-30d3-46ec-bb16-05c77f658e0d">

#7 이 `dev`로 머지가 되면서 `config` 모듈이 Jacoco 테스트 커버리지 기준을 충족하지 못하여 테스트가 실패합니다. `config` 모듈을 테스트 범위에서 제외하는 것이 적절하다고 생각하여 해당 PR을 올립니다.


## ➕ 추가/변경된 기능

---
- Jacoco 테스트 범위에서 `config` 모듈 제외

## 🥺 리뷰어에게 하고싶은 말

---
추가적으로 커버리지 범위에서 제거해야 할 모듈이나 파일이 있다면 알려주세요.

## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-23
