### PR TITLE
[OING-92] feat: 회원 탈퇴 API 구현

### DIFF
--- a/common/src/main/java/com/oing/domain/model/BaseAuditEntityWithDelete.java
+++ b/common/src/main/java/com/oing/domain/model/BaseAuditEntityWithDelete.java
@@ -1,0 +1,21 @@
+package com.oing.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseAuditEntityWithDelete extends BaseAuditEntity {
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void updateDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+}

--- a/common/src/main/java/com/oing/domain/model/BaseAuditEntityWithDelete.java
+++ b/common/src/main/java/com/oing/domain/model/BaseAuditEntityWithDelete.java
@@ -15,7 +15,7 @@ public class BaseAuditEntityWithDelete extends BaseAuditEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public void updateDeletedAt(LocalDateTime deletedAt) {
-        this.deletedAt = deletedAt;
+    public void updateDeletedAt() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/common/src/main/java/com/oing/domain/model/DeletableBaseAuditEntity.java
+++ b/common/src/main/java/com/oing/domain/model/DeletableBaseAuditEntity.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
-public class BaseAuditEntityWithDelete extends BaseAuditEntity {
+public class DeletableBaseAuditEntity extends BaseAuditEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 

--- a/common/src/main/java/com/oing/exception/AuthorizationFailedException.java
+++ b/common/src/main/java/com/oing/exception/AuthorizationFailedException.java
@@ -1,0 +1,10 @@
+package com.oing.exception;
+
+import com.oing.domain.exception.DomainException;
+import com.oing.domain.exception.ErrorCode;
+
+public class AuthorizationFailedException extends DomainException {
+    public AuthorizationFailedException() {
+        super(ErrorCode.AUTHORIZATION_FAILED);
+    }
+}

--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -57,9 +57,10 @@ public class MemberController implements MemberApi {
 
     @Override
     @Transactional
-    public MemberResponse updateMemberProfileImageUrl(UpdateMemberProfileImageUrlRequest request) {
-        String memberId = authenticationHolder.getUserId();
+    public MemberResponse updateMemberProfileImageUrl(String memberId, UpdateMemberProfileImageUrlRequest request) {
+        validateMemberId(memberId);
         Member member = memberService.findMemberById(memberId);
+
         deleteMemberProfileImage(member.getProfileImgUrl());
         member.updateProfileImgUrl(request.profileImageUrl());
 
@@ -74,8 +75,8 @@ public class MemberController implements MemberApi {
 
     @Override
     @Transactional
-    public MemberResponse updateMemberName(UpdateMemberNameRequest request) {
-        String memberId = authenticationHolder.getUserId();
+    public MemberResponse updateMemberName(String memberId, UpdateMemberNameRequest request) {
+        validateMemberId(memberId);
         Member member = memberService.findMemberById(memberId);
 
         validateName(request.name());
@@ -93,11 +94,16 @@ public class MemberController implements MemberApi {
     @Override
     @Transactional
     public void deleteMember(String memberId) {
-        if (!memberId.equals(authenticationHolder.getUserId())) {
-            throw new AuthorizationFailedException();
-        }
+        validateMemberId(memberId);
         Member member = memberService.findMemberById(memberId);
         memberService.deleteAllSocialMembersByMember(memberId);
         member.deleteMemberInfo();
+    }
+
+    private void validateMemberId(String memberId) {
+        String loginId = authenticationHolder.getUserId();
+        if (!loginId.equals(memberId)) {
+            throw new AuthorizationFailedException();
+        }
     }
 }

--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.oing.domain.PaginationDTO;
 import com.oing.domain.exception.DomainException;
 import com.oing.domain.exception.ErrorCode;
 import com.oing.domain.model.Member;
+import com.oing.domain.model.SocialMember;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.request.UpdateMemberNameRequest;
 import com.oing.dto.request.UpdateMemberProfileImageUrlRequest;
@@ -14,12 +15,13 @@ import com.oing.dto.response.PreSignedUrlResponse;
 import com.oing.restapi.MemberApi;
 import com.oing.service.MemberService;
 import com.oing.util.AuthenticationHolder;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import com.oing.util.PreSignedUrlGenerator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
+
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -91,14 +93,13 @@ public class MemberController implements MemberApi {
     }
 
     @Override
-    public void deleteMember(String memberId) {
-        String memberIdBase = "01HGW2N7EHJVJ4CJ999RRS2E97";
-        memberId = "01HGW2N7EHJVJ4CJ999RRS2E97";
+    @Transactional
+    public void deleteMember() {
+        String memberId = authenticationHolder.getUserId();
+        Member member = memberService.findMemberById(memberId);
+        List<SocialMember> socialMembers = memberService.findAllSocialMemberByMember(member);
 
-        //TODO: 탈퇴 요청한 회원 id와 요청으로 들어온 memberId 일치하는지 검증
-        if (!memberIdBase.equals(memberId)) {
-            throw new DomainException(ErrorCode.AUTHORIZATION_FAILED);
-        }
-        //TODO: 타객체들간의 연관관계 해제 및 마스킹 처리
+        socialMembers.forEach(memberService::deleteMember);
+        member.deleteMemberInfo();
     }
 }

--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -12,6 +12,7 @@ import com.oing.dto.response.FamilyMemberProfileResponse;
 import com.oing.dto.response.MemberResponse;
 import com.oing.dto.response.PaginationResponse;
 import com.oing.dto.response.PreSignedUrlResponse;
+import com.oing.exception.AuthorizationFailedException;
 import com.oing.restapi.MemberApi;
 import com.oing.service.MemberService;
 import com.oing.util.AuthenticationHolder;
@@ -94,8 +95,10 @@ public class MemberController implements MemberApi {
 
     @Override
     @Transactional
-    public void deleteMember() {
-        String memberId = authenticationHolder.getUserId();
+    public void deleteMember(String memberId) {
+        if (!memberId.equals(authenticationHolder.getUserId())) {
+            throw new AuthorizationFailedException();
+        }
         Member member = memberService.findMemberById(memberId);
         List<SocialMember> socialMembers = memberService.findAllSocialMemberByMember(member);
 

--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -4,7 +4,6 @@ import com.oing.domain.PaginationDTO;
 import com.oing.domain.exception.DomainException;
 import com.oing.domain.exception.ErrorCode;
 import com.oing.domain.model.Member;
-import com.oing.domain.model.SocialMember;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.request.UpdateMemberNameRequest;
 import com.oing.dto.request.UpdateMemberProfileImageUrlRequest;
@@ -21,8 +20,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
-
-import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -100,9 +97,7 @@ public class MemberController implements MemberApi {
             throw new AuthorizationFailedException();
         }
         Member member = memberService.findMemberById(memberId);
-        List<SocialMember> socialMembers = memberService.findAllSocialMemberByMember(member);
-
-        socialMembers.forEach(memberService::deleteMember);
+        memberService.deleteAllSocialMembersByMember(memberId);
         member.deleteMemberInfo();
     }
 }

--- a/member/src/main/java/com/oing/domain/model/Member.java
+++ b/member/src/main/java/com/oing/domain/model/Member.java
@@ -19,7 +19,7 @@ import java.time.LocalDate;
 @Getter
 @Builder
 @Entity(name = "member")
-public class Member extends BaseAuditEntity {
+public class Member extends BaseAuditEntityWithDelete {
     @Id
     @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
     private String id;
@@ -42,5 +42,11 @@ public class Member extends BaseAuditEntity {
 
     public void updateName(String name) {
         this.name = name;
+    }
+
+    public void deleteMemberInfo() {
+        super.updateDeletedAt(super.getCreatedAt());
+        this.name = "DeletedUser";
+        this.profileImgUrl = null;
     }
 }

--- a/member/src/main/java/com/oing/domain/model/Member.java
+++ b/member/src/main/java/com/oing/domain/model/Member.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Id;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * no5ing-server
@@ -45,7 +46,7 @@ public class Member extends BaseAuditEntityWithDelete {
     }
 
     public void deleteMemberInfo() {
-        super.updateDeletedAt(super.getCreatedAt());
+        super.updateDeletedAt(LocalDateTime.now());
         this.name = "DeletedUser";
         this.profileImgUrl = null;
     }

--- a/member/src/main/java/com/oing/domain/model/Member.java
+++ b/member/src/main/java/com/oing/domain/model/Member.java
@@ -19,7 +19,7 @@ import java.time.LocalDate;
 @Getter
 @Builder
 @Entity(name = "member")
-public class Member extends BaseAuditEntityWithDelete {
+public class Member extends DeletableBaseAuditEntity {
     @Id
     @Column(name = "member_id", length = 26, columnDefinition = "CHAR(26)")
     private String id;

--- a/member/src/main/java/com/oing/domain/model/Member.java
+++ b/member/src/main/java/com/oing/domain/model/Member.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Id;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 /**
  * no5ing-server
@@ -46,7 +45,7 @@ public class Member extends BaseAuditEntityWithDelete {
     }
 
     public void deleteMemberInfo() {
-        super.updateDeletedAt(LocalDateTime.now());
+        super.updateDeletedAt();
         this.name = "DeletedUser";
         this.profileImgUrl = null;
     }

--- a/member/src/main/java/com/oing/repository/SocialMemberRepository.java
+++ b/member/src/main/java/com/oing/repository/SocialMemberRepository.java
@@ -1,11 +1,8 @@
 package com.oing.repository;
 
-import com.oing.domain.model.Member;
 import com.oing.domain.model.SocialMember;
 import com.oing.domain.model.key.SocialMemberKey;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 /**
  * no5ing-server
@@ -14,5 +11,5 @@ import java.util.List;
  * Time: 11:45 AM
  */
 public interface SocialMemberRepository extends JpaRepository<SocialMember, SocialMemberKey> {
-    List<SocialMember> findAllSocialMemberByMember(Member member);
+    void deleteAllByMemberId(String memberId);
 }

--- a/member/src/main/java/com/oing/repository/SocialMemberRepository.java
+++ b/member/src/main/java/com/oing/repository/SocialMemberRepository.java
@@ -1,8 +1,11 @@
 package com.oing.repository;
 
+import com.oing.domain.model.Member;
 import com.oing.domain.model.SocialMember;
 import com.oing.domain.model.key.SocialMemberKey;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 /**
  * no5ing-server
@@ -11,4 +14,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * Time: 11:45 AM
  */
 public interface SocialMemberRepository extends JpaRepository<SocialMember, SocialMemberKey> {
+    List<SocialMember> findAllSocialMemberByMember(Member member);
 }

--- a/member/src/main/java/com/oing/restapi/MemberApi.java
+++ b/member/src/main/java/com/oing/restapi/MemberApi.java
@@ -68,10 +68,6 @@ public interface MemberApi {
     );
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 수행합니다.")
-    @DeleteMapping("/{memberId}")
-    void deleteMember(
-            @Parameter(description = "탈퇴할 회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
-            @PathVariable
-            String memberId
-    );
+    @DeleteMapping
+    void deleteMember();
 }

--- a/member/src/main/java/com/oing/restapi/MemberApi.java
+++ b/member/src/main/java/com/oing/restapi/MemberApi.java
@@ -52,16 +52,24 @@ public interface MemberApi {
     );
 
     @Operation(summary = "회원 프로필 이미지 수정", description = "회원 프로필 이미지를 수정합니다.")
-    @PutMapping("/profile-image-url")
+    @PutMapping("/profile-image-url/{memberId}")
     MemberResponse updateMemberProfileImageUrl(
+            @Parameter(description = "수정할 회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String memberId,
+
             @Valid
             @RequestBody
             UpdateMemberProfileImageUrlRequest request
     );
 
     @Operation(summary = "회원 이름 수정", description = "회원 이름을 수정합니다.")
-    @PutMapping("/name")
+    @PutMapping("/name/{memberId}")
     MemberResponse updateMemberName(
+            @Parameter(description = "수정할 회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String memberId,
+
             @Valid
             @RequestBody
             UpdateMemberNameRequest request

--- a/member/src/main/java/com/oing/restapi/MemberApi.java
+++ b/member/src/main/java/com/oing/restapi/MemberApi.java
@@ -68,6 +68,10 @@ public interface MemberApi {
     );
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 수행합니다.")
-    @DeleteMapping
-    void deleteMember();
+    @DeleteMapping("/{memberId}")
+    void deleteMember(
+            @Parameter(description = "탈퇴할 회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String memberId
+    );
 }

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -96,4 +96,8 @@ public class MemberService {
     public void deleteMember(SocialMember socialMember) {
         socialMemberRepository.delete(socialMember);
     }
+
+    public List<SocialMember> findAllSocialMemberByMember(Member member) {
+        return socialMemberRepository.findAllSocialMemberByMember(member);
+    }
 }

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -92,4 +92,8 @@ public class MemberService {
                 .map(FamilyMemberProfileResponse::of)
                 .collect(Collectors.toList());
     }
+
+    public void deleteMember(SocialMember socialMember) {
+        socialMemberRepository.delete(socialMember);
+    }
 }

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -93,11 +93,7 @@ public class MemberService {
                 .collect(Collectors.toList());
     }
 
-    public void deleteMember(SocialMember socialMember) {
-        socialMemberRepository.delete(socialMember);
-    }
-
-    public List<SocialMember> findAllSocialMemberByMember(Member member) {
-        return socialMemberRepository.findAllSocialMemberByMember(member);
+    public void deleteAllSocialMembersByMember(String memberId) {
+        socialMemberRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/member/src/test/java/com/oing/domain/SocialLoginProviderTest.java
+++ b/member/src/test/java/com/oing/domain/SocialLoginProviderTest.java
@@ -23,9 +23,10 @@ public class SocialLoginProviderTest {
 
         // Then
         assertNotNull(providers);
-        assertEquals(2, providers.length);
+        assertEquals(3, providers.length);
         assertEquals(SocialLoginProvider.APPLE, providers[0]);
-        assertEquals(SocialLoginProvider.INTERNAL, providers[1]);
+        assertEquals(SocialLoginProvider.KAKAO, providers[1]);
+        assertEquals(SocialLoginProvider.INTERNAL, providers[2]);
     }
 
     @DisplayName("SocialLoginProvider valueOf 테스트")


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
회원 탈퇴 API를 구현했습니다.

## ➕ 추가/변경된 기능

---
- BaseAuditEntityWithDelete 구현
- 회원 탈퇴 API 구현
  - Member와 연결된 모든 SocialMember 객체 삭제
  - 회원 정보 마스킹 

## 🥺 리뷰어에게 하고싶은 말

---
SocialMember를 다 끊어내면 된다고 하셔서 이렇게 구현했습니다. 로직이 맞는지 확인해주세요. 🎄메리크리스마스 🎄



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-92