### PR TITLE
[OING-135] hotfix: 닉네임 길이 제한 조건 수정

### DIFF
--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -76,7 +76,7 @@ public class MemberController implements MemberApi {
     }
 
     private void validateName(String name) {
-        if (name.length() < 2 || name.length() > 10) {
+        if (name.length() < 1 || name.length() > 9) {
             throw new InvalidParameterException();
         }
     }

--- a/member/src/main/java/com/oing/domain/CreateNewUserDTO.java
+++ b/member/src/main/java/com/oing/domain/CreateNewUserDTO.java
@@ -1,5 +1,7 @@
 package com.oing.domain;
 
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDate;
 
 /**
@@ -11,6 +13,7 @@ import java.time.LocalDate;
 public record CreateNewUserDTO(
         SocialLoginProvider provider,
         String identifier,
+        @Size(min = 1, max = 9)
         String memberName,
         LocalDate dayOfBirth,
         String profileImgUrl

--- a/member/src/main/java/com/oing/domain/CreateNewUserDTO.java
+++ b/member/src/main/java/com/oing/domain/CreateNewUserDTO.java
@@ -1,5 +1,6 @@
 package com.oing.domain;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
@@ -13,6 +14,7 @@ import java.time.LocalDate;
 public record CreateNewUserDTO(
         SocialLoginProvider provider,
         String identifier,
+        @NotBlank
         @Size(min = 1, max = 9)
         String memberName,
         LocalDate dayOfBirth,

--- a/member/src/main/java/com/oing/dto/request/UpdateMemberNameRequest.java
+++ b/member/src/main/java/com/oing/dto/request/UpdateMemberNameRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "회원 이름 수정 요청")
 public record UpdateMemberNameRequest(
         @NotBlank
-        @Size(min = 2, max = 10)
+        @Size(min = 1, max = 9)
         @Schema(description = "회원 이름", example = "홍길동")
         String name
 ) {


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
QA 중 디자인 팀의 요청으로 닉네임 길이 제한을 `2자~10자` -> `1자~9자`로 수정했습니다.

## ➕ 추가/변경된 기능

---
- 닉네임 길이 제한 수정

## 🥺 리뷰어에게 하고싶은 말

---
수정해야할 곳이 더 있는지 확인해주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-135