### PR TITLE
[OING-123] hotfix: 새로운 형태의 Object storage url으로 인해 이미지 키가 제대로 추출되지 않는 오류 해결 

### DIFF
--- a/gateway/src/main/java/com/oing/config/support/S3PreSignedUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/S3PreSignedUrlProvider.java
@@ -14,7 +14,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.security.InvalidParameterException;
 import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -84,8 +87,19 @@ public class S3PreSignedUrlProvider implements PreSignedUrlGenerator {
 
     @Override
     public String extractImageKey(String imageUrl) {
-        int bucketIndex = imageUrl.indexOf(bucket);
-        String imagePath = imageUrl.substring(bucketIndex + bucket.length());
-        return imagePath.startsWith("/") ? imagePath.substring(1) : imagePath;
+        Pattern pattern1 = Pattern.compile("https://.+?/" + Pattern.quote(bucket) + "/(.+)");
+        Pattern pattern2 = Pattern.compile("https://" + Pattern.quote(bucket) + ".+?/" + "(.+)");
+
+        Matcher matcher = pattern1.matcher(imageUrl);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+
+        matcher.usePattern(pattern2);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+
+        throw new InvalidParameterException();
     }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
#65 처럼 새로운 형태의 Object storage url에서 이미지 키를 제대로 추출되지 않는 버그를 확인하여 로직을 수정했습니다.

## ➕ 추가/변경된 기능

---
- 두가지 형태의 url에서 이미지 키를 추출하도록 로직 수정

## 🥺 리뷰어에게 하고싶은 말

---
추가적으로 대응해야 할 부분이 있는지 확인해주세요



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-123