### PR TITLE
[OING-58] feat: MemberPost 도메인 entity & repository 구성

### DIFF
--- a/member/src/test/java/com/oing/domain/model/MemberTest.java
+++ b/member/src/test/java/com/oing/domain/model/MemberTest.java
@@ -2,6 +2,9 @@ package com.oing.domain.model;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -17,9 +20,12 @@ public class MemberTest {
     void testMemberConstructorAndGetters() {
         // Given
         String memberId = "sampleId";
+        String familyId = "sampleFamilyId";
+        LocalDate dayofBirth = LocalDate.of(2023, 7, 8);
+        String name = "sampleName";
 
         // When
-        Member member = new Member(memberId);
+        Member member = new Member(memberId, familyId, dayofBirth, name, null);
 
         // Then
         assertNotNull(member);
@@ -31,8 +37,13 @@ public class MemberTest {
     void testMemberEqualsAndHashCode() {
         // Given
         String memberId = "sampleId";
-        Member member1 = new Member(memberId);
-        Member member2 = new Member(memberId);
+        String familyId = "sampleFamilyId";
+        LocalDate dayofBirth = LocalDate.of(2023, 7, 8);
+        String name = "sampleName";
+
+        // When
+        Member member1 = new Member(memberId, familyId, dayofBirth, name, null);
+        Member member2 = new Member(memberId, familyId, dayofBirth, name, null);
 
         // Then
         assertEquals(member1, member2);

--- a/member/src/test/java/com/oing/domain/model/SocialMemberTest.java
+++ b/member/src/test/java/com/oing/domain/model/SocialMemberTest.java
@@ -3,6 +3,9 @@ package com.oing.domain.model;
 import com.oing.domain.SocialLoginProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -19,7 +22,10 @@ public class SocialMemberTest {
         // Given
         SocialLoginProvider provider = SocialLoginProvider.APPLE;
         String identifier = "user123";
-        Member member = new Member("sampleId");
+
+        // When
+        Member member = new Member("sampleId", "sampleFamilyId",
+                LocalDate.of(2023, 7, 8), "sampleName", null);
 
         // When
         SocialMember socialMember = new SocialMember(provider, identifier, member);
@@ -37,8 +43,10 @@ public class SocialMemberTest {
         // Given
         SocialLoginProvider provider = SocialLoginProvider.APPLE;
         String identifier = "user123";
-        Member member = new Member("sampleId");
+        Member member = new Member("sampleId", "sampleFamilyId",
+                LocalDate.of(2023, 7, 8), "sampleName", null);
 
+        // When
         SocialMember socialMember1 = new SocialMember(provider, identifier, member);
         SocialMember socialMember2 = new SocialMember(provider, identifier, member);
 

--- a/post/build.gradle
+++ b/post/build.gradle
@@ -4,6 +4,7 @@ repositories {
 
 dependencies {
     implementation project(':common')
+    implementation project(':member')
 }
 
 tasks.named('bootJar') {

--- a/post/build.gradle
+++ b/post/build.gradle
@@ -4,7 +4,6 @@ repositories {
 
 dependencies {
     implementation project(':common')
-    implementation project(':member')
 }
 
 tasks.named('bootJar') {

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -17,9 +17,8 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "post_id", length = 26, columnDefinition = "CHAR(26)")
     private String id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
+    private String memberId;
 
     @Column(name = "post_date", nullable = false)
     private LocalDate postDate;

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,10 +18,10 @@ import java.util.List;
 @Entity(name = "member_post")
 public class MemberPost extends BaseAuditEntity {
     @Id
-    @Column(name = "post_id", length = 26, columnDefinition = "CHAR(26)")
+    @Column(name = "post_id", columnDefinition = "CHAR(26)", nullable = false)
     private String id;
 
-    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
+    @Column(name = "member_id", columnDefinition = "CHAR(26)", nullable = false)
     private String memberId;
 
     @Column(name = "post_date", nullable = false)
@@ -36,8 +37,8 @@ public class MemberPost extends BaseAuditEntity {
     private int reactionCnt;
 
     @OneToMany(mappedBy = "post")
-    private List<MemberPostComment> comments;
+    private List<MemberPostComment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "post")
-    private List<MemberPostReaction> reactions;
+    private List<MemberPostReaction> reactions = new ArrayList<>();
 }

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -11,6 +11,9 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 @Builder
+@Table(indexes = {
+        @Index(name = "member_post_idx1", columnList = "member_id")
+})
 @Entity(name = "member_post")
 public class MemberPost extends BaseAuditEntity {
     @Id
@@ -32,9 +35,9 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "reaction_cnt", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private int reactionCnt;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "member_post")
     private List<MemberPostComment> comments;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "member_post")
     private List<MemberPostReaction> reactions;
 }

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(callSuper = false)
@@ -16,7 +17,7 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "post_id", length = 26, columnDefinition = "CHAR(26)")
     private String id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
@@ -26,9 +27,15 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "image_url")
     private String imageUrl;
 
-    @Column(name = "comment_cnt", nullable = false)
+    @Column(name = "comment_cnt", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private int commentCnt;
 
-    @Column(name = "reaction_cnt", nullable = false)
+    @Column(name = "reaction_cnt", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private int reactionCnt;
+
+    @OneToMany(mappedBy = "post")
+    private List<MemberPostComment> comments;
+
+    @OneToMany(mappedBy = "post")
+    private List<MemberPostReaction> reactions;
 }

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -35,9 +35,9 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "reaction_cnt", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private int reactionCnt;
 
-    @OneToMany(mappedBy = "member_post")
+    @OneToMany(mappedBy = "post")
     private List<MemberPostComment> comments;
 
-    @OneToMany(mappedBy = "member_post")
+    @OneToMany(mappedBy = "post")
     private List<MemberPostReaction> reactions;
 }

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 @Getter
 @Builder
 @Entity(name = "member_post")
-public class MemberPost extends BaseAuditEntity {
+public class MemberPost extends BaseEntity {
     @Id
     @Column(name = "post_id", length = 26, columnDefinition = "CHAR(26)")
     private String id;

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -1,0 +1,33 @@
+package com.oing.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity(name = "member_post")
+public class MemberPost extends BaseAuditEntity {
+    @Id
+    @Column(name = "post_id", length = 26, columnDefinition = "CHAR(26)")
+    private String id;
+
+    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
+    private String memberId;
+
+    @Column(name = "post_date", nullable = false)
+    private LocalDate postDate;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "comment_cnt", nullable = false)
+    private int commentCnt;
+
+    @Column(name = "reaction_cnt", nullable = false)
+    private int reactionCnt;
+}

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -11,13 +11,14 @@ import java.time.LocalDate;
 @Getter
 @Builder
 @Entity(name = "member_post")
-public class MemberPost extends BaseEntity {
+public class MemberPost extends BaseAuditEntity {
     @Id
     @Column(name = "post_id", length = 26, columnDefinition = "CHAR(26)")
     private String id;
 
-    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
-    private String memberId;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "post_date", nullable = false)
     private LocalDate postDate;

--- a/post/src/main/java/com/oing/domain/model/MemberPostComment.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostComment.java
@@ -14,11 +14,11 @@ public class MemberPostComment extends BaseAuditEntity {
     @Column(name = "comment_id", length = 26, columnDefinition = "CHAR(26)")
     private String id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private MemberPost post;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/post/src/main/java/com/oing/domain/model/MemberPostComment.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostComment.java
@@ -18,9 +18,8 @@ public class MemberPostComment extends BaseAuditEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private MemberPost post;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
+    private String memberId;
 
     @Column(name = "comment", nullable = false)
     private String comment;

--- a/post/src/main/java/com/oing/domain/model/MemberPostComment.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostComment.java
@@ -18,8 +18,9 @@ public class MemberPostComment extends BaseAuditEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private MemberPost post;
 
-    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
-    private String memberId;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "comment", nullable = false)
     private String comment;

--- a/post/src/main/java/com/oing/domain/model/MemberPostComment.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostComment.java
@@ -1,0 +1,26 @@
+package com.oing.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity(name = "member_post_comment")
+public class MemberPostComment extends BaseAuditEntity {
+    @Id
+    @Column(name = "comment_id", length = 26, columnDefinition = "CHAR(26)")
+    private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private MemberPost post;
+
+    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
+    private String memberId;
+
+    @Column(name = "comment", nullable = false)
+    private String comment;
+}

--- a/post/src/main/java/com/oing/domain/model/MemberPostComment.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostComment.java
@@ -15,14 +15,14 @@ import lombok.*;
 @Entity(name = "member_post_comment")
 public class MemberPostComment extends BaseAuditEntity {
     @Id
-    @Column(name = "comment_id", length = 26, columnDefinition = "CHAR(26)")
+    @Column(name = "comment_id", columnDefinition = "CHAR(26)", nullable = false)
     private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private MemberPost post;
 
-    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
+    @Column(name = "member_id", columnDefinition = "CHAR(26)", nullable = false)
     private String memberId;
 
     @Column(name = "comment", nullable = false)

--- a/post/src/main/java/com/oing/domain/model/MemberPostComment.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostComment.java
@@ -8,6 +8,10 @@ import lombok.*;
 @AllArgsConstructor
 @Getter
 @Builder
+@Table(indexes = {
+        @Index(name = "member_post_comment_idx1", columnList = "post_id"),
+        @Index(name = "member_post_comment_idx2", columnList = "member_id")
+})
 @Entity(name = "member_post_comment")
 public class MemberPostComment extends BaseAuditEntity {
     @Id

--- a/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
@@ -1,0 +1,26 @@
+package com.oing.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@Getter
+@Builder
+@Entity(name = "member_post_reaction")
+public class MemberPostReaction {
+    @Id
+    @Column(name = "reaction_id", length = 26, columnDefinition = "CHAR(26)")
+    private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private MemberPost post;
+
+    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
+    private String memberId;
+
+    @Column(name = "ascii", length = 16, nullable = false)
+    private String ascii;
+}

--- a/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
@@ -15,16 +15,16 @@ import lombok.*;
 @Entity(name = "member_post_reaction")
 public class MemberPostReaction extends BaseEntity {
     @Id
-    @Column(name = "reaction_id", length = 26, columnDefinition = "CHAR(26)")
+    @Column(name = "reaction_id", columnDefinition = "CHAR(26)", nullable = false)
     private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private MemberPost post;
 
-    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
+    @Column(name = "member_id", columnDefinition = "CHAR(26)", nullable = false)
     private String memberId;
 
-    @Column(name = "ascii", length = 16, nullable = false)
+    @Column(name = "ascii", nullable = false)
     private String ascii;
 }

--- a/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Getter
 @Builder
 @Entity(name = "member_post_reaction")
-public class MemberPostReaction {
+public class MemberPostReaction extends BaseEntity {
     @Id
     @Column(name = "reaction_id", length = 26, columnDefinition = "CHAR(26)")
     private String id;
@@ -18,8 +18,9 @@ public class MemberPostReaction {
     @JoinColumn(name = "post_id", nullable = false)
     private MemberPost post;
 
-    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
-    private String memberId;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "ascii", length = 16, nullable = false)
     private String ascii;

--- a/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
@@ -18,9 +18,8 @@ public class MemberPostReaction extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private MemberPost post;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
+    private String memberId;
 
     @Column(name = "ascii", length = 16, nullable = false)
     private String ascii;

--- a/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
@@ -8,6 +8,10 @@ import lombok.*;
 @AllArgsConstructor
 @Getter
 @Builder
+@Table(indexes = {
+        @Index(name = "member_post_reaction_idx1", columnList = "post_id"),
+        @Index(name = "member_post_reaction_idx2", columnList = "member_id")
+})
 @Entity(name = "member_post_reaction")
 public class MemberPostReaction extends BaseEntity {
     @Id

--- a/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
@@ -14,11 +14,11 @@ public class MemberPostReaction extends BaseEntity {
     @Column(name = "reaction_id", length = 26, columnDefinition = "CHAR(26)")
     private String id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private MemberPost post;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/post/src/main/java/com/oing/repository/MemberPostCommentRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberPostCommentRepository.java
@@ -1,0 +1,7 @@
+package com.oing.repository;
+
+import com.oing.domain.model.MemberPostComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberPostCommentRepository extends JpaRepository<MemberPostComment, String> {
+}

--- a/post/src/main/java/com/oing/repository/MemberPostReactionRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberPostReactionRepository.java
@@ -1,0 +1,7 @@
+package com.oing.repository;
+
+import com.oing.domain.model.MemberPostReaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberPostReactionRepository extends JpaRepository<MemberPostReaction, String> {
+}

--- a/post/src/main/java/com/oing/repository/MemberPostRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRepository.java
@@ -1,0 +1,7 @@
+package com.oing.repository;
+
+import com.oing.domain.model.MemberPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberPostRepository extends JpaRepository<MemberPost, String> {
+}

--- a/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
@@ -1,0 +1,32 @@
+package com.oing.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MemberPostCommentTest {
+
+    @DisplayName("MemberPostComment 생성자 및 getter 테스트")
+    @Test
+    void testMemberPostCommentConstructorAndGetters() {
+        // Given
+        String postId = "samplePostId";
+        String memberId = "sampleMemberId";
+        String commentId = "sampleCommentId";
+        String commentContents = "sampleCommentContents";
+        LocalDate postDate = LocalDate.of(2023, 7, 8);
+        MemberPost post = new MemberPost(postId, memberId, postDate, null, 0, 0,
+                null, null);
+
+        // When
+        MemberPostComment comment = new MemberPostComment(commentId, post, memberId, commentContents);
+
+        // Then
+        assertNotNull(comment);
+        assertEquals(commentId, comment.getId());
+    }
+}

--- a/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
@@ -1,0 +1,32 @@
+package com.oing.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MemberPostReactionTest {
+
+    @DisplayName("MemberPostReaction 생성자 및 getter 테스트")
+    @Test
+    void testMemberPostReactionConstructorAndGetters() {
+        // Given
+        String postId = "samplePostId";
+        String memberId = "sampleMemberId";
+        String reactionId = "sampleCommentId";
+        String ascii = "sampleAscii";
+        LocalDate postDate = LocalDate.of(2023, 7, 8);
+        MemberPost post = new MemberPost(postId, memberId, postDate, null, 0, 0,
+                null, null);
+
+        // When
+        MemberPostReaction reaction = new MemberPostReaction(reactionId, post, memberId, ascii);
+
+        // Then
+        assertNotNull(reaction);
+        assertEquals(reactionId, reaction.getId());
+    }
+}

--- a/post/src/test/java/com/oing/domain/model/MemberPostTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostTest.java
@@ -1,0 +1,29 @@
+package com.oing.domain.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class MemberPostTest {
+
+    @DisplayName("MemberPost 생성자 및 getter 테스트")
+    @Test
+    void testMemberPostConstructorAndGetters() {
+        // Given
+        String postId = "samplePostId";
+        String memberId = "sampleMemberId";
+        LocalDate postDate = LocalDate.of(2023, 7, 8);
+
+        // When
+        MemberPost post = new MemberPost(postId, memberId, postDate, null, 0, 0,
+                null, null);
+
+        // Then
+        assertNotNull(post);
+        assertEquals(postId, post.getId());
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
MemberPost 도메인 DDL 기반 모델을 구성했습니다.

## ➕ 추가/변경된 기능

---
- MemberPost 엔티티 및 레포지토리 구성
- MemberPostComment 엔티티 및 레포지토리 구성
- MemberPostReaction 엔티티 및 레포지토리 구성
- 새로 생성한 도메인에 대해 테스트 코드 추가

## 🥺 리뷰어에게 하고싶은 말

---
수정해야 할 부분이 있는지 확인해주세요. 🥲

## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-58
