### PR TITLE
[OING-131] 위젯 응답 객체에 게시자 이름 추가

### DIFF
--- a/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
@@ -44,7 +44,7 @@ public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
      */
     @Override
     public String getKBImageUrlGenerator(String bucketImageUrl) {
-        String imagePath = bucketImageUrl.split(bucketName)[1];
+        String imagePath = bucketImageUrl.split(bucketImageUrl)[1];
 
         return imageOptimizerCdnUrl + imagePath + KB_IMAGE_OPTIMIZER_QUERY_STRING;
     }

--- a/gateway/src/main/java/com/oing/controller/WidgetController.java
+++ b/gateway/src/main/java/com/oing/controller/WidgetController.java
@@ -45,6 +45,7 @@ public class WidgetController implements WidgetApi {
         MemberPost latestPost = latestPosts.get(0);
         Member author = memberService.findMemberById(latestPost.getMemberId());
         return ResponseEntity.ok(new SingleRecentPostWidgetResponse(
+                author.getName(),
                 optimizedImageUrlGenerator.getKBImageUrlGenerator(author.getProfileImgUrl()),
                 optimizedImageUrlGenerator.getKBImageUrlGenerator(latestPost.getPostImgUrl()),
                 latestPost.getContent()

--- a/gateway/src/main/java/com/oing/dto/response/SingleRecentPostWidgetResponse.java
+++ b/gateway/src/main/java/com/oing/dto/response/SingleRecentPostWidgetResponse.java
@@ -1,14 +1,15 @@
 package com.oing.dto.response;
 
-import com.oing.domain.Member;
-import com.oing.domain.MemberPost;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "단일 최근 게시물 위젯 응답")
 public record SingleRecentPostWidgetResponse(
 
+        @Schema(description = "게시자 이름", example = "권순찬")
+        String authorName,
+
         @Schema(description = "게시자 프로필 사진 주소", example = "https://asset.no5ing.kr/post/01HGW2N7EHJVJ4CJ999RRS2E97")
-        String profileImageUrl,
+        String authorProfileImageUrl,
 
         @Schema(description = "피드 게시물 사진 주소", example = "https://asset.no5ing.kr/post/01HGW2N7EHJVJ4CJ999RRS2E97")
         String postImageUrl,


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
프로필 사진이 없는 유저의 경우 이름을 통해 디폴트 프로필을 클라이언트에서 만들기 위해, 응갑 객체에 작성자 이름을 추가해달라고 요청받았슴다.

## ➕ 추가/변경된 기능

---
- SingleRecentPostWidgetResponse에 authorName 추가, profileImageUrl -> authorProfileImageUrl 변경

## 🥺 리뷰어에게 하고싶은 말

---




## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-131