### PR TITLE
[OING-147] feat: 리얼 이모지 테이블 클래스 및 리얼 이모지 API 틀 추가

### DIFF
--- a/gateway/src/main/resources/db/migration/V202401141930__add_real_emoji_tbl.sql
+++ b/gateway/src/main/resources/db/migration/V202401141930__add_real_emoji_tbl.sql
@@ -1,0 +1,30 @@
+CREATE TABLE `member_real_emoji`
+(
+    `real_emoji_id`     CHAR(26)        NOT NULL    COMMENT 'ULID',
+    `member_id`         CHAR(26)        NOT NULL    COMMENT 'ULID',
+    `type`              VARCHAR(16)     NOT NULL,
+    `real_emoji_image_url`   TEXT            NOT NULL,
+    `real_emoji_image_key`   VARCHAR(255)    NOT NULL,
+    `created_at`        TIMESTAMP       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`        TIMESTAMP       NOT NULL    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`real_emoji_id`),
+    INDEX       `member_real_emoji_idx1` (`member_id`)
+) DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_unicode_ci COMMENT '리얼이모지';
+
+CREATE TABLE `member_post_real_emoji`
+(
+    `post_real_emoji_id`    CHAR(26)       NOT NULL    COMMENT 'ULID',
+    `real_emoji_id`         CHAR(26)        NOT NULL    COMMENT 'ULID',
+    `post_id`               CHAR(26)        NOT NULL    COMMENT 'ULID',
+    `member_id`             CHAR(26)        NOT NULL    COMMENT 'ULID',
+    `created_at`            TIMESTAMP       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`post_real_emoji_id`),
+    FOREIGN KEY  `member_post_real_emoji_fk1` (`post_id`) REFERENCES `member_post` (`post_id`),
+    FOREIGN KEY  `member_post_real_emoji_fk2` (`real_emoji_id`) REFERENCES `member_real_emoji` (`real_emoji_id`),
+    INDEX        `member_post_real_emoji_idx1` (`post_id`),
+    INDEX        `member_post_real_emoji_idx2` (`member_id`)
+) DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_unicode_ci COMMENT '게시물리얼이모지';
+
+ALTER TABLE `member_post` ADD COLUMN `real_emoji_cnt` INTEGER  NOT NULL  DEFAULT 0;

--- a/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
@@ -1,0 +1,46 @@
+package com.oing.controller;
+
+
+import com.oing.domain.MemberPost;
+import com.oing.domain.PaginationDTO;
+import com.oing.dto.request.CreatePostRequest;
+import com.oing.dto.request.PostRealEmojiRequest;
+import com.oing.dto.request.PreSignedUrlRequest;
+import com.oing.dto.response.*;
+import com.oing.exception.DuplicatePostUploadException;
+import com.oing.exception.InvalidUploadTimeException;
+import com.oing.restapi.MemberPostApi;
+import com.oing.restapi.MemberPostRealEmojiApi;
+import com.oing.service.MemberBridge;
+import com.oing.service.MemberPostService;
+import com.oing.util.AuthenticationHolder;
+import com.oing.util.IdentityGenerator;
+import com.oing.util.PreSignedUrlGenerator;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Controller
+public class MemberPostRealEmojiController implements MemberPostRealEmojiApi {
+
+    @Override
+    public DefaultResponse createRealEmoji(String postId, PostRealEmojiRequest request) {
+        return new DefaultResponse(true);
+    }
+
+    @Override
+    public DefaultResponse deleteRealEmoji(String postId, PostRealEmojiRequest request) {
+        return new DefaultResponse(true);
+    }
+
+    @Override
+    public ArrayResponse<PostRealEmojiResponse> getPostRealEmojis(String postId) {
+        return ArrayResponse.of(Collections.emptyList());
+    }
+}

--- a/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
@@ -35,7 +35,7 @@ public class MemberPostRealEmojiController implements MemberPostRealEmojiApi {
     }
 
     @Override
-    public DefaultResponse deleteRealEmoji(String postId, PostRealEmojiRequest request) {
+    public DefaultResponse deleteRealEmoji(String postId, String realEmojiId) {
         return new DefaultResponse(true);
     }
 

--- a/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
@@ -15,17 +15,17 @@ import org.springframework.stereotype.Controller;
 public class MemberRealEmojiController implements MemberRealEmojiApi {
 
     @Override
-    public PreSignedUrlResponse requestPresignedUrl(PreSignedUrlRequest request) {
+    public PreSignedUrlResponse requestPresignedUrl(String memberId, PreSignedUrlRequest request) {
         return new PreSignedUrlResponse("https://test/2021-08-22/real-emoji-1.jpg");
     }
 
     @Override
-    public DefaultResponse createMyRealEmoji(CreateMyRealEmojiRequest request) {
+    public DefaultResponse createMyRealEmoji(String memberId, CreateMyRealEmojiRequest request) {
         return new DefaultResponse(true);
     }
 
     @Override
-    public DefaultResponse changeMyRealEmoji(String realEmojiId, CreateMyRealEmojiRequest request) {
+    public DefaultResponse changeMyRealEmoji(String memberId, String realEmojiId, CreateMyRealEmojiRequest request) {
         return new DefaultResponse(true);
     }
 

--- a/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
@@ -1,0 +1,42 @@
+package com.oing.controller;
+
+
+import com.oing.dto.request.CreateMyRealEmojiRequest;
+import com.oing.dto.request.PostRealEmojiRequest;
+import com.oing.dto.request.PreSignedUrlRequest;
+import com.oing.dto.response.*;
+import com.oing.restapi.MemberPostRealEmojiApi;
+import com.oing.restapi.MemberRealEmojiApi;
+import com.oing.service.MemberBridge;
+import com.oing.util.AuthenticationHolder;
+import com.oing.util.IdentityGenerator;
+import com.oing.util.PreSignedUrlGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Controller
+public class MemberRealEmojiController implements MemberRealEmojiApi {
+
+    @Override
+    public PreSignedUrlResponse requestPresignedUrl(PreSignedUrlRequest request) {
+        return new PreSignedUrlResponse("https://test/2021-08-22/real-emoji-1.jpg");
+    }
+
+    @Override
+    public DefaultResponse createMyRealEmoji(CreateMyRealEmojiRequest request) {
+        return new DefaultResponse(true);
+    }
+
+    @Override
+    public DefaultResponse changeMyRealEmoji(String realEmojiId, CreateMyRealEmojiRequest request) {
+        return new DefaultResponse(true);
+    }
+
+    @Override
+    public MyPostRealEmojisResponse getMyRealEmojis(String memberId) {
+        return new MyPostRealEmojisResponse(Collections.emptyMap());
+    }
+}

--- a/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
@@ -2,19 +2,13 @@ package com.oing.controller;
 
 
 import com.oing.dto.request.CreateMyRealEmojiRequest;
-import com.oing.dto.request.PostRealEmojiRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
-import com.oing.dto.response.*;
-import com.oing.restapi.MemberPostRealEmojiApi;
+import com.oing.dto.response.DefaultResponse;
+import com.oing.dto.response.PreSignedUrlResponse;
+import com.oing.dto.response.RealEmojisResponse;
 import com.oing.restapi.MemberRealEmojiApi;
-import com.oing.service.MemberBridge;
-import com.oing.util.AuthenticationHolder;
-import com.oing.util.IdentityGenerator;
-import com.oing.util.PreSignedUrlGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-
-import java.util.Collections;
 
 @RequiredArgsConstructor
 @Controller
@@ -36,7 +30,7 @@ public class MemberRealEmojiController implements MemberRealEmojiApi {
     }
 
     @Override
-    public MyPostRealEmojisResponse getMyRealEmojis(String memberId) {
-        return new MyPostRealEmojisResponse(Collections.emptyMap());
+    public RealEmojisResponse getMyRealEmojis(String memberId) {
+        return new RealEmojisResponse(null);
     }
 }

--- a/post/src/main/java/com/oing/domain/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/MemberPost.java
@@ -39,11 +39,17 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "reaction_cnt", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private int reactionCnt;
 
+    @Column(name = "real_emoji_cnt", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
+    private int realEmojiCnt;
+
     @OneToMany(mappedBy = "post")
     private List<MemberPostComment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "post")
     private List<MemberPostReaction> reactions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post")
+    private List<MemberPostRealEmoji> realEmojis = new ArrayList<>();
 
     public MemberPost(String id, String memberId, String postImgUrl, String postImgKey, String content) {
         validateContent(content);
@@ -54,6 +60,7 @@ public class MemberPost extends BaseAuditEntity {
         this.content = content;
         this.commentCnt = 0;
         this.reactionCnt = 0;
+        this.realEmojiCnt = 0;
     }
 
     private void validateContent(String content) {
@@ -67,8 +74,18 @@ public class MemberPost extends BaseAuditEntity {
         this.reactionCnt += 1;
     }
 
+    public void addRealEmoji(MemberPostRealEmoji realEmoji) {
+        this.realEmojis.add(realEmoji);
+        this.realEmojiCnt += 1;
+    }
+
     public void removeReaction(MemberPostReaction reaction) {
         this.reactions.remove(reaction);
         this.reactionCnt -= 1;
+    }
+
+    public void removeRealEmoji(MemberPostRealEmoji realEmoji) {
+        this.realEmojis.remove(realEmoji);
+        this.realEmojiCnt -= 1;
     }
 }

--- a/post/src/main/java/com/oing/domain/MemberPostRealEmoji.java
+++ b/post/src/main/java/com/oing/domain/MemberPostRealEmoji.java
@@ -18,7 +18,7 @@ public class MemberPostRealEmoji extends BaseEntity {
     @Column(name = "post_real_emoji_id", columnDefinition = "CHAR(26)", nullable = false)
     private String id;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "real_emoji_id", nullable = false)
     private MemberRealEmoji realEmoji;
 

--- a/post/src/main/java/com/oing/domain/MemberPostRealEmoji.java
+++ b/post/src/main/java/com/oing/domain/MemberPostRealEmoji.java
@@ -1,0 +1,30 @@
+package com.oing.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@Getter
+@Table(indexes = {
+        @Index(name = "member_post_real_emoji_idx1", columnList = "post_id"),
+        @Index(name = "member_post_real_emoji_idx2", columnList = "member_id")
+})
+@Entity(name = "member_post_real_emoji")
+public class MemberPostRealEmoji extends BaseEntity {
+
+    @Id
+    @Column(name = "post_real_emoji_id", columnDefinition = "CHAR(26)", nullable = false)
+    private String id;
+
+    @Column(name = "real_emoji_id", columnDefinition = "CHAR(26)", nullable = false)
+    private String realEmojiId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private MemberPost post;
+
+    @Column(name = "member_id", columnDefinition = "CHAR(26)", nullable = false)
+    private String memberId;
+}

--- a/post/src/main/java/com/oing/domain/MemberPostRealEmoji.java
+++ b/post/src/main/java/com/oing/domain/MemberPostRealEmoji.java
@@ -18,8 +18,9 @@ public class MemberPostRealEmoji extends BaseEntity {
     @Column(name = "post_real_emoji_id", columnDefinition = "CHAR(26)", nullable = false)
     private String id;
 
-    @Column(name = "real_emoji_id", columnDefinition = "CHAR(26)", nullable = false)
-    private String realEmojiId;
+    @OneToOne
+    @JoinColumn(name = "real_emoji_id", nullable = false)
+    private MemberRealEmoji realEmoji;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)

--- a/post/src/main/java/com/oing/domain/MemberRealEmoji.java
+++ b/post/src/main/java/com/oing/domain/MemberRealEmoji.java
@@ -1,0 +1,32 @@
+package com.oing.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+@Getter
+@Table(indexes = {
+        @Index(name = "member_real_emoji_idx1", columnList = "member_id")
+})
+@Entity(name = "member_real_emoji")
+public class MemberRealEmoji extends BaseAuditEntity {
+
+    @Id
+    @Column(name = "real_emoji_id", columnDefinition = "CHAR(26)", nullable = false)
+    private String id;
+
+    @Column(name = "member_id", columnDefinition = "CHAR(26)", nullable = false)
+    private String memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private Emoji type;
+
+    @Column(name = "real_emoji_image_url", nullable = false)
+    private String realEmojiImageUrl;
+
+    @Column(name = "real_emoji_image_key", nullable = false)
+    private String realEmojiImageKey;
+}

--- a/post/src/main/java/com/oing/dto/request/CreateMyRealEmojiRequest.java
+++ b/post/src/main/java/com/oing/dto/request/CreateMyRealEmojiRequest.java
@@ -1,0 +1,16 @@
+package com.oing.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "자신의 리얼 이모지 생성 요청")
+public record CreateMyRealEmojiRequest(
+
+        @Schema(description = "리얼 이모지 타입", example = "EMOJI_1")
+        String type,
+
+        @NotNull
+        @Schema(description = "리얼 이모지 사진 주소", example = "https://no5ing.com/feed/1.jpg")
+        String imageUrl
+) {
+}

--- a/post/src/main/java/com/oing/dto/request/PostRealEmojiRequest.java
+++ b/post/src/main/java/com/oing/dto/request/PostRealEmojiRequest.java
@@ -1,0 +1,12 @@
+package com.oing.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "피드 게시물 리얼 이모지 생성 및 삭제 요청")
+public record PostRealEmojiRequest(
+        @NotBlank
+        @Schema(description = "이모지 Id", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String emojiId
+) {
+}

--- a/post/src/main/java/com/oing/dto/request/PostRealEmojiRequest.java
+++ b/post/src/main/java/com/oing/dto/request/PostRealEmojiRequest.java
@@ -3,7 +3,7 @@ package com.oing.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-@Schema(description = "피드 게시물 리얼 이모지 생성 및 삭제 요청")
+@Schema(description = "피드 게시물 리얼 이모지 생성 요청")
 public record PostRealEmojiRequest(
         @NotBlank
         @Schema(description = "이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")

--- a/post/src/main/java/com/oing/dto/request/PostRealEmojiRequest.java
+++ b/post/src/main/java/com/oing/dto/request/PostRealEmojiRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(description = "피드 게시물 리얼 이모지 생성 및 삭제 요청")
 public record PostRealEmojiRequest(
         @NotBlank
-        @Schema(description = "이모지 Id", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
-        String emojiId
+        @Schema(description = "이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String realEmojiId
 ) {
 }

--- a/post/src/main/java/com/oing/dto/response/MyPostRealEmojisResponse.java
+++ b/post/src/main/java/com/oing/dto/response/MyPostRealEmojisResponse.java
@@ -1,0 +1,12 @@
+package com.oing.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Map;
+
+@Schema(description = "자신이 생성한 리얼 이모지 리스트 응답")
+public record MyPostRealEmojisResponse(
+        @Schema(description = "자신이 생성한 리얼 이모지 정보")
+        Map<String, String> myRealEmojiList
+) {
+}

--- a/post/src/main/java/com/oing/dto/response/PostRealEmojiResponse.java
+++ b/post/src/main/java/com/oing/dto/response/PostRealEmojiResponse.java
@@ -1,0 +1,20 @@
+package com.oing.dto.response;
+
+import com.oing.domain.MemberPostReaction;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "피드 게시물 응답")
+public record PostRealEmojiResponse(
+        @Schema(description = "피드 게시물 리얼 이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String realEmojiId,
+
+        @Schema(description = "피드 게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String postId,
+
+        @Schema(description = "반응 작성 사용자 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String memberId,
+
+        @Schema(description = "피드 게시물 리얼 이모지 이미지 주소", example = "http://test.com/test-profile.jpg")
+        String emojiImageUrl
+) {
+}

--- a/post/src/main/java/com/oing/dto/response/RealEmojiResponse.java
+++ b/post/src/main/java/com/oing/dto/response/RealEmojiResponse.java
@@ -1,0 +1,16 @@
+package com.oing.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "자신이 생성한 리얼 이모지 응답")
+public record RealEmojiResponse (
+        @Schema(description = "리얼 이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String realEmojiId,
+
+        @Schema(description = "리얼 이모지 타입", example = "EMOJI_1")
+        String type,
+
+        @Schema(description = "리얼 이모지 이미지 주소", example = "https://no5ing.com/profile/1.jpg")
+        String imageUrl
+){
+}

--- a/post/src/main/java/com/oing/dto/response/RealEmojisResponse.java
+++ b/post/src/main/java/com/oing/dto/response/RealEmojisResponse.java
@@ -2,11 +2,11 @@ package com.oing.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.util.Map;
+import java.util.List;
 
 @Schema(description = "자신이 생성한 리얼 이모지 리스트 응답")
-public record MyPostRealEmojisResponse(
+public record RealEmojisResponse(
         @Schema(description = "자신이 생성한 리얼 이모지 정보")
-        Map<String, String> myRealEmojiList
+        List<RealEmojiResponse> myRealEmojiList
 ) {
 }

--- a/post/src/main/java/com/oing/repository/MemberPostRealEmojiRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRealEmojiRepository.java
@@ -1,0 +1,7 @@
+package com.oing.repository;
+
+import com.oing.domain.MemberPostRealEmoji;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberPostRealEmojiRepository extends JpaRepository<MemberPostRealEmoji, String> {
+}

--- a/post/src/main/java/com/oing/repository/MemberRealEmojiRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberRealEmojiRepository.java
@@ -1,0 +1,7 @@
+package com.oing.repository;
+
+import com.oing.domain.MemberRealEmoji;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRealEmojiRepository extends JpaRepository<MemberRealEmoji, String> {
+}

--- a/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
@@ -4,6 +4,7 @@ import com.oing.dto.request.PostRealEmojiRequest;
 import com.oing.dto.response.ArrayResponse;
 import com.oing.dto.response.DefaultResponse;
 import com.oing.dto.response.PostReactionResponse;
+import com.oing.dto.response.PostRealEmojiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,7 +43,7 @@ public interface MemberPostRealEmojiApi {
 
     @Operation(summary = "게시물의 리얼 이모지 전체 조회", description = "게시물에 달린 모든 리얼 이모지 목록을 조회합니다.")
     @GetMapping("/{postId}")
-    ArrayResponse<PostReactionResponse> getPostRealEmojis(
+    ArrayResponse<PostRealEmojiResponse> getPostRealEmojis(
             @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String postId

--- a/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
@@ -1,0 +1,50 @@
+package com.oing.restapi;
+
+import com.oing.dto.request.PostRealEmojiRequest;
+import com.oing.dto.response.ArrayResponse;
+import com.oing.dto.response.DefaultResponse;
+import com.oing.dto.response.PostReactionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시물 리얼 이모지 API", description = "게시물 리얼 이모지 관련 API")
+@RestController
+@Valid
+@RequestMapping("/v1/posts/real-emoji")
+public interface MemberPostRealEmojiApi {
+
+    @Operation(summary = "게시물에 리얼 이모지 등록", description = "게시물에 리얼 이모지를 추가합니다.")
+    @PostMapping("/{postId}")
+    DefaultResponse createRealEmoji(
+            @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String postId,
+
+            @Valid
+            @RequestBody
+            PostRealEmojiRequest request
+    );
+
+    @Operation(summary = "게시물에서 리얼 이모지 삭제", description = "게시물에서 리얼 이모지를 삭제합니다.")
+    @DeleteMapping("/{postId}")
+    DefaultResponse deleteRealEmoji(
+            @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String postId,
+
+            @Valid
+            @RequestBody
+            PostRealEmojiRequest request
+    );
+
+    @Operation(summary = "게시물의 리얼 이모지 전체 조회", description = "게시물에 달린 모든 리얼 이모지 목록을 조회합니다.")
+    @GetMapping("/{postId}")
+    ArrayResponse<PostReactionResponse> getPostRealEmojis(
+            @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String postId
+    );
+}

--- a/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
@@ -3,7 +3,6 @@ package com.oing.restapi;
 import com.oing.dto.request.PostRealEmojiRequest;
 import com.oing.dto.response.ArrayResponse;
 import com.oing.dto.response.DefaultResponse;
-import com.oing.dto.response.PostReactionResponse;
 import com.oing.dto.response.PostRealEmojiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
@@ -29,15 +29,15 @@ public interface MemberPostRealEmojiApi {
     );
 
     @Operation(summary = "게시물에서 리얼 이모지 삭제", description = "게시물에서 리얼 이모지를 삭제합니다.")
-    @DeleteMapping("/{postId}")
+    @DeleteMapping("/{postId}/{realEmojiId}")
     DefaultResponse deleteRealEmoji(
             @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String postId,
 
-            @Valid
-            @RequestBody
-            PostRealEmojiRequest request
+            @Parameter(description = "리얼 이모지 ID", example = "01HEFDFADFDFDAFDFDARS2E97")
+            @PathVariable
+            String realEmojiId
     );
 
     @Operation(summary = "게시물의 리얼 이모지 전체 조회", description = "게시물에 달린 모든 리얼 이모지 목록을 조회합니다.")

--- a/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "게시물 리얼 이모지 API", description = "게시물 리얼 이모지 관련 API")
 @RestController
 @Valid
-@RequestMapping("/v1/posts/real-emoji")
+@RequestMapping("/v1/posts/{postId}/real-emoji")
 public interface MemberPostRealEmojiApi {
 
     @Operation(summary = "게시물에 리얼 이모지 등록", description = "게시물에 리얼 이모지를 추가합니다.")
-    @PostMapping("/{postId}")
+    @PostMapping
     DefaultResponse createRealEmoji(
             @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
@@ -29,7 +29,7 @@ public interface MemberPostRealEmojiApi {
     );
 
     @Operation(summary = "게시물에서 리얼 이모지 삭제", description = "게시물에서 리얼 이모지를 삭제합니다.")
-    @DeleteMapping("/{postId}/{realEmojiId}")
+    @DeleteMapping("/{realEmojiId}")
     DefaultResponse deleteRealEmoji(
             @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
@@ -41,7 +41,7 @@ public interface MemberPostRealEmojiApi {
     );
 
     @Operation(summary = "게시물의 리얼 이모지 전체 조회", description = "게시물에 달린 모든 리얼 이모지 목록을 조회합니다.")
-    @GetMapping("/{postId}")
+    @GetMapping
     ArrayResponse<PostRealEmojiResponse> getPostRealEmojis(
             @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable

--- a/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
@@ -3,7 +3,7 @@ package com.oing.restapi;
 import com.oing.dto.request.CreateMyRealEmojiRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.response.DefaultResponse;
-import com.oing.dto.response.MyPostRealEmojisResponse;
+import com.oing.dto.response.RealEmojisResponse;
 import com.oing.dto.response.PreSignedUrlResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -47,7 +47,7 @@ public interface MemberRealEmojiApi {
 
     @Operation(summary = "회원의 리얼 이모지 조회", description = "자신의 리얼 이모지를 조회합니다.")
     @GetMapping("/{memberId}")
-    MyPostRealEmojisResponse getMyRealEmojis(
+    RealEmojisResponse getMyRealEmojis(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String memberId

--- a/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
@@ -11,15 +11,19 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "게시물 리얼 이모지 API", description = "게시물 리얼 이모지 관련 API")
+@Tag(name = "회원 리얼 이모지 API", description = "회원 리얼 이모지 관련 API")
 @RestController
 @Valid
-@RequestMapping("/v1/real-emoji")
+@RequestMapping("/v1/members/{memberId}/real-emoji")
 public interface MemberRealEmojiApi {
 
     @Operation(summary = "리얼 이모지 사진 Presigned Url 요청", description = "S3 Presigned Url을 요청합니다.")
     @PostMapping("/image-upload-request")
     PreSignedUrlResponse requestPresignedUrl(
+            @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String memberId,
+
             @Valid
             @RequestBody
             PreSignedUrlRequest request
@@ -28,6 +32,10 @@ public interface MemberRealEmojiApi {
     @Operation(summary = "자신의 리얼 이모지 추가", description = "자신의 리얼 이모지를 추가합니다.")
     @PostMapping
     DefaultResponse createMyRealEmoji(
+            @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String memberId,
+
             @Valid
             @RequestBody
             CreateMyRealEmojiRequest request
@@ -36,6 +44,10 @@ public interface MemberRealEmojiApi {
     @Operation(summary = "자신의 리얼 이모지 변경", description = "자신의 리얼 이모지 사진을 변경합니다.")
     @PutMapping("/{realEmojiId}")
     DefaultResponse changeMyRealEmoji(
+            @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String memberId,
+
             @Parameter(description = "리얼 이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String realEmojiId,
@@ -46,7 +58,7 @@ public interface MemberRealEmojiApi {
     );
 
     @Operation(summary = "회원의 리얼 이모지 조회", description = "자신의 리얼 이모지를 조회합니다.")
-    @GetMapping("/{memberId}")
+    @GetMapping
     RealEmojisResponse getMyRealEmojis(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable

--- a/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
@@ -1,0 +1,55 @@
+package com.oing.restapi;
+
+import com.oing.dto.request.CreateMyRealEmojiRequest;
+import com.oing.dto.request.PreSignedUrlRequest;
+import com.oing.dto.response.DefaultResponse;
+import com.oing.dto.response.MyPostRealEmojisResponse;
+import com.oing.dto.response.PreSignedUrlResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시물 리얼 이모지 API", description = "게시물 리얼 이모지 관련 API")
+@RestController
+@Valid
+@RequestMapping("/v1/real-emoji")
+public interface MemberRealEmojiApi {
+
+    @Operation(summary = "리얼 이모지 사진 Presigned Url 요청", description = "S3 Presigned Url을 요청합니다.")
+    @PostMapping("/image-upload-request")
+    PreSignedUrlResponse requestPresignedUrl(
+            @Valid
+            @RequestBody
+            PreSignedUrlRequest request
+    );
+
+    @Operation(summary = "자신의 리얼 이모지 추가", description = "자신의 리얼 이모지를 추가합니다.")
+    @PostMapping
+    DefaultResponse createMyRealEmoji(
+            @Valid
+            @RequestBody
+            CreateMyRealEmojiRequest request
+    );
+
+    @Operation(summary = "자신의 리얼 이모지 변경", description = "자신의 리얼 이모지 사진을 변경합니다.")
+    @PutMapping("/{realEmojiId}")
+    DefaultResponse changeMyRealEmoji(
+            @Parameter(description = "리얼 이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String realEmojiId,
+
+            @Valid
+            @RequestBody
+            CreateMyRealEmojiRequest request
+    );
+
+    @Operation(summary = "회원의 리얼 이모지 조회", description = "자신의 리얼 이모지를 조회합니다.")
+    @GetMapping("/{memberId}")
+    MyPostRealEmojisResponse getMyRealEmojis(
+            @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String memberId
+    );
+}

--- a/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
@@ -22,7 +22,7 @@ public class MemberPostCommentTest {
         String commentId = "sampleCommentId";
         String commentContents = "sampleCommentContents";
         MemberPost post = new MemberPost(postId, memberId, imageUrl, imageKey, content, 0,
-                0, null, null);
+                0, 0, null, null, null);
 
         // When
         MemberPostComment comment = new MemberPostComment(commentId, post, memberId, commentContents);

--- a/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
@@ -23,7 +23,7 @@ public class MemberPostReactionTest {
         String reactionId = "sampleCommentId";
         Emoji emoji = Emoji.EMOJI_1;
         MemberPost post = new MemberPost(postId, memberId, imageUrl, imageKey, content, 0,
-                0, null, null);
+                0, 0, null, null, null);
 
         // When
         MemberPostReaction reaction = new MemberPostReaction(reactionId, post, memberId, emoji);

--- a/post/src/test/java/com/oing/domain/model/MemberPostTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostTest.java
@@ -23,7 +23,7 @@ public class MemberPostTest {
 
         // When
         MemberPost post = new MemberPost(postId, memberId, imageUrl, imageKey, content, 0,
-                0, null, null);
+                0, 0, null, null, null);
 
         // Then
         assertNotNull(post);


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
리얼 이모지 기능이 추가되면서 필요한 테이블 클래스와 기본 api 틀을 작성했습니다.

## ➕ 추가/변경된 기능

---
- 리얼 이모지 테이블 migration 파일 추가
- 리얼 이모지 테이블 클래스 추가
  - 사용자가 생성한 리얼 이모지 테이블 클래스
  - 피드에 남긴 리얼 이모지 테이블 클래스 
- 리얼 이모지에 필요한 기본적인 API 틀 추가

## 🥺 리뷰어에게 하고싶은 말

---
리얼 이모지 api uri를 계층적으로 나누어야 할 지 고민을 하다가 사용자가 자신의 리얼 이모지를 생성하기 위한 API 클래스는 포스트 패키지 아래에 있지만 실제로는 post 객체와는 상관없으므로 uri에서는 /posts 경로를 제외했습니다. 괜찮은지 확인해주세요~

## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-147