### PR TITLE
[OING-21] feat: 기본 oAuth & 멤버 인증 관련 모듈 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-local.yaml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 ## 14th-team-BE
 디프만 14기 팀 백엔드 프로젝트입니다!
+
+### 환경변수
+
+| 이름                | 설명                          |
+|-------------------|-----------------------------|
+| MYSQL_URL         | MYSQL 주소입니다 (JDBC 형태여야 합니다) |
+| MYSQL_USERNAME    | MYSQL 사용자 명 입니다.            |
+| SLACK_WEBHOOK_URL | 슬랙 웹훅 URL 입니다.              |
+| TOKEN_SECRET_KEY  | JWT 토큰용 시크릿 키 입니다.          |
+

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,10 @@ subprojects {
 		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 		implementation 'org.springframework.boot:spring-boot-starter-security'
 		implementation 'com.github.f4b6a3:ulid-creator:5.2.2'
+		implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+		runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+		runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+		implementation("com.nimbusds:nimbus-jose-jwt:9.37")
 		compileOnly 'org.projectlombok:lombok'
 		annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 		annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,7 @@ subprojects {
 		implementation 'org.springframework.boot:spring-boot-starter-actuator'
 		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 		implementation 'org.springframework.boot:spring-boot-starter-security'
+		implementation 'com.github.f4b6a3:ulid-creator:5.2.2'
 		compileOnly 'org.projectlombok:lombok'
 		annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 		annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/common/src/main/java/com/oing/domain/ErrorReportDTO.java
+++ b/common/src/main/java/com/oing/domain/ErrorReportDTO.java
@@ -1,0 +1,13 @@
+package com.oing.domain;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 12:57 PM
+ */
+public record ErrorReportDTO(
+        String errorMessage,
+        String payload
+) {
+}

--- a/common/src/main/java/com/oing/domain/model/BaseAuditEntity.java
+++ b/common/src/main/java/com/oing/domain/model/BaseAuditEntity.java
@@ -1,0 +1,30 @@
+package com.oing.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:38 AM
+ */
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseAuditEntity {
+    @LastModifiedDate
+    @Column(name = "updated_at", updatable = false)
+    private LocalDateTime updatedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/common/src/main/java/com/oing/util/IdentityGenerator.java
+++ b/common/src/main/java/com/oing/util/IdentityGenerator.java
@@ -1,0 +1,11 @@
+package com.oing.util;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:48 AM
+ */
+public interface IdentityGenerator {
+    String generateIdentity();
+}

--- a/common/src/test/java/com/oing/domain/ErrorReportDTOTest.java
+++ b/common/src/test/java/com/oing/domain/ErrorReportDTOTest.java
@@ -1,0 +1,89 @@
+package com.oing.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 1:53 PM
+ */
+class ErrorReportDTOTest {
+
+    @DisplayName("ErrorReportDTO 생성자 테스트")
+    @Test
+    void createErrorReportDTO() {
+        // Given
+        String errorMessage = "Test Error Message";
+        String payload = "Test Payload";
+
+        // When
+        ErrorReportDTO errorReportDTO = new ErrorReportDTO(errorMessage, payload);
+
+        // Then
+        assertEquals(errorMessage, errorReportDTO.errorMessage());
+        assertEquals(payload, errorReportDTO.payload());
+    }
+
+    @DisplayName("ErrorReportDTO toString 테스트")
+    @Test
+    void testToString() {
+        // Given
+        String errorMessage = "Test Error Message";
+        String payload = "Test Payload";
+        ErrorReportDTO errorReportDTO = new ErrorReportDTO(errorMessage, payload);
+
+        // When
+        String result = errorReportDTO.toString();
+
+        // Then
+        assertEquals("ErrorReportDTO[errorMessage=Test Error Message, payload=Test Payload]", result);
+    }
+
+    @DisplayName("ErrorReportDTO equals 테스트")
+    @Test
+    void testEquals() {
+        // Given
+        String errorMessage = "Test Error Message";
+        String payload = "Test Payload";
+        ErrorReportDTO errorReportDTO1 = new ErrorReportDTO(errorMessage, payload);
+        ErrorReportDTO errorReportDTO2 = new ErrorReportDTO(errorMessage, payload);
+
+        // When
+        // Then
+        assertEquals(errorReportDTO1, errorReportDTO2);
+    }
+
+    @DisplayName("ErrorReportDTO notEquals 테스트")
+    @Test
+    void testNotEquals() {
+        // Given
+        String errorMessage1 = "Test Error Message 1";
+        String payload1 = "Test Payload 1";
+        String errorMessage2 = "Test Error Message 2";
+        String payload2 = "Test Payload 2";
+        ErrorReportDTO errorReportDTO1 = new ErrorReportDTO(errorMessage1, payload1);
+        ErrorReportDTO errorReportDTO2 = new ErrorReportDTO(errorMessage2, payload2);
+
+        // When
+        // Then
+        assertNotEquals(errorReportDTO1, errorReportDTO2);
+    }
+
+    @DisplayName("ErrorReportDTO hashCode 테스트")
+    @Test
+    void testHashCode() {
+        // Given
+        String errorMessage = "Test Error Message";
+        String payload = "Test Payload";
+        ErrorReportDTO errorReportDTO1 = new ErrorReportDTO(errorMessage, payload);
+        ErrorReportDTO errorReportDTO2 = new ErrorReportDTO(errorMessage, payload);
+
+        // When
+        // Then
+        assertEquals(errorReportDTO1.hashCode(), errorReportDTO2.hashCode());
+    }
+}

--- a/common/src/test/java/com/oing/domain/model/BaseAuditEntityTest.java
+++ b/common/src/test/java/com/oing/domain/model/BaseAuditEntityTest.java
@@ -1,0 +1,27 @@
+package com.oing.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 1:44 PM
+ */
+class BaseAuditEntityTest {
+    @DisplayName("BaseAuditEntity 클래스 인스턴스 생성시 기본값은 null이어야 한다")
+    @Test
+    void fieldsShouldBeNullOnNewInstance() {
+        // Given
+        BaseAuditEntity baseAuditEntity = new BaseAuditEntity();
+
+        // When
+
+        // Then
+        assertNull(baseAuditEntity.getCreatedAt());
+        assertNull(baseAuditEntity.getUpdatedAt());
+    }
+}

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -18,9 +18,6 @@ dependencies {
     implementation 'org.flywaydb:flyway-mysql'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('bootJar') {

--- a/config/src/main/java/com/oing/ServerApplication.java
+++ b/config/src/main/java/com/oing/ServerApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
+@EnableAsync
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class ServerApplication {

--- a/config/src/main/java/com/oing/ServerApplication.java
+++ b/config/src/main/java/com/oing/ServerApplication.java
@@ -3,7 +3,9 @@ package com.oing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class ServerApplication {

--- a/config/src/main/java/com/oing/component/ApplicationListener.java
+++ b/config/src/main/java/com/oing/component/ApplicationListener.java
@@ -1,0 +1,50 @@
+package com.oing.component;
+
+import com.oing.domain.ErrorReportDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 1:16 PM
+ */
+@RequiredArgsConstructor
+@Component
+public class ApplicationListener {
+    private final SlackGateway slackGateway;
+
+    @Async
+    @EventListener
+    public void onErrorReport(ErrorReportDTO errorReportDTO) {
+        String errorMessage = errorReportDTO.errorMessage() == null ? "알 수 없는 에러" : errorReportDTO.errorMessage();
+        SlackGateway.SlackBotDto dto = SlackGateway.SlackBotDto.builder()
+                .attachments(List.of(
+                        SlackGateway.SlackBotAttachmentDto.builder()
+                                .authorName("no5ing-server")
+                                .title("백엔드 서비스 에러 리포트")
+                                .text("백엔드 서버에서 핸들링되지 않은 오류가 발생하였습니다")
+                                .fields(List.of(
+                                        SlackGateway.SlackBotFieldDto.builder()
+                                                .title("에러 메시지")
+                                                .value(errorMessage)
+                                                .shortField(false)
+                                                .build(),
+                                        SlackGateway.SlackBotFieldDto.builder()
+                                                .title("에러 페이로드")
+                                                .value(errorReportDTO.payload())
+                                                .shortField(false)
+                                                .build()
+                                ))
+                                .build()
+                ))
+                .build();
+
+        slackGateway.sendSlackBotMessage(dto);
+    }
+}

--- a/config/src/main/java/com/oing/component/JWTTokenGenerator.java
+++ b/config/src/main/java/com/oing/component/JWTTokenGenerator.java
@@ -1,4 +1,4 @@
-package com.oing.config;
+package com.oing.component;
 
 import com.oing.config.properties.TokenProperties;
 import com.oing.domain.TokenPair;

--- a/config/src/main/java/com/oing/component/SlackGateway.java
+++ b/config/src/main/java/com/oing/component/SlackGateway.java
@@ -3,13 +3,11 @@ package com.oing.component;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oing.config.properties.ExternalUrlProperties;
-import jakarta.annotation.PostConstruct;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 

--- a/config/src/main/java/com/oing/component/SlackGateway.java
+++ b/config/src/main/java/com/oing/component/SlackGateway.java
@@ -1,0 +1,73 @@
+package com.oing.component;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oing.config.properties.ExternalUrlProperties;
+import jakarta.annotation.PostConstruct;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 1:00 PM
+ */
+@RequiredArgsConstructor
+@Component
+public class SlackGateway {
+    private final ExternalUrlProperties externalUrlProperties;
+    private final ObjectMapper objectMapper;
+
+    @SneakyThrows
+    public void sendSlackBotMessage(SlackBotDto dto) {
+        String body = objectMapper.writeValueAsString(dto);
+        RestTemplate restTemplate = new RestTemplate();
+        RequestEntity<String> requestEntity = RequestEntity
+                .post(externalUrlProperties.slackWebhook())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body);
+
+        restTemplate.exchange(requestEntity, Void.class);
+    }
+
+    @Builder
+    public static class SlackBotDto{
+        @JsonProperty("attachments")
+        final List<SlackBotAttachmentDto> attachments;
+    }
+
+    @Builder
+    public static class SlackBotAttachmentDto{
+        @JsonProperty("mrkdwn_in")
+        final String mrkdwn_in = "[\"text\"]";
+        @JsonProperty("color")
+        final String color = "#ff2400";
+        @JsonProperty("author_name")
+        final String authorName;
+        @JsonProperty("title")
+        final String title;
+        @JsonProperty("text")
+        final String text;
+        @JsonProperty("fields")
+        final List<SlackBotFieldDto> fields;
+    }
+
+    @Builder
+    public static class SlackBotFieldDto {
+        @JsonProperty("title")
+        final String title;
+        @JsonProperty("value")
+        final String value;
+        @JsonProperty("short")
+        final boolean shortField;
+    }
+}

--- a/config/src/main/java/com/oing/component/UlidIdentityGenerator.java
+++ b/config/src/main/java/com/oing/component/UlidIdentityGenerator.java
@@ -1,4 +1,4 @@
-package com.oing.config;
+package com.oing.component;
 
 import com.github.f4b6a3.ulid.UlidCreator;
 import com.oing.util.IdentityGenerator;

--- a/config/src/main/java/com/oing/config/UlidIdentityGenerator.java
+++ b/config/src/main/java/com/oing/config/UlidIdentityGenerator.java
@@ -1,0 +1,19 @@
+package com.oing.config;
+
+import com.github.f4b6a3.ulid.UlidCreator;
+import com.oing.util.IdentityGenerator;
+import org.springframework.stereotype.Component;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:48 AM
+ */
+@Component
+public class UlidIdentityGenerator implements IdentityGenerator {
+    @Override
+    public String generateIdentity() {
+        return UlidCreator.getMonotonicUlid().toString();
+    }
+}

--- a/config/src/main/java/com/oing/config/properties/ExternalUrlProperties.java
+++ b/config/src/main/java/com/oing/config/properties/ExternalUrlProperties.java
@@ -1,0 +1,17 @@
+package com.oing.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 1:08 PM
+ */
+@ConfigurationProperties(prefix = "app.external-urls")
+@ConfigurationPropertiesBinding
+public record ExternalUrlProperties(
+        String slackWebhook
+) {
+}

--- a/config/src/main/resources/application-prod.yaml
+++ b/config/src/main/resources/application-prod.yaml
@@ -1,0 +1,14 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+    properties:
+      hibernate:
+        create_empty_composites:
+          enabled: true
+        show_sql: false
+        format_sql: false
+  h2:
+    console:
+      enabled: false

--- a/config/src/main/resources/application-test.yaml
+++ b/config/src/main/resources/application-test.yaml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:~/oing;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+    username: sa
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        create_empty_composites:
+          enabled: true
+        show_sql: true
+        format_sql: true
+app:
+  external-urls:
+    slack-webhook: https://www.naver.com # Must Be Replaced
+  token:
+    secret-key: thisiskeyfortestpurpose0101010101010thisiskeyfortestpurpose0101010101010

--- a/config/src/main/resources/application.yaml
+++ b/config/src/main/resources/application.yaml
@@ -27,6 +27,7 @@ app:
     url-whitelists:
       - /actuator/**
       - /swagger-ui.html
+      - /v1/auth/**
     url-no-logging:
       - /swagger-ui.html
     header-names:

--- a/config/src/main/resources/application.yaml
+++ b/config/src/main/resources/application.yaml
@@ -18,6 +18,8 @@ spring:
       settings:
         web-allow-others: true
 app:
+  external-urls:
+    slack-webhook: {SLACK_WEBHOOK_URL}
   token:
     secret-key: secret-key
     expiration:

--- a/config/src/main/resources/application.yaml
+++ b/config/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
-    url: jdbc:h2:~/oing;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
-    username: sa
+    url: ${MYSQL_URL}
+    username: ${MYSQL_USERNAME}
   jpa:
     hibernate:
       ddl-auto: update
@@ -19,9 +19,9 @@ spring:
         web-allow-others: true
 app:
   external-urls:
-    slack-webhook: {SLACK_WEBHOOK_URL}
+    slack-webhook: ${SLACK_WEBHOOK_URL}
   token:
-    secret-key: secret-key
+    secret-key: ${TOKEN_SECRET_KEY}
     expiration:
       access-token: 86400000
       refresh-token: 384000000

--- a/config/src/main/resources/template-application-local.yaml
+++ b/config/src/main/resources/template-application-local.yaml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:~/oing;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+    username: sa
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        create_empty_composites:
+          enabled: true
+        show_sql: true
+        format_sql: true
+app:
+  external-urls:
+    slack-webhook: ${SLACK_WEBHOOK_URL} # Must Be Replaced
+  token:
+    secret-key: ${TOKEN_SECRET_KEY} # Must Be Replaced

--- a/config/src/test/java/com/oing/ServerApplicationTests.java
+++ b/config/src/test/java/com/oing/ServerApplicationTests.java
@@ -2,7 +2,9 @@ package com.oing;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ServerApplicationTests {
 

--- a/member/src/main/java/com/oing/controller/AuthController.java
+++ b/member/src/main/java/com/oing/controller/AuthController.java
@@ -1,8 +1,12 @@
 package com.oing.controller;
 
+import com.oing.domain.SocialLoginProvider;
+import com.oing.domain.SocialLoginResult;
 import com.oing.dto.request.NativeSocialLoginRequest;
 import com.oing.dto.response.AuthResultResponse;
 import com.oing.restapi.AuthApi;
+import com.oing.service.AuthService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 
 /**
@@ -11,10 +15,16 @@ import org.springframework.stereotype.Controller;
  * Date: 2023/11/27
  * Time: 11:04 AM
  */
+@RequiredArgsConstructor
 @Controller
 public class AuthController implements AuthApi {
+    private final AuthService authService;
+
     @Override
-    public AuthResultResponse socialLoginWithNativeApple(NativeSocialLoginRequest request) {
+    public AuthResultResponse socialLogin(String provider, NativeSocialLoginRequest request) {
+        SocialLoginProvider socialLoginProvider = SocialLoginProvider.valueOf(provider.toUpperCase());
+        SocialLoginResult socialLoginResult = authService
+                .authenticateFromProvider(socialLoginProvider, request.accessToken());
         return null;
     }
 }

--- a/member/src/main/java/com/oing/controller/AuthController.java
+++ b/member/src/main/java/com/oing/controller/AuthController.java
@@ -1,13 +1,20 @@
 package com.oing.controller;
 
+import com.oing.domain.CreateNewUserDTO;
 import com.oing.domain.SocialLoginProvider;
 import com.oing.domain.SocialLoginResult;
+import com.oing.domain.TokenPair;
+import com.oing.domain.model.Member;
 import com.oing.dto.request.NativeSocialLoginRequest;
 import com.oing.dto.response.AuthResultResponse;
 import com.oing.restapi.AuthApi;
 import com.oing.service.AuthService;
+import com.oing.service.MemberService;
+import com.oing.service.TokenGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+
+import java.util.Optional;
 
 /**
  * no5ing-server
@@ -19,12 +26,29 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class AuthController implements AuthApi {
     private final AuthService authService;
+    private final MemberService memberService;
+    private final TokenGenerator tokenGenerator;
 
     @Override
     public AuthResultResponse socialLogin(String provider, NativeSocialLoginRequest request) {
+        // oAuth 로그인 검증 (Apple 등)
         SocialLoginProvider socialLoginProvider = SocialLoginProvider.valueOf(provider.toUpperCase());
         SocialLoginResult socialLoginResult = authService
                 .authenticateFromProvider(socialLoginProvider, request.accessToken());
-        return null;
+
+        // 위 결과에서 나온 identifier로 이미 있는 사용자인지 확인
+        Member member = memberService
+                .findMemberBySocialMemberKey(socialLoginProvider, socialLoginResult.identifier())
+                .orElseGet(() -> {
+                    //없으면 사용자 회원가입 (생성)
+                    CreateNewUserDTO createNewUserDTO = new CreateNewUserDTO(
+                            socialLoginProvider,
+                            socialLoginResult.identifier());
+                    return memberService.createNewMember(createNewUserDTO);
+                });
+
+        //사용자로 토큰 생성
+        TokenPair tokenPair = tokenGenerator.generateTokenPair(member.getId());
+        return AuthResultResponse.of(tokenPair);
     }
 }

--- a/member/src/main/java/com/oing/controller/AuthController.java
+++ b/member/src/main/java/com/oing/controller/AuthController.java
@@ -1,0 +1,20 @@
+package com.oing.controller;
+
+import com.oing.dto.request.NativeSocialLoginRequest;
+import com.oing.dto.response.AuthResultResponse;
+import com.oing.restapi.AuthApi;
+import org.springframework.stereotype.Controller;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:04 AM
+ */
+@Controller
+public class AuthController implements AuthApi {
+    @Override
+    public AuthResultResponse socialLoginWithNativeApple(NativeSocialLoginRequest request) {
+        return null;
+    }
+}

--- a/member/src/main/java/com/oing/controller/AuthController.java
+++ b/member/src/main/java/com/oing/controller/AuthController.java
@@ -11,6 +11,7 @@ import com.oing.restapi.AuthApi;
 import com.oing.service.AuthService;
 import com.oing.service.MemberService;
 import com.oing.service.TokenGenerator;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 
@@ -29,6 +30,7 @@ public class AuthController implements AuthApi {
     private final MemberService memberService;
     private final TokenGenerator tokenGenerator;
 
+    @Transactional
     @Override
     public AuthResultResponse socialLogin(String provider, NativeSocialLoginRequest request) {
         // oAuth 로그인 검증 (Apple 등)

--- a/member/src/main/java/com/oing/domain/CreateNewUserDTO.java
+++ b/member/src/main/java/com/oing/domain/CreateNewUserDTO.java
@@ -1,0 +1,13 @@
+package com.oing.domain;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 12:04 PM
+ */
+public record CreateNewUserDTO(
+        SocialLoginProvider provider,
+        String identifier
+) {
+}

--- a/member/src/main/java/com/oing/domain/SocialLoginProvider.java
+++ b/member/src/main/java/com/oing/domain/SocialLoginProvider.java
@@ -1,0 +1,11 @@
+package com.oing.domain;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:22 AM
+ */
+public enum SocialLoginProvider {
+    APPLE
+}

--- a/member/src/main/java/com/oing/domain/SocialLoginProvider.java
+++ b/member/src/main/java/com/oing/domain/SocialLoginProvider.java
@@ -7,5 +7,6 @@ package com.oing.domain;
  * Time: 11:22 AM
  */
 public enum SocialLoginProvider {
-    APPLE
+    APPLE, //애플 로그인
+    INTERNAL //내부 로그인
 }

--- a/member/src/main/java/com/oing/domain/SocialLoginResult.java
+++ b/member/src/main/java/com/oing/domain/SocialLoginResult.java
@@ -1,0 +1,12 @@
+package com.oing.domain;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:21 AM
+ */
+public record SocialLoginResult(
+        String identifier
+) {
+}

--- a/member/src/main/java/com/oing/domain/model/Member.java
+++ b/member/src/main/java/com/oing/domain/model/Member.java
@@ -3,10 +3,7 @@ package com.oing.domain.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * no5ing-server
@@ -17,6 +14,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(callSuper = false)
 @AllArgsConstructor
+@Getter
+@Setter
+@Builder
 @Entity(name = "member")
 public class Member extends BaseAuditEntity {
     @Id

--- a/member/src/main/java/com/oing/domain/model/Member.java
+++ b/member/src/main/java/com/oing/domain/model/Member.java
@@ -1,0 +1,25 @@
+package com.oing.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:31 AM
+ */
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@Entity(name = "member")
+public class Member extends BaseAuditEntity {
+    @Id
+    @Column(name = "member_id", length = 26)
+    private String id;
+}

--- a/member/src/main/java/com/oing/domain/model/SocialMember.java
+++ b/member/src/main/java/com/oing/domain/model/SocialMember.java
@@ -1,0 +1,36 @@
+package com.oing.domain.model;
+
+import com.oing.domain.SocialLoginProvider;
+import com.oing.domain.model.key.SocialMemberKey;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:32 AM
+ */
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@Table(indexes = @Index(name = "social_member_idx1", columnList = "memberId"))
+@IdClass(SocialMemberKey.class)
+@Entity(name = "social_member")
+public class SocialMember extends BaseAuditEntity {
+    @Id
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider")
+    private SocialLoginProvider provider;
+
+    @Id
+    @Column(name = "identifier")
+    private String identifier;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/member/src/main/java/com/oing/domain/model/SocialMember.java
+++ b/member/src/main/java/com/oing/domain/model/SocialMember.java
@@ -3,10 +3,7 @@ package com.oing.domain.model;
 import com.oing.domain.SocialLoginProvider;
 import com.oing.domain.model.key.SocialMemberKey;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * no5ing-server
@@ -17,6 +14,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(callSuper = false)
 @AllArgsConstructor
+@Getter
+@Setter
 @Table(indexes = @Index(name = "social_member_idx1", columnList = "memberId"))
 @IdClass(SocialMemberKey.class)
 @Entity(name = "social_member")

--- a/member/src/main/java/com/oing/domain/model/SocialMember.java
+++ b/member/src/main/java/com/oing/domain/model/SocialMember.java
@@ -16,7 +16,7 @@ import lombok.*;
 @AllArgsConstructor
 @Getter
 @Setter
-@Table(indexes = @Index(name = "social_member_idx1", columnList = "memberId"))
+@Table(indexes = @Index(name = "social_member_idx1", columnList = "member_id"))
 @IdClass(SocialMemberKey.class)
 @Entity(name = "social_member")
 public class SocialMember extends BaseAuditEntity {

--- a/member/src/main/java/com/oing/domain/model/key/SocialMemberKey.java
+++ b/member/src/main/java/com/oing/domain/model/key/SocialMemberKey.java
@@ -1,0 +1,22 @@
+package com.oing.domain.model.key;
+
+import com.oing.domain.SocialLoginProvider;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:43 AM
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class SocialMemberKey implements Serializable {
+    private SocialLoginProvider provider;
+    private String identifier;
+}

--- a/member/src/main/java/com/oing/dto/request/NativeSocialLoginRequest.java
+++ b/member/src/main/java/com/oing/dto/request/NativeSocialLoginRequest.java
@@ -1,0 +1,16 @@
+package com.oing.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:13 AM
+ */
+@Schema(description = "네이티브 소셜 로그인 요청")
+public record NativeSocialLoginRequest(
+        @NotBlank @Schema(description = "네이티브 로그인 절차 후 얻은 엑세스 토큰") String accessToken
+) {
+}

--- a/member/src/main/java/com/oing/dto/response/AppleKeyListResponse.java
+++ b/member/src/main/java/com/oing/dto/response/AppleKeyListResponse.java
@@ -1,0 +1,12 @@
+package com.oing.dto.response;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 12:23 PM
+ */
+public record AppleKeyListResponse(
+        AppleKeyResponse[] keys
+) {
+}

--- a/member/src/main/java/com/oing/dto/response/AppleKeyResponse.java
+++ b/member/src/main/java/com/oing/dto/response/AppleKeyResponse.java
@@ -1,0 +1,17 @@
+package com.oing.dto.response;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 12:23 PM
+ */
+public record AppleKeyResponse(
+        String kty,
+        String kid,
+        String use,
+        String alg,
+        String n,
+        String e
+) {
+}

--- a/member/src/main/java/com/oing/dto/response/AuthResultResponse.java
+++ b/member/src/main/java/com/oing/dto/response/AuthResultResponse.java
@@ -1,0 +1,19 @@
+package com.oing.dto.response;
+
+import com.oing.domain.TokenPair;
+import com.oing.domain.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 후 토큰 응답")
+public record AuthResultResponse(
+        @Schema(description = "엑세스 토큰", example = "")
+        String accessToken,
+
+        @Schema(description = "리프레시 토큰", example = "")
+        String refreshToken
+) {
+
+    public static AuthResultResponse of(TokenPair tokenPair) {
+        return new AuthResultResponse(tokenPair.accessToken(), tokenPair.refreshToken());
+    }
+}

--- a/member/src/main/java/com/oing/repository/MemberRepository.java
+++ b/member/src/main/java/com/oing/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.oing.repository;
+
+import com.oing.domain.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:52 AM
+ */
+public interface MemberRepository extends JpaRepository<Member, String> {
+}

--- a/member/src/main/java/com/oing/repository/SocialMemberRepository.java
+++ b/member/src/main/java/com/oing/repository/SocialMemberRepository.java
@@ -1,0 +1,14 @@
+package com.oing.repository;
+
+import com.oing.domain.model.SocialMember;
+import com.oing.domain.model.key.SocialMemberKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:45 AM
+ */
+public interface SocialMemberRepository extends JpaRepository<SocialMember, SocialMemberKey> {
+}

--- a/member/src/main/java/com/oing/restapi/AuthApi.java
+++ b/member/src/main/java/com/oing/restapi/AuthApi.java
@@ -4,10 +4,7 @@ import com.oing.dto.request.NativeSocialLoginRequest;
 import com.oing.dto.response.AuthResultResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * no5ing-server
@@ -19,6 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/auth")
 public interface AuthApi {
-    @PostMapping(value = "/social", params = "type=APPLE")
-    AuthResultResponse socialLoginWithNativeApple(@RequestBody @Valid NativeSocialLoginRequest request);
+    @PostMapping(value = "/social")
+    AuthResultResponse socialLogin(
+            @RequestParam("provider") String provider,
+            @RequestBody @Valid NativeSocialLoginRequest request
+    );
 }

--- a/member/src/main/java/com/oing/restapi/AuthApi.java
+++ b/member/src/main/java/com/oing/restapi/AuthApi.java
@@ -1,0 +1,24 @@
+package com.oing.restapi;
+
+import com.oing.dto.request.NativeSocialLoginRequest;
+import com.oing.dto.response.AuthResultResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:04 AM
+ */
+@Tag(name = "인증 API", description = "인증(로그인) 관련 API")
+@RestController
+@RequestMapping("/v1/auth")
+public interface AuthApi {
+    @PostMapping(value = "/social", params = "type=APPLE")
+    AuthResultResponse socialLoginWithNativeApple(@RequestBody @Valid NativeSocialLoginRequest request);
+}

--- a/member/src/main/java/com/oing/restapi/AuthApi.java
+++ b/member/src/main/java/com/oing/restapi/AuthApi.java
@@ -2,6 +2,7 @@ package com.oing.restapi;
 
 import com.oing.dto.request.NativeSocialLoginRequest;
 import com.oing.dto.response.AuthResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/v1/auth")
 public interface AuthApi {
+    @Operation(summary = "네이티브 소셜 로그인", description = "네이티브(apple 등) 소셜 로그인을 진행합니다.")
     @PostMapping(value = "/social")
     AuthResultResponse socialLogin(
             @RequestParam("provider") String provider,

--- a/member/src/main/java/com/oing/service/AuthService.java
+++ b/member/src/main/java/com/oing/service/AuthService.java
@@ -1,0 +1,24 @@
+package com.oing.service;
+
+import com.oing.domain.SocialLoginProvider;
+import com.oing.domain.SocialLoginResult;
+import org.springframework.stereotype.Service;
+
+/**
+ * no5ing-server
+ * User: CChuYong
+ * Date: 2023/11/27
+ * Time: 11:18 AM
+ */
+@Service
+public class AuthService {
+    public SocialLoginResult authenticateFromProvider(SocialLoginProvider provider, String accessToken) {
+        return switch (provider) {
+            case APPLE -> authenticateFromApple(accessToken);
+        };
+    }
+
+    private SocialLoginResult authenticateFromApple(String accessToken) {
+        return null;
+    }
+}

--- a/member/src/main/java/com/oing/service/AuthService.java
+++ b/member/src/main/java/com/oing/service/AuthService.java
@@ -83,7 +83,7 @@ public class AuthService {
             String identifier = parsedClaims.getBody().get("sub", String.class);
             return new SocialLoginResult(identifier);
         } catch(Exception ex) {
-            throw new DomainException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new DomainException(ErrorCode.UNKNOWN_SERVER_ERROR);
         }
     }
 }

--- a/member/src/main/java/com/oing/service/AuthService.java
+++ b/member/src/main/java/com/oing/service/AuthService.java
@@ -1,8 +1,30 @@
 package com.oing.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.jwk.JWK;
 import com.oing.domain.SocialLoginProvider;
 import com.oing.domain.SocialLoginResult;
+import com.oing.domain.exception.DomainException;
+import com.oing.domain.exception.ErrorCode;
+import com.oing.dto.response.AppleKeyListResponse;
+import com.oing.dto.response.AppleKeyResponse;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.security.Key;
+import java.security.interfaces.RSAKey;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Objects;
 
 /**
  * no5ing-server
@@ -10,15 +32,58 @@ import org.springframework.stereotype.Service;
  * Date: 2023/11/27
  * Time: 11:18 AM
  */
+@RequiredArgsConstructor
 @Service
 public class AuthService {
+    private final ObjectMapper objectMapper;
+
     public SocialLoginResult authenticateFromProvider(SocialLoginProvider provider, String accessToken) {
         return switch (provider) {
             case APPLE -> authenticateFromApple(accessToken);
+            default -> throw new DomainException(ErrorCode.INVALID_INPUT_VALUE);
         };
     }
 
     private SocialLoginResult authenticateFromApple(String accessToken) {
-        return null;
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.put("Content-type", Collections.singletonList("application/x-www-form-urlencoded;charset=utf-8"));
+
+        ResponseEntity<AppleKeyListResponse> keyListResponse = restTemplate.exchange(RequestEntity
+                .get("https://appleid.apple.com/auth/keys")
+                .headers(headers)
+                .build(), AppleKeyListResponse.class);
+
+        if(!keyListResponse.getStatusCode().is2xxSuccessful())
+            throw new DomainException(ErrorCode.UNKNOWN_SERVER_ERROR);
+
+        AppleKeyResponse[] keys = Objects.requireNonNull(keyListResponse.getBody()).keys();
+
+        try {
+            String[] tokenParts = accessToken.split("\\.");
+            String header = new String(Base64.getDecoder().decode(tokenParts[0]));
+            JsonNode node = objectMapper.readTree(header);
+            String kid = node.get("kid").asText();
+
+            AppleKeyResponse matchedKey = null;
+            for (AppleKeyResponse key : keys){
+                if(key.kid().equals(kid)) {
+                    matchedKey = key;
+                }
+            }
+
+            if(matchedKey == null) throw new DomainException(ErrorCode.INVALID_INPUT_VALUE);
+
+            Key keyData = JWK.parse(objectMapper.writeValueAsString(matchedKey)).toRSAKey().toRSAPublicKey();
+            Jws<Claims> parsedClaims = Jwts.parserBuilder()
+                    .setSigningKey(keyData)
+                    .build()
+                    .parseClaimsJws(accessToken);
+
+            String identifier = parsedClaims.getBody().get("sub", String.class);
+            return new SocialLoginResult(identifier);
+        } catch(Exception ex) {
+            throw new DomainException(ErrorCode.INVALID_INPUT_VALUE);
+        }
     }
 }

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -1,8 +1,51 @@
 package com.oing.service;
 
+import com.oing.domain.CreateNewUserDTO;
+import com.oing.domain.SocialLoginProvider;
+import com.oing.domain.model.Member;
+import com.oing.domain.model.SocialMember;
+import com.oing.domain.model.key.SocialMemberKey;
+import com.oing.repository.MemberRepository;
+import com.oing.repository.SocialMemberRepository;
+import com.oing.util.IdentityGenerator;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
+@RequiredArgsConstructor
 @Service
 public class MemberService {
+    private final MemberRepository memberRepository;
+    private final SocialMemberRepository socialMemberRepository;
 
+    private final IdentityGenerator identityGenerator;
+
+    @Transactional
+    public Optional<Member> findMemberBySocialMemberKey(SocialLoginProvider provider, String identifier) {
+        SocialMemberKey key = new SocialMemberKey(provider, identifier);
+        return socialMemberRepository
+                .findById(key)
+                .map(SocialMember::getMember);
+    }
+
+    @Transactional
+    public Member createNewMember(CreateNewUserDTO createNewUserDTO) {
+        //사용자 생성
+        Member member = Member
+                .builder()
+                .id(identityGenerator.generateIdentity())
+                .build();
+        memberRepository.save(member);
+
+        //사용자 소셜 로그인 정보 링크
+        SocialMember socialMember = new SocialMember(
+                createNewUserDTO.provider(),
+                createNewUserDTO.identifier(),
+                member);
+        socialMemberRepository.save(socialMember);
+
+        return member;
+    }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
애플 로그인 기능 및 사용자 기능, 사용자 인증이 필요했습니다

## ➕ 추가/변경된 기능

---
- POST /v1/auth/social 이 추가되었습니다
- 애플 로그인 기능이 추가되었습니다
- 관련 엔티티 (Member, SocialMember)가 추가되었습니다
- 에러 발생시 슬랙 알림 기능이 추가되었습니다.
- 테스트 프로파일이 추가되었습니다.

## 🥺 리뷰어에게 하고싶은 말

---
원래 몇개는 티켓으로 새로 빠져야하는데,, 보일러플레이팅때 못했던거 마저 해둔거라 우선 이 피쳐에 병합해두었습니다 ㅜ

## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-21
