### PR TITLE
[OING-111] 새로운 형태의 Object storage url으로 인해 썸네일 url이 작동하지 못한 오류 해결

### DIFF
--- a/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
@@ -16,9 +16,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
 
-    @Value("${cloud.ncp.storage.bucket}")
-    private String bucketName;
-
     @Value("${cloud.ncp.image-optimizer-cdn}")
     private String imageOptimizerCdnUrl;
 
@@ -32,7 +29,7 @@ public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
      */
     @Override
     public String getThumbnailUrlGenerator(String bucketImageUrl) {
-        String imagePath = bucketImageUrl.split(bucketName)[1];
+        String imagePath = bucketImageUrl.substring(bucketImageUrl.indexOf("/images"));
 
         return imageOptimizerCdnUrl + imagePath + THUMBNAIL_OPTIMIZER_QUERY_STRING;
     }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
새로운 형태의 Object storage url으로 인해 썸네일 url이 작동하지 못한 오류 해결했습니다.

## ➕ 추가/변경된 기능

---
- bucketImageUrl에서 imagePath를 찾는 코드의 패턴을 변경

## 🥺 리뷰어에게 하고싶은 말

---
요청받은 오류 해결했습니다.



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-111