### PR TITLE
[OING-67] feat: 피드 업로드 API 모킹

### DIFF
--- a/common/src/main/java/com/oing/util/PreSignedUrlGenerator.java
+++ b/common/src/main/java/com/oing/util/PreSignedUrlGenerator.java
@@ -3,5 +3,5 @@ package com.oing.util;
 import com.oing.dto.response.PreSignedUrlResponse;
 
 public interface PreSignedUrlGenerator {
-    PreSignedUrlResponse getPreSignedUrl(String imageName, Long memberId);
+    PreSignedUrlResponse getFeedPreSignedUrl(String imageName, Long memberId);
 }

--- a/common/src/main/java/com/oing/util/PreSignedUrlGenerator.java
+++ b/common/src/main/java/com/oing/util/PreSignedUrlGenerator.java
@@ -3,5 +3,5 @@ package com.oing.util;
 import com.oing.dto.response.PreSignedUrlResponse;
 
 public interface PreSignedUrlGenerator {
-    PreSignedUrlResponse getFeedPreSignedUrl(String imageName, Long memberId);
+    PreSignedUrlResponse getFeedPreSignedUrl(String imageName);
 }

--- a/gateway/src/main/java/com/oing/config/support/S3PreSignedUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/S3PreSignedUrlProvider.java
@@ -26,9 +26,10 @@ public class S3PreSignedUrlProvider implements PreSignedUrlGenerator {
     private final AmazonS3Client amazonS3Client;
 
     @Override
-    public PreSignedUrlResponse getPreSignedUrl(String imageName, Long memberId) {
+    public PreSignedUrlResponse getFeedPreSignedUrl(String imageName, Long memberId) {
 
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest(imageName, memberId);
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest("feed",
+                imageName, memberId);
 
         return new PreSignedUrlResponse(generatePreSignedUrl(generatePresignedUrlRequest));
     }
@@ -44,9 +45,9 @@ public class S3PreSignedUrlProvider implements PreSignedUrlGenerator {
         return preSignedUrl;
     }
 
-    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String imageName, Long memberId) {
+    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String directory, String imageName, Long memberId) {
         String savedImageName = uniqueImageName(imageName, memberId);
-        String savedImagePath = "images" + "/" + savedImageName;
+        String savedImagePath = "images" + "/" + directory + "/" + savedImageName;
 
         return getPreSignedUrlRequest(bucket, savedImagePath);
     }

--- a/gateway/src/main/java/com/oing/config/support/S3PreSignedUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/S3PreSignedUrlProvider.java
@@ -7,13 +7,14 @@ import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.oing.dto.response.PreSignedUrlResponse;
+import com.oing.util.IdentityGenerator;
 import com.oing.util.PreSignedUrlGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
 import java.util.Date;
-import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,6 +25,7 @@ public class S3PreSignedUrlProvider implements PreSignedUrlGenerator {
     private String bucket;
 
     private final AmazonS3Client amazonS3Client;
+    private final IdentityGenerator identityGenerator;
 
     @Override
     public PreSignedUrlResponse getFeedPreSignedUrl(String imageName) {
@@ -46,7 +48,7 @@ public class S3PreSignedUrlProvider implements PreSignedUrlGenerator {
     }
 
     private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String directory, String imageName) {
-        String savedImageName = uniqueImageName(imageName);
+        String savedImageName = generateUniqueImageName(imageName);
         String savedImagePath = "images" + "/" + directory + "/" + savedImageName;
 
         return getPreSignedUrlRequest(bucket, savedImagePath);
@@ -65,9 +67,10 @@ public class S3PreSignedUrlProvider implements PreSignedUrlGenerator {
     }
 
     /**
-     * image path 형식 : "images" + "/" + "기능 dir" + "/" + UUID + "_" + imageName + 확장자;
+     * image path 형식 : "images" + "/" + "기능 dir" + "/" + ULID + 확장자;
      */
-    private String uniqueImageName(String imageName) {
-        return UUID.randomUUID() + "_" + imageName;
+    private String generateUniqueImageName(String imageName) {
+        String ext = imageName.substring(imageName.lastIndexOf("."));
+        return identityGenerator.generateIdentity() + ext;
     }
 }

--- a/gateway/src/main/java/com/oing/config/support/S3PreSignedUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/S3PreSignedUrlProvider.java
@@ -26,10 +26,10 @@ public class S3PreSignedUrlProvider implements PreSignedUrlGenerator {
     private final AmazonS3Client amazonS3Client;
 
     @Override
-    public PreSignedUrlResponse getFeedPreSignedUrl(String imageName, Long memberId) {
+    public PreSignedUrlResponse getFeedPreSignedUrl(String imageName) {
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest("feed",
-                imageName, memberId);
+                imageName);
 
         return new PreSignedUrlResponse(generatePreSignedUrl(generatePresignedUrlRequest));
     }
@@ -45,8 +45,8 @@ public class S3PreSignedUrlProvider implements PreSignedUrlGenerator {
         return preSignedUrl;
     }
 
-    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String directory, String imageName, Long memberId) {
-        String savedImageName = uniqueImageName(imageName, memberId);
+    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String directory, String imageName) {
+        String savedImageName = uniqueImageName(imageName);
         String savedImagePath = "images" + "/" + directory + "/" + savedImageName;
 
         return getPreSignedUrlRequest(bucket, savedImagePath);
@@ -65,9 +65,9 @@ public class S3PreSignedUrlProvider implements PreSignedUrlGenerator {
     }
 
     /**
-     * image path 형식 : "images" + "/" + memberId + "/" + UUID + "_" + imageName + 확장자;
+     * image path 형식 : "images" + "/" + "기능 dir" + "/" + UUID + "_" + imageName + 확장자;
      */
-    private String uniqueImageName(String imageName, Long memberId) {
-        return memberId + "/" + UUID.randomUUID() + "_" + imageName;
+    private String uniqueImageName(String imageName) {
+        return UUID.randomUUID() + "_" + imageName;
     }
 }

--- a/gateway/src/main/resources/db/migration/V2__modify_Post.sql
+++ b/gateway/src/main/resources/db/migration/V2__modify_Post.sql
@@ -1,3 +1,3 @@
-ALTER TABLE `member_post` ADD COLUMN `content` VARCHAR(8) NOT NULL;
+ALTER TABLE `member_post` ADD COLUMN `content` VARCHAR(255);
 ALTER TABLE `member_post` MODIFY COLUMN `image_url` TEXT NOT NULL;
 ALTER TABLE `member_post_reaction` CHANGE COLUMN `ascii` `emoji` VARCHAR(16) NOT NULL;

--- a/gateway/src/main/resources/db/migration/V2__modify_Post.sql
+++ b/gateway/src/main/resources/db/migration/V2__modify_Post.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `member_post` ADD COLUMN `content` VARCHAR(8) NOT NULL;
+ALTER TABLE `member_post` MODIFY COLUMN `image_url` TEXT NOT NULL;
+ALTER TABLE `member_post_reaction` CHANGE COLUMN `ascii` `emoji` VARCHAR(16) NOT NULL;

--- a/gateway/src/test/java/com/oing/config/support/S3PreSignedUrlProviderTest.java
+++ b/gateway/src/test/java/com/oing/config/support/S3PreSignedUrlProviderTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.oing.dto.response.PreSignedUrlResponse;
 import com.oing.support.InfraTest;
+import com.oing.util.IdentityGenerator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,15 +28,15 @@ public class S3PreSignedUrlProviderTest extends InfraTest {
 
     @BeforeEach
     void setUp() {
-        provider = new S3PreSignedUrlProvider(amazonS3Client);
+        IdentityGenerator identityGenerator = mock(IdentityGenerator.class);
+        provider = new S3PreSignedUrlProvider(amazonS3Client, identityGenerator);
     }
 
     @Test
     @DisplayName("PreSigned Url을 성공적으로 얻는다")
     void getPreSignedUrl() {
         //given
-        String imageName = "test-image";
-        Long memberId = 123L;
+        String imageName = "test_image.jpg";
         URL mockPresignedUrl = mock(URL.class);
         when(amazonS3Client.generatePresignedUrl(any(GeneratePresignedUrlRequest.class))).thenReturn(mockPresignedUrl);
 

--- a/gateway/src/test/java/com/oing/config/support/S3PreSignedUrlProviderTest.java
+++ b/gateway/src/test/java/com/oing/config/support/S3PreSignedUrlProviderTest.java
@@ -40,7 +40,7 @@ public class S3PreSignedUrlProviderTest extends InfraTest {
         when(amazonS3Client.generatePresignedUrl(any(GeneratePresignedUrlRequest.class))).thenReturn(mockPresignedUrl);
 
         // when
-        PreSignedUrlResponse response = provider.getFeedPreSignedUrl(imageName, memberId);
+        PreSignedUrlResponse response = provider.getFeedPreSignedUrl(imageName);
 
         // then
         Assertions.assertAll(

--- a/gateway/src/test/java/com/oing/config/support/S3PreSignedUrlProviderTest.java
+++ b/gateway/src/test/java/com/oing/config/support/S3PreSignedUrlProviderTest.java
@@ -40,7 +40,7 @@ public class S3PreSignedUrlProviderTest extends InfraTest {
         when(amazonS3Client.generatePresignedUrl(any(GeneratePresignedUrlRequest.class))).thenReturn(mockPresignedUrl);
 
         // when
-        PreSignedUrlResponse response = provider.getPreSignedUrl(imageName, memberId);
+        PreSignedUrlResponse response = provider.getFeedPreSignedUrl(imageName, memberId);
 
         // then
         Assertions.assertAll(

--- a/member/src/test/java/com/oing/domain/CreateNewUserDTOTest.java
+++ b/member/src/test/java/com/oing/domain/CreateNewUserDTOTest.java
@@ -2,6 +2,9 @@ package com.oing.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -19,9 +22,12 @@ public class CreateNewUserDTOTest {
         // Given
         SocialLoginProvider provider = SocialLoginProvider.APPLE;
         String identifier = "user123";
+        String memberName = "디프만";
+        LocalDate dayOfBirth = LocalDate.of(2000, 7,8);
+        String profileImgUrl = "https://picsum.photos/200/300?random=1";
 
         // When
-        CreateNewUserDTO createUserDTO = new CreateNewUserDTO(provider, identifier);
+        CreateNewUserDTO createUserDTO = new CreateNewUserDTO(provider, identifier, memberName, dayOfBirth, profileImgUrl);
 
         // Then
         assertNotNull(createUserDTO);
@@ -35,9 +41,12 @@ public class CreateNewUserDTOTest {
         // Given
         SocialLoginProvider provider = SocialLoginProvider.INTERNAL;
         String identifier = "admin";
+        String memberName = "관리자";
+        LocalDate dayOfBirth = LocalDate.of(2000, 7,8);
+        String profileImgUrl = "https://picsum.photos/200/300?random=1";
 
         // When
-        CreateNewUserDTO createUserDTO = new CreateNewUserDTO(provider, identifier);
+        CreateNewUserDTO createUserDTO = new CreateNewUserDTO(provider, identifier, memberName, dayOfBirth, profileImgUrl);
 
         // Then
         assertNotNull(createUserDTO);

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -66,8 +66,8 @@ public class PostController implements PostApi {
         Optional<MemberPost> myPost;
         if (new Random().nextBoolean()) {
             myPost = Optional.of(new MemberPost("01HGW2N7EHJVJ4CJ999RRS2E", "01HGW2N7EHJVJ4CJ888RRS2E",
-                    LocalDate.now(), "https://picsum.photos/200/300?random=00", 0, 0,
-                    Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+                    LocalDate.now(), "https://picsum.photos/200/300?random=00", "hi", 0,
+                    0, Collections.EMPTY_LIST, Collections.EMPTY_LIST));
         } else {
             myPost = Optional.empty();
         }

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -29,8 +29,8 @@ public class PostController implements PostApi {
     private final PreSignedUrlGenerator preSignedUrlGenerator;
 
     @Override
-    public PreSignedUrlResponse requestPresignedUrl(String imageName) {
-        return preSignedUrlGenerator.getFeedPreSignedUrl(imageName);
+    public ResponseEntity<PreSignedUrlResponse> requestPresignedUrl(String imageName) {
+        return ResponseEntity.ok(preSignedUrlGenerator.getFeedPreSignedUrl(imageName));
     }
 
     @Override

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -29,8 +29,8 @@ public class PostController implements PostApi {
     private final PreSignedUrlGenerator preSignedUrlGenerator;
 
     @Override
-    public PreSignedUrlResponse requestPresignedUrl(Long memberId, String imageName) {
-        return preSignedUrlGenerator.getFeedPreSignedUrl(imageName, memberId);
+    public PreSignedUrlResponse requestPresignedUrl(String imageName) {
+        return preSignedUrlGenerator.getFeedPreSignedUrl(imageName);
     }
 
     @Override

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -5,7 +5,6 @@ import com.oing.domain.model.MemberPost;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.response.PaginationResponse;
 import com.oing.dto.response.PostResponse;
-import com.oing.dto.response.PostFeedResponse;
 import com.oing.dto.response.PreSignedUrlResponse;
 import com.oing.restapi.PostApi;
 import com.oing.util.PreSignedUrlGenerator;

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -65,7 +65,9 @@ public class PostController implements PostApi {
 //        Optional<MemberPost> myPost = memberPostService.findPostByMemberId(tokenAuthenticationHolder.getUserId());
         Optional<MemberPost> myPost;
         if (new Random().nextBoolean()) {
-            myPost = Optional.of(new MemberPost("01HGW2N7EHJVJ4CJ999RRS2E", "01HGW2N7EHJVJ4CJ888RRS2E", LocalDate.now(), "https://picsum.photos/200/300?random=00", 0, 0, Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+            myPost = Optional.of(new MemberPost("01HGW2N7EHJVJ4CJ999RRS2E", "01HGW2N7EHJVJ4CJ888RRS2E",
+                    LocalDate.now(), "https://picsum.photos/200/300?random=00", 0, 0,
+                    Collections.EMPTY_LIST, Collections.EMPTY_LIST));
         } else {
             myPost = Optional.empty();
         }

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -30,7 +30,7 @@ public class PostController implements PostApi {
 
     @Override
     public PreSignedUrlResponse requestPresignedUrl(Long memberId, String imageName) {
-        return preSignedUrlGenerator.getPreSignedUrl(imageName, memberId);
+        return preSignedUrlGenerator.getFeedPreSignedUrl(imageName, memberId);
     }
 
     @Override

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -52,6 +52,7 @@ public class PostController implements PostApi {
                             random.nextInt(5),
                             random.nextInt(5),
                             "https://picsum.photos/200/300?random=" + currentIndex,
+                            "hi",
                             ZonedDateTime.now().minusSeconds(currentIndex * 30L)
                     )
             );
@@ -84,6 +85,7 @@ public class PostController implements PostApi {
                 0,
                 0,
                 "https://picsum.photos/200/300?random=00",
+                "hi",
                 ZonedDateTime.now()
         );
 
@@ -91,8 +93,25 @@ public class PostController implements PostApi {
     }
 
     @Override
-    public PostResponse createPost(CreatePostRequest request) {
-        return null;
+    public ResponseEntity<PostResponse> createPost(CreatePostRequest request) {
+        CreatePostRequest createPostRequest = new CreatePostRequest(
+                request.imageUrl(),
+                request.content()
+        );
+
+        String postIdBase = "01HGW2N7EHJVJ4CJ999RRS2E";
+        String writerIdBase = "01HGW2N7EHJVJ4CJ888RRS2E";
+        PostResponse mockResponse = new PostResponse(
+                postIdBase,
+                writerIdBase,
+                0,
+                0,
+                createPostRequest.imageUrl(),
+                createPostRequest.content(),
+                ZonedDateTime.now()
+        );
+
+        return ResponseEntity.ok(mockResponse);
     }
 
     @Override

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -9,12 +9,14 @@ import com.oing.dto.response.PreSignedUrlResponse;
 import com.oing.restapi.PostApi;
 import com.oing.util.PreSignedUrlGenerator;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 
 /**
  * no5ing-server
@@ -29,8 +31,8 @@ public class PostController implements PostApi {
     private final PreSignedUrlGenerator preSignedUrlGenerator;
 
     @Override
-    public ResponseEntity<PreSignedUrlResponse> requestPresignedUrl(String imageName) {
-        return ResponseEntity.ok(preSignedUrlGenerator.getFeedPreSignedUrl(imageName));
+    public PreSignedUrlResponse requestPresignedUrl(String imageName) {
+        return preSignedUrlGenerator.getFeedPreSignedUrl(imageName);
     }
 
     @Override
@@ -62,7 +64,7 @@ public class PostController implements PostApi {
     }
 
     @Override
-    public ResponseEntity<PostResponse> fetchDailyFeeds() {
+    public PostResponse fetchDailyFeeds() {
 //        Optional<MemberPost> myPost = memberPostService.findPostByMemberId(tokenAuthenticationHolder.getUserId());
         Optional<MemberPost> myPost;
         if (new Random().nextBoolean()) {
@@ -74,7 +76,7 @@ public class PostController implements PostApi {
         }
 
         if (myPost.isEmpty()) {
-            return ResponseEntity.noContent().build();
+            return null;
         }
 
         String postIdBase = "01HGW2N7EHJVJ4CJ999RRS2E";
@@ -89,11 +91,11 @@ public class PostController implements PostApi {
                 ZonedDateTime.now()
         );
 
-        return ResponseEntity.ok(mockResponse);
+        return mockResponse;
     }
 
     @Override
-    public ResponseEntity<PostResponse> createPost(CreatePostRequest request) {
+    public PostResponse createPost(CreatePostRequest request) {
         String postIdBase = "01HGW2N7EHJVJ4CJ999RRS2E";
         String writerIdBase = "01HGW2N7EHJVJ4CJ888RRS2E";
         PostResponse mockResponse = new PostResponse(
@@ -106,7 +108,7 @@ public class PostController implements PostApi {
                 ZonedDateTime.now()
         );
 
-        return ResponseEntity.ok(mockResponse);
+        return mockResponse;
     }
 
     @Override

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -67,8 +67,8 @@ public class PostController implements PostApi {
         Optional<MemberPost> myPost;
         if (new Random().nextBoolean()) {
             myPost = Optional.of(new MemberPost("01HGW2N7EHJVJ4CJ999RRS2E", "01HGW2N7EHJVJ4CJ888RRS2E",
-                    LocalDate.now(), "https://picsum.photos/200/300?random=00", "hi", 0,
-                    0, Collections.EMPTY_LIST, Collections.EMPTY_LIST));
+                    LocalDate.now(), "https://picsum.photos/200/300?random=00", "hi",
+                    0, 0));
         } else {
             myPost = Optional.empty();
         }
@@ -94,11 +94,6 @@ public class PostController implements PostApi {
 
     @Override
     public ResponseEntity<PostResponse> createPost(CreatePostRequest request) {
-        CreatePostRequest createPostRequest = new CreatePostRequest(
-                request.imageUrl(),
-                request.content()
-        );
-
         String postIdBase = "01HGW2N7EHJVJ4CJ999RRS2E";
         String writerIdBase = "01HGW2N7EHJVJ4CJ888RRS2E";
         PostResponse mockResponse = new PostResponse(
@@ -106,8 +101,8 @@ public class PostController implements PostApi {
                 writerIdBase,
                 0,
                 0,
-                createPostRequest.imageUrl(),
-                createPostRequest.content(),
+                request.imageUrl(),
+                request.content(),
                 ZonedDateTime.now()
         );
 

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -1,7 +1,6 @@
 package com.oing.controller;
 
 
-import com.oing.domain.model.MemberPost;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.response.PaginationResponse;
 import com.oing.dto.response.PostResponse;
@@ -15,7 +14,6 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 
 /**
@@ -46,6 +44,7 @@ public class PostController implements PostApi {
                             0,
                             0,
                             "https://picsum.photos/200/300?random=00",
+                            "즐거운 하루~",
                             ZonedDateTime.now()
                     )
             ));

--- a/post/src/main/java/com/oing/controller/PostReactionController.java
+++ b/post/src/main/java/com/oing/controller/PostReactionController.java
@@ -13,6 +13,6 @@ public class PostReactionController implements PostReactionApi {
 
     @Override
     public void deletePostReaction(String postId, CreatePostReactionRequest request) {
-        
+
     }
 }

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -30,7 +30,7 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
-    @Column(name = "content")
+    @Column(name = "content", columnDefinition = "VARCHAR(6)")
     private String content;
 
     @Column(name = "comment_cnt", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
@@ -44,4 +44,15 @@ public class MemberPost extends BaseAuditEntity {
 
     @OneToMany(mappedBy = "post")
     private List<MemberPostReaction> reactions = new ArrayList<>();
+
+    public MemberPost(String id, String memberId, LocalDate postDate, String imageUrl, String content,
+                      int commentCnt, int reactionCnt) {
+        this.id = id;
+        this.memberId = memberId;
+        this.postDate = postDate;
+        this.imageUrl = imageUrl;
+        this.content = content;
+        this.commentCnt = commentCnt;
+        this.reactionCnt = reactionCnt;
+    }
 }

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -27,8 +27,11 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "post_date", nullable = false)
     private LocalDate postDate;
 
-    @Column(name = "image_url")
+    @Column(name = "image_url", nullable = false)
     private String imageUrl;
+
+    @Column(name = "content")
+    private String content;
 
     @Column(name = "comment_cnt", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private int commentCnt;

--- a/post/src/main/java/com/oing/domain/model/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPost.java
@@ -1,5 +1,7 @@
 package com.oing.domain.model;
 
+import com.oing.domain.exception.DomainException;
+import com.oing.domain.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -30,7 +32,7 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
-    @Column(name = "content", columnDefinition = "VARCHAR(6)")
+    @Column(name = "content")
     private String content;
 
     @Column(name = "comment_cnt", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
@@ -47,6 +49,7 @@ public class MemberPost extends BaseAuditEntity {
 
     public MemberPost(String id, String memberId, LocalDate postDate, String imageUrl, String content,
                       int commentCnt, int reactionCnt) {
+        validateContent();
         this.id = id;
         this.memberId = memberId;
         this.postDate = postDate;
@@ -54,5 +57,11 @@ public class MemberPost extends BaseAuditEntity {
         this.content = content;
         this.commentCnt = commentCnt;
         this.reactionCnt = reactionCnt;
+    }
+
+    private void validateContent() {
+        if (this.content.length() > 8) {
+            throw new DomainException(ErrorCode.INVALID_INPUT_VALUE);
+        }
     }
 }

--- a/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
+++ b/post/src/main/java/com/oing/domain/model/MemberPostReaction.java
@@ -25,6 +25,6 @@ public class MemberPostReaction extends BaseEntity {
     @Column(name = "member_id", columnDefinition = "CHAR(26)", nullable = false)
     private String memberId;
 
-    @Column(name = "ascii", nullable = false)
-    private String ascii;
+    @Column(name = "emoji", nullable = false)
+    private String emoji;
 }

--- a/post/src/main/java/com/oing/dto/request/CreatePostRequest.java
+++ b/post/src/main/java/com/oing/dto/request/CreatePostRequest.java
@@ -1,6 +1,7 @@
 package com.oing.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * no5ing-server
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  */
 @Schema(description = "피드 게시물 생성 요청")
 public record CreatePostRequest(
+        @NotNull
         @Schema(description = "피드 게시물 사진 주소", example = "https://asset.no5ing.kr/post/01HGW2N7EHJVJ4CJ999RRS2E97")
         String imageUrl,
 

--- a/post/src/main/java/com/oing/dto/response/PostResponse.java
+++ b/post/src/main/java/com/oing/dto/response/PostResponse.java
@@ -27,6 +27,9 @@ public record PostResponse(
         @Schema(description = "피드 게시물 사진 주소", example = "https://asset.no5ing.kr/post/01HGW2N7EHJVJ4CJ999RRS2E97")
         String imageUrl,
 
+        @Schema(description = "피드 게시물 내용", example = "맛있는 밥!")
+        String content,
+
         @Schema(description = "피드 작성 시간", example = "2021-12-05T12:30:00.000+09:00")
         ZonedDateTime createdAt
 ) {

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -6,7 +6,6 @@ import com.oing.dto.response.PostResponse;
 import com.oing.dto.response.PreSignedUrlResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -63,6 +62,7 @@ public interface PostApi {
     @Operation(summary = "게시물 생성", description = "게시물을 생성합니다.")
     @PostMapping
     PostResponse createPost(
+            @Valid
             @RequestBody
             CreatePostRequest request
     );

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -28,7 +28,7 @@ import java.time.LocalDate;
 @RequestMapping("/v1/posts")
 public interface PostApi {
     @Operation(summary = "S3 Presigned Url 요청", description = "S3 Presigned Url을 요청합니다.")
-    @PostMapping("/image-upload-request")
+    @PostMapping("/presigned-url")
     PreSignedUrlResponse requestPresignedUrl(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E")
             Long memberId,

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -28,11 +28,8 @@ import java.time.LocalDate;
 @RequestMapping("/v1/posts")
 public interface PostApi {
     @Operation(summary = "S3 Presigned Url 요청", description = "S3 Presigned Url을 요청합니다.")
-    @PostMapping("/presigned-url")
+    @PostMapping("/image-upload-request")
     PreSignedUrlResponse requestPresignedUrl(
-            @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E")
-            Long memberId,
-
             @Parameter(description = "이미지 이름", example = "image")
             String imageName
     );

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -29,7 +29,7 @@ import java.time.LocalDate;
 public interface PostApi {
     @Operation(summary = "S3 Presigned Url 요청", description = "S3 Presigned Url을 요청합니다.")
     @PostMapping("/image-upload-request")
-    PreSignedUrlResponse requestPresignedUrl(
+    ResponseEntity<PreSignedUrlResponse> requestPresignedUrl(
             @Parameter(description = "이미지 이름", example = "image")
             String imageName
     );

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -2,7 +2,6 @@ package com.oing.restapi;
 
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.response.PaginationResponse;
-import com.oing.dto.response.PostFeedResponse;
 import com.oing.dto.response.PreSignedUrlResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -2,6 +2,7 @@ package com.oing.restapi;
 
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.response.PaginationResponse;
+import com.oing.dto.response.PostResponse;
 import com.oing.dto.response.PreSignedUrlResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,9 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-import com.oing.dto.response.PostResponse;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -29,7 +28,7 @@ import java.time.LocalDate;
 public interface PostApi {
     @Operation(summary = "S3 Presigned Url 요청", description = "S3 Presigned Url을 요청합니다.")
     @PostMapping("/image-upload-request")
-    ResponseEntity<PreSignedUrlResponse> requestPresignedUrl(
+    PreSignedUrlResponse requestPresignedUrl(
             @Parameter(description = "이미지 이름", example = "image")
             String imageName
     );
@@ -57,11 +56,11 @@ public interface PostApi {
     @ApiResponse(responseCode = "200", description = "오늘 자신이 올린 게시글이 있는 경우")
     @ApiResponse(responseCode = "204", description = "오늘 자신이 올린 게시글이 없는 경우")
     @GetMapping(params = {"type=DAILY", "scope=ME"})
-    ResponseEntity<PostResponse> fetchDailyFeeds();
+    PostResponse fetchDailyFeeds();
 
     @Operation(summary = "게시물 생성", description = "게시물을 생성합니다.")
     @PostMapping
-    ResponseEntity<PostResponse> createPost(
+    PostResponse createPost(
             @RequestBody
             CreatePostRequest request
     );

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -64,7 +64,7 @@ public interface PostApi {
 
     @Operation(summary = "게시물 생성", description = "게시물을 생성합니다.")
     @PostMapping
-    PostResponse createPost(
+    ResponseEntity<PostResponse> createPost(
             @RequestBody
             CreatePostRequest request
     );

--- a/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
@@ -16,10 +16,12 @@ public class MemberPostCommentTest {
         // Given
         String postId = "samplePostId";
         String memberId = "sampleMemberId";
+        String imageUrl = "https://picsum.photos/200/300?random=1";
+        String content = "밥 맛있다!";
         String commentId = "sampleCommentId";
         String commentContents = "sampleCommentContents";
         LocalDate postDate = LocalDate.of(2023, 7, 8);
-        MemberPost post = new MemberPost(postId, memberId, postDate, null, 0, 0,
+        MemberPost post = new MemberPost(postId, memberId, postDate, imageUrl, content, 0, 0,
                 null, null);
 
         // When

--- a/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
@@ -16,14 +16,16 @@ public class MemberPostReactionTest {
         // Given
         String postId = "samplePostId";
         String memberId = "sampleMemberId";
+        String imageUrl = "https://picsum.photos/200/300?random=1";
+        String content = "밥 맛있다!";
         String reactionId = "sampleCommentId";
-        String ascii = "sampleAscii";
+        String emoji = "sampleAscii";
         LocalDate postDate = LocalDate.of(2023, 7, 8);
-        MemberPost post = new MemberPost(postId, memberId, postDate, null, 0, 0,
+        MemberPost post = new MemberPost(postId, memberId, postDate, imageUrl, content, 0, 0,
                 null, null);
 
         // When
-        MemberPostReaction reaction = new MemberPostReaction(reactionId, post, memberId, ascii);
+        MemberPostReaction reaction = new MemberPostReaction(reactionId, post, memberId, emoji);
 
         // Then
         assertNotNull(reaction);

--- a/post/src/test/java/com/oing/domain/model/MemberPostTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostTest.java
@@ -17,9 +17,11 @@ public class MemberPostTest {
         String postId = "samplePostId";
         String memberId = "sampleMemberId";
         LocalDate postDate = LocalDate.of(2023, 7, 8);
+        String imageUrl = "https://picsum.photos/200/300?random=1";
+        String content = "밥 맛있다!";
 
         // When
-        MemberPost post = new MemberPost(postId, memberId, postDate, null, 0, 0,
+        MemberPost post = new MemberPost(postId, memberId, postDate, imageUrl, content, 0, 0,
                 null, null);
 
         // Then

--- a/post/src/test/java/com/oing/dto/response/PostFeedResponseTest.java
+++ b/post/src/test/java/com/oing/dto/response/PostFeedResponseTest.java
@@ -21,10 +21,12 @@ public class PostFeedResponseTest {
         Integer commentCount = 3;
         Integer emojiCount = 2;
         String imageUrl = "https://asset.no5ing.kr/post/01HGW2N7EHJVJ4CJ999RRS2E97";
+        String content = "맛있는 밥!";
         ZonedDateTime createdAt = ZonedDateTime.parse("2021-12-05T12:30:00.000+09:00");
 
         // When
-        PostResponse postFeedResponse = new PostResponse(postId, authorId, commentCount, emojiCount, imageUrl, createdAt);
+        PostResponse postFeedResponse = new PostResponse(postId, authorId, commentCount, emojiCount, imageUrl,
+                content, createdAt);
 
         // Then
         assertNotNull(postFeedResponse);


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
피드 업로드 API 모킹 및 피드 업로드를 위한 presigned-url 요청 로직을 리팩터링했습니다.

## ➕ 추가/변경된 기능

---
- Post 도메인 ddl 및 엔티티 수정
  - `content` 컬럼 추가
  - `imageUrl` 컬럼 not null 설정 추가
- Post reaction 도메인 ddl 및 엔티티 수정
  - `ascii` 필드명을 `emoji`로 수정 (이모지 로직이 고정 5개 이모지만 사용할 수 있게 바뀌어서 필드명도 수정했습니다)
- 피드 업로드 API 모킹
- 피드 업로드를 위한 presigned-url 요청 로직 리팩터링
  - 경로 수정: `/images/{memberId}` =>  `/images/feed`

## 🥺 리뷰어에게 하고싶은 말

---
추가적으로 수정해야할 부분이 있는지 확인해주세요. 🙂

