### PR TITLE
[OING-98] feat: 회원 프로필 이미지 수정 기능에서 기존 이미지 삭제 로직 주석처리

### DIFF
--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -14,11 +14,10 @@ import com.oing.dto.response.PreSignedUrlResponse;
 import com.oing.restapi.MemberApi;
 import com.oing.service.MemberService;
 import com.oing.util.AuthenticationHolder;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import com.oing.util.PreSignedUrlGenerator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -60,7 +59,7 @@ public class MemberController implements MemberApi {
     public MemberResponse updateMemberProfileImageUrl(UpdateMemberProfileImageUrlRequest request) {
         String memberId = authenticationHolder.getUserId();
         Member member = memberService.findMemberById(memberId);
-        deleteMemberProfileImage(member.getProfileImgUrl());
+        //deleteMemberProfileImage(member.getProfileImgUrl());
         member.updateProfileImgUrl(request.profileImageUrl());
 
         return new MemberResponse(member.getId(), member.getName(), member.getProfileImgUrl());


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
순찬님과 상의했을 때 당분간 프로필 및 피드 이미지 주소를 풀 url로 저장하는 것이 맞다고 생각하여 풀 url이 아닌 path를 기준으로 이미지 삭제하는 로직을 주석처리 했습니다.

## ➕ 추가/변경된 기능

---
- 회원 프로필 이미지 수정 기능에서 기존 이미지 삭제 로직 주석처리

## 🥺 리뷰어에게 하고싶은 말

---
리뷰 잘부탁드려요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-98