### PR TITLE
[OING-24] chore: Swagger 환경 세팅

### DIFF
--- a/config/src/main/java/com/oing/config/SpringWebConfig.java
+++ b/config/src/main/java/com/oing/config/SpringWebConfig.java
@@ -19,6 +19,7 @@ public class SpringWebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(webRequestInterceptor);
+        registry.addInterceptor(webRequestInterceptor)
+                .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error");
     }
 }

--- a/config/src/main/java/com/oing/config/SwaggerConfig.java
+++ b/config/src/main/java/com/oing/config/SwaggerConfig.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpHeaders;
 @OpenAPIDefinition(
         servers = @Server(url = "/", description = "Default Server URL"),
         info = @Info(
-                title = "Oing 백엔드 API 명세",
+                title = "no5ing 백엔드 API 명세",
                 description = "springdoc을 이용한 Swagger API 문서입니다.",
                 version = "1.0",
                 contact = @Contact(

--- a/config/src/main/java/com/oing/config/SwaggerConfig.java
+++ b/config/src/main/java/com/oing/config/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package com.oing.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+@OpenAPIDefinition(
+        servers = @Server(url = "/", description = "Default Server URL"),
+        info = @Info(
+                title = "Oing 백엔드 API 명세",
+                description = "springdoc을 이용한 Swagger API 문서입니다.",
+                version = "1.0",
+                contact = @Contact(
+                        name = "springdoc 공식문서",
+                        url = "https://springdoc.org/"
+                )
+        )
+)
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("JWT", bearerAuth()));
+    }
+
+    public SecurityScheme bearerAuth() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+    }
+}

--- a/config/src/main/java/com/oing/config/filter/WebRequestInterceptor.java
+++ b/config/src/main/java/com/oing/config/filter/WebRequestInterceptor.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -26,6 +27,9 @@ public class WebRequestInterceptor implements HandlerInterceptor {
     public boolean preHandle(
             HttpServletRequest request, HttpServletResponse response, Object handler
     ) throws Exception {
+        if (isPreflight(request) || isSwaggerRequest(request)) {
+            return true;
+        }
         long startTime = System.currentTimeMillis();
         request.setAttribute(START_TIME_ATTR_NAME, startTime);
         return true;
@@ -44,5 +48,14 @@ public class WebRequestInterceptor implements HandlerInterceptor {
         String forwardedIp = request.getHeader(webProperties.headerNames().proxyForwardHeader());
         String originIp = forwardedIp != null ? forwardedIp : request.getRemoteAddr();
         log.info("{} {} {} {}ms", request.getMethod(), request.getRequestURI(), originIp, executionTime);
+    }
+
+    private boolean isSwaggerRequest(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        return uri.contains("swagger") || uri.contains("api-docs") || uri.contains("webjars");
+    }
+
+    private boolean isPreflight(HttpServletRequest request) {
+        return request.getMethod().equals(HttpMethod.OPTIONS.toString());
     }
 }

--- a/config/src/main/resources/application.yaml
+++ b/config/src/main/resources/application.yaml
@@ -27,3 +27,13 @@ app:
     header-names:
       access-token: X-AUTH-TOKEN
       proxy-forward-header: X-FORWARDED-FOR
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /swagger-ui.html
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+    tags-sorter: alpha


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
프론트 측에서 백엔드 API를 UI 상에서 편리하게 이용할 수 있도록 Swagger를 세팅했습니다.

## ➕ 추가/변경된 기능

---
- Swagger 세팅
- 인터셉터 url pattern에서 swagger관련 제외하도록 추가

## 🥺 리뷰어에게 하고싶은 말

---
http://localhost:8080/swagger-ui/index.html 로 접속하면 Authentication failed가 뜹니다. `SpringWebConfig`의 인터셉터 적용 범위에서 스웨거 관련 패턴들을 다 제거하도록 추가했지만 해결되지 않습니다. 현재 상황에서는 해결할 수 없는 문제라 생각해서 PR을 올렸는데 해결할 수 있는 문제라면 알려주세요.

## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-24
