### PR TITLE
[OING-128] refactor: 가족 멤버 프로필 조회 시, 탈퇴한 회원은 응답에서 제외되도록 수정

### DIFF
--- a/gateway/src/test/resources/application.yaml
+++ b/gateway/src/test/resources/application.yaml
@@ -1,4 +1,6 @@
 app:
+  oauth:
+    google-client-id: test
   web:
     url-whitelists:
       - /actuator/**
@@ -18,3 +20,5 @@ cloud:
     storage:
       bucket: bucket
     image-optimizer-cdn: https://cdn.com/abc
+
+

--- a/gateway/src/test/resources/application.yaml
+++ b/gateway/src/test/resources/application.yaml
@@ -20,5 +20,3 @@ cloud:
     storage:
       bucket: bucket
     image-optimizer-cdn: https://cdn.com/abc
-
-

--- a/member/src/main/java/com/oing/repository/MemberRepository.java
+++ b/member/src/main/java/com/oing/repository/MemberRepository.java
@@ -16,5 +16,5 @@ import java.util.List;
 public interface MemberRepository extends JpaRepository<Member, String> {
     List<Member> findAllByFamilyId(String familyId);
 
-    Page<Member> findAllByFamilyId(String familyId, PageRequest pageRequest);
+    Page<Member> findAllByFamilyIdAndDeletedAtIsNull(String familyId, PageRequest pageRequest);
 }

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -82,7 +82,7 @@ public class MemberService {
     public Page<FamilyMemberProfileResponse> findFamilyMembersProfilesByFamilyId(
             String familyId, int page, int size
     ) {
-        Page<Member> memberPage = memberRepository.findAllByFamilyId(familyId, PageRequest.of(page - 1, size));
+        Page<Member> memberPage = memberRepository.findAllByFamilyIdAndDeletedAtIsNull(familyId, PageRequest.of(page - 1, size));
         List<Member> members = memberPage.getContent();
 
         List<FamilyMemberProfileResponse> familyMemberProfiles = createFamilyMemberProfiles(members);

--- a/member/src/test/java/com/oing/domain/SocialLoginProviderTest.java
+++ b/member/src/test/java/com/oing/domain/SocialLoginProviderTest.java
@@ -25,10 +25,11 @@ public class SocialLoginProviderTest {
 
         // Then
         assertNotNull(providers);
-        assertEquals(3, providers.length);
+        assertEquals(4, providers.length);
         assertEquals(SocialLoginProvider.APPLE, providers[0]);
         assertEquals(SocialLoginProvider.KAKAO, providers[1]);
-        assertEquals(SocialLoginProvider.INTERNAL, providers[2]);
+        assertEquals(SocialLoginProvider.GOOGLE, providers[2]);
+        assertEquals(SocialLoginProvider.INTERNAL, providers[3]);
     }
 
     @DisplayName("SocialLoginProvider valueOf 테스트")


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
가족 멤버 프로필 조회 시, 탈퇴한 회원은 응답에 포함되지 않도록 수정했습니다.

## ➕ 추가/변경된 기능

---
- 가족 멤버 프로필 조회 시, 탈퇴한 회원은 제외되도록 수정
- SocialLoginProvider 테스트 에러 해결

## 🥺 리뷰어에게 하고싶은 말

---
리뷰 잘 부탁드려요~~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-128