### PR TITLE
[OING-129] 이미지 최적화 빈의 NullPointerException 방지

### DIFF
--- a/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
@@ -31,8 +31,11 @@ public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
      */
     @Override
     public String getThumbnailUrlGenerator(String bucketImageUrl) {
-        String imagePath = bucketImageUrl.substring(bucketImageUrl.indexOf("/images"));
+        if (bucketImageUrl == null) {
+            return null;
+        }
 
+        String imagePath = bucketImageUrl.substring(bucketImageUrl.indexOf("/igit bmages"));
         return imageOptimizerCdnUrl + imagePath + THUMBNAIL_OPTIMIZER_QUERY_STRING;
     }
 
@@ -44,8 +47,11 @@ public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
      */
     @Override
     public String getKBImageUrlGenerator(String bucketImageUrl) {
-        String imagePath = bucketImageUrl.substring(bucketImageUrl.indexOf("/images"));
+        if (bucketImageUrl == null) {
+            return null;
+        }
 
+        String imagePath = bucketImageUrl.substring(bucketImageUrl.indexOf("/images"));
         return imageOptimizerCdnUrl + imagePath + KB_IMAGE_OPTIMIZER_QUERY_STRING;
     }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
이미지를 압축하는 빈에서 이미지가 없어 Null일 때, NullPointerException이 발생하는 것을 발견했습니다.

## ➕ 추가/변경된 기능

---
- bucketImageUrl이 NULL이면 압축하지 않고, 그대로 NULL을 반환하도록 코드 추가

## 🥺 리뷰어에게 하고싶은 말

---
파이팅



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-129