### PR TITLE
[OING-130] feat: postDate 컬럼 삭제 및 가족이 없는 멤버에 대해 가족 프로필 조회 시, 예외 반환 로직 추가

### DIFF
--- a/gateway/src/main/java/com/oing/repository/MemberPostRepositoryImpl.java
+++ b/gateway/src/main/java/com/oing/repository/MemberPostRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.oing.exception.FamilyNotFoundException;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimeTemplate;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -72,10 +74,26 @@ public class MemberPostRepositoryImpl implements MemberPostRepositoryCustom {
     }
 
     private BooleanExpression eqDate(LocalDate date) {
-        return date == null ? null : memberPost.postDate.eq(date);
+        DateTimeTemplate<LocalDate> createdAtDate = Expressions.dateTimeTemplate(LocalDate.class,
+                "DATE({0})", memberPost.createdAt);
+
+        return date == null ? null : createdAtDate.eq(date);
     }
 
     private BooleanExpression eqMemberId(String memberId) {
         return memberId == null ? null : memberPost.memberId.eq(memberId);
+    }
+
+    @Override
+    public boolean existsByMemberIdAndCreatedAt(String memberId, LocalDate postDate) {
+        DateTimeTemplate<LocalDate> createdAtDate = Expressions.dateTimeTemplate(LocalDate.class,
+                "DATE({0})", memberPost.createdAt);
+
+        return queryFactory
+                .select(memberPost.id)
+                .from(memberPost)
+                .where(memberPost.memberId.eq(memberId)
+                        .and(createdAtDate.eq(postDate)))
+                .fetchFirst() != null;
     }
 }

--- a/gateway/src/main/resources/db/migration/V202401082259__delete_postDate_column.sql
+++ b/gateway/src/main/resources/db/migration/V202401082259__delete_postDate_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `member_post` DROP COLUMN `post_date`;

--- a/member/src/main/java/com/oing/exception/FamilyNotFoundException.java
+++ b/member/src/main/java/com/oing/exception/FamilyNotFoundException.java
@@ -1,0 +1,7 @@
+package com.oing.exception;
+
+public class FamilyNotFoundException extends DomainException {
+    public FamilyNotFoundException() {
+        super(ErrorCode.FAMILY_NOT_FOUND);
+    }
+}

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -6,6 +6,7 @@ import com.oing.domain.SocialLoginProvider;
 import com.oing.domain.SocialMember;
 import com.oing.domain.key.SocialMemberKey;
 import com.oing.dto.response.FamilyMemberProfileResponse;
+import com.oing.exception.FamilyNotFoundException;
 import com.oing.exception.MemberNotFoundException;
 import com.oing.repository.MemberRepository;
 import com.oing.repository.SocialMemberRepository;
@@ -36,7 +37,11 @@ public class MemberService {
     }
 
     public String findFamilyIdByMemberId(String memberId) {
-        return findMemberById(memberId).getFamilyId();
+        Member findMember = findMemberById(memberId);
+        if (findMember.getFamilyId() == null) {
+            throw new FamilyNotFoundException();
+        }
+        return findMember.getFamilyId();
     }
 
     @Transactional

--- a/post/src/main/java/com/oing/controller/MemberPostController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostController.java
@@ -67,7 +67,7 @@ public class MemberPostController implements MemberPostApi {
         validateUploadTime(uploadTime);
 
         String postImgKey = preSignedUrlGenerator.extractImageKey(request.imageUrl());
-        MemberPost post = new MemberPost(postId, memberId, uploadTime.toLocalDate(), request.imageUrl(),
+        MemberPost post = new MemberPost(postId, memberId, request.imageUrl(),
                 postImgKey, request.content());
         MemberPost savedPost = memberPostService.save(post);
 

--- a/post/src/main/java/com/oing/domain/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/MemberPost.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.security.InvalidParameterException;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,9 +23,6 @@ public class MemberPost extends BaseAuditEntity {
 
     @Column(name = "member_id", columnDefinition = "CHAR(26)", nullable = false)
     private String memberId;
-
-    @Column(name = "post_date", nullable = false)
-    private LocalDate postDate;
 
     @Column(name = "post_img_url", nullable = false)
     private String postImgUrl;
@@ -49,11 +45,10 @@ public class MemberPost extends BaseAuditEntity {
     @OneToMany(mappedBy = "post")
     private List<MemberPostReaction> reactions = new ArrayList<>();
 
-    public MemberPost(String id, String memberId, LocalDate postDate, String postImgUrl, String postImgKey, String content) {
+    public MemberPost(String id, String memberId, String postImgUrl, String postImgKey, String content) {
         validateContent(content);
         this.id = id;
         this.memberId = memberId;
-        this.postDate = postDate;
         this.postImgUrl = postImgUrl;
         this.postImgKey = postImgKey;
         this.content = content;

--- a/post/src/main/java/com/oing/repository/MemberPostRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 
 public interface MemberPostRepository extends JpaRepository<MemberPost, String>, MemberPostRepositoryCustom {
-    boolean existsByMemberIdAndPostDate(String memberId, LocalDate postDate);
+    boolean existsByMemberIdAndCreatedAt(String memberId, LocalDate postDate);
 }

--- a/post/src/main/java/com/oing/repository/MemberPostRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRepository.java
@@ -3,8 +3,5 @@ package com.oing.repository;
 import com.oing.domain.MemberPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
-
 public interface MemberPostRepository extends JpaRepository<MemberPost, String>, MemberPostRepositoryCustom {
-    boolean existsByMemberIdAndCreatedAt(String memberId, LocalDate postDate);
 }

--- a/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface MemberPostRepositoryCustom {
     List<MemberPostCountDTO> countPostsOfEveryday(List<String> memberIds, LocalDateTime startDate, LocalDateTime endDate);
 
     QueryResults<MemberPost> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId, boolean asc);
+
+    boolean existsByMemberIdAndCreatedAt(String memberId, LocalDate postDate);
 }

--- a/post/src/main/java/com/oing/service/MemberPostService.java
+++ b/post/src/main/java/com/oing/service/MemberPostService.java
@@ -59,9 +59,8 @@ public class MemberPostService {
      * @return 오늘 회원이 작성한 글이 있는지 반환
      */
     public boolean hasUserCreatedPostToday(String memberId, LocalDate today) {
-        return memberPostRepository.existsByMemberIdAndPostDate(memberId, today);
+        return memberPostRepository.existsByMemberIdAndCreatedAt(memberId, today);
     }
-
 
     /**
      * 멤버가 오늘 작성한 게시물을 저장한다.

--- a/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
@@ -5,8 +5,6 @@ import com.oing.domain.MemberPostComment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -23,8 +21,7 @@ public class MemberPostCommentTest {
         String content = "밥 맛있다!";
         String commentId = "sampleCommentId";
         String commentContents = "sampleCommentContents";
-        LocalDate postDate = LocalDate.of(2023, 7, 8);
-        MemberPost post = new MemberPost(postId, memberId, postDate, imageUrl, imageKey, content, 0,
+        MemberPost post = new MemberPost(postId, memberId, imageUrl, imageKey, content, 0,
                 0, null, null);
 
         // When

--- a/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
@@ -6,8 +6,6 @@ import com.oing.domain.MemberPostReaction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -24,8 +22,7 @@ public class MemberPostReactionTest {
         String content = "밥 맛있다!";
         String reactionId = "sampleCommentId";
         Emoji emoji = Emoji.EMOJI_1;
-        LocalDate postDate = LocalDate.of(2023, 7, 8);
-        MemberPost post = new MemberPost(postId, memberId, postDate, imageUrl, imageKey, content, 0,
+        MemberPost post = new MemberPost(postId, memberId, imageUrl, imageKey, content, 0,
                 0, null, null);
 
         // When

--- a/post/src/test/java/com/oing/domain/model/MemberPostTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostTest.java
@@ -17,13 +17,12 @@ public class MemberPostTest {
         // Given
         String postId = "samplePostId";
         String memberId = "sampleMemberId";
-        LocalDate postDate = LocalDate.of(2023, 7, 8);
         String imageUrl = "https://picsum.photos/200/300?random=1";
         String imageKey = "/200/300?random=1";
         String content = "밥 맛있다!";
 
         // When
-        MemberPost post = new MemberPost(postId, memberId, postDate, imageUrl, imageKey, content, 0,
+        MemberPost post = new MemberPost(postId, memberId, imageUrl, imageKey, content, 0,
                 0, null, null);
 
         // Then


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
Post에서 postDate 컬럼 삭제 및 가족이 없는 멤버에 대해 가족 프로필 조회 시, 예외 반환 로직 추가했습니다.

## ➕ 추가/변경된 기능

---
- postDate 컬럼 삭제
- 가족이 없는 멤버에 대해 가족 프로필 조회 시, 예외 반환 로직 추가

## 🥺 리뷰어에게 하고싶은 말

---
확인해주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-130