### PR TITLE
[OING-148] feat: Post 삭제 기능 추가

### DIFF
--- a/post/src/main/java/com/oing/controller/MemberPostController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostController.java
@@ -5,6 +5,7 @@ import com.oing.domain.MemberPost;
 import com.oing.domain.PaginationDTO;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
+import com.oing.dto.response.DefaultResponse;
 import com.oing.dto.response.PaginationResponse;
 import com.oing.dto.response.PostResponse;
 import com.oing.dto.response.PreSignedUrlResponse;
@@ -106,5 +107,11 @@ public class MemberPostController implements MemberPostApi {
     public PostResponse getPost(String postId) {
         MemberPost memberPostProjection = memberPostService.getMemberPostById(postId);
         return PostResponse.from(memberPostProjection);
+    }
+
+    @Override
+    public DefaultResponse deletePost(String postId) {
+        memberPostService.deleteMemberPostById(postId);
+        return DefaultResponse.ok();
     }
 }

--- a/post/src/main/java/com/oing/repository/MemberPostCommentRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberPostCommentRepository.java
@@ -4,4 +4,5 @@ import com.oing.domain.MemberPostComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberPostCommentRepository extends JpaRepository<MemberPostComment, String>, MemberPostCommentRepositoryCustom {
+    void deleteAllByPostId(String memberPostId);
 }

--- a/post/src/main/java/com/oing/repository/MemberPostReactionRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberPostReactionRepository.java
@@ -14,4 +14,6 @@ public interface MemberPostReactionRepository extends JpaRepository<MemberPostRe
     Optional<MemberPostReaction> findReactionByPostAndMemberIdAndEmoji(MemberPost post, String memberId, Emoji emoji);
 
     List<MemberPostReaction> findAllByPostId(String postId);
+
+    void deleteAllByPostId(String memberPostId);
 }

--- a/post/src/main/java/com/oing/restapi/MemberPostApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostApi.java
@@ -2,6 +2,7 @@ package com.oing.restapi;
 
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
+import com.oing.dto.response.DefaultResponse;
 import com.oing.dto.response.PaginationResponse;
 import com.oing.dto.response.PostResponse;
 import com.oing.dto.response.PreSignedUrlResponse;
@@ -72,6 +73,15 @@ public interface MemberPostApi {
     @Operation(summary = "단일 게시물 조회", description = "ID를 통해 게시물을 조회합니다.")
     @GetMapping("/{postId}")
     PostResponse getPost(
+            @PathVariable
+            @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            String postId
+    );
+
+    //* 테스트용 API
+    @Operation(summary = "게시물 삭제", description = "ID를 통해 게시물을 삭제합니다.")
+    @DeleteMapping("/{postId}")
+    DefaultResponse deletePost(
             @PathVariable
             @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             String postId

--- a/post/src/main/java/com/oing/service/MemberPostCommentService.java
+++ b/post/src/main/java/com/oing/service/MemberPostCommentService.java
@@ -1,12 +1,15 @@
 package com.oing.service;
 
+import com.oing.domain.MemberPost;
 import com.oing.domain.MemberPostComment;
 import com.oing.domain.PaginationDTO;
 import com.oing.exception.MemberPostCommentNotFoundException;
 import com.oing.repository.MemberPostCommentRepository;
+import com.oing.service.event.DeleteMemberPostEvent;
 import com.querydsl.core.QueryResults;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -67,5 +70,11 @@ public class MemberPostCommentService {
                 totalPage,
                 results.getResults()
         );
+    }
+
+    @EventListener
+    public void deleteAllWhenPostDelete(DeleteMemberPostEvent event) {
+        MemberPost post = event.memberPost();
+        memberPostCommentRepository.deleteAllByPostId(post.getId());
     }
 }

--- a/post/src/main/java/com/oing/service/MemberPostReactionService.java
+++ b/post/src/main/java/com/oing/service/MemberPostReactionService.java
@@ -5,7 +5,9 @@ import com.oing.domain.MemberPost;
 import com.oing.domain.MemberPostReaction;
 import com.oing.exception.EmojiNotFoundException;
 import com.oing.repository.MemberPostReactionRepository;
+import com.oing.service.event.DeleteMemberPostEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -38,5 +40,11 @@ public class MemberPostReactionService {
 
     public List<MemberPostReaction> getMemberPostReactionsByPostId(String postId) {
         return memberPostReactionRepository.findAllByPostId(postId);
+    }
+
+    @EventListener
+    public void deleteAllWhenPostDelete(DeleteMemberPostEvent event) {
+        MemberPost post = event.memberPost();
+        memberPostReactionRepository.deleteAllByPostId(post.getId());
     }
 }

--- a/post/src/main/java/com/oing/service/MemberPostService.java
+++ b/post/src/main/java/com/oing/service/MemberPostService.java
@@ -3,13 +3,13 @@ package com.oing.service;
 import com.oing.domain.MemberPost;
 import com.oing.domain.MemberPostDailyCalendarDTO;
 import com.oing.domain.PaginationDTO;
-import com.oing.exception.DomainException;
-import com.oing.exception.ErrorCode;
 import com.oing.exception.PostNotFoundException;
 import com.oing.repository.MemberPostRepository;
+import com.oing.service.event.DeleteMemberPostEvent;
 import com.querydsl.core.QueryResults;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -20,7 +20,7 @@ import java.util.List;
 public class MemberPostService {
 
     private final MemberPostRepository memberPostRepository;
-
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * 멤버들이 범위 날짜 안에 올린 대표 게시물들을 가져온다.
@@ -89,5 +89,12 @@ public class MemberPostService {
                 totalPage,
                 results.getResults()
         );
+    }
+
+    @Transactional
+    public void deleteMemberPostById(String postId) {
+        MemberPost memberPost = memberPostRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+        applicationEventPublisher.publishEvent(new DeleteMemberPostEvent(memberPost));
+        memberPostRepository.delete(memberPost);
     }
 }

--- a/post/src/main/java/com/oing/service/event/DeleteMemberPostEvent.java
+++ b/post/src/main/java/com/oing/service/event/DeleteMemberPostEvent.java
@@ -1,0 +1,6 @@
+package com.oing.service.event;
+
+import com.oing.domain.MemberPost;
+
+public record DeleteMemberPostEvent(MemberPost memberPost) {
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
프론트의 요청으로 테스트를 위한 피드 삭제 기능을 추가했습니다.

## ➕ 추가/변경된 기능

---
피드 삭제 api 추가

## 🥺 리뷰어에게 하고싶은 말

---
- 테스트용 api 여서 본인이 작성한 글인지 확인하는 검증 로직은 다 제거했습니다.
- 같은 패키지 안에 있더라도 서비스에서 다른 레포 의존성을 갖는 것보단 이벤트 리스너로 풀어내는 게 좋다고 생각해서 위와 같이 구현했는데 괜찮은지 확인해주세요. (지금처럼 이벤트리스너 써서 한 서비스 안에 하나의 레포만 참조하는 게 좋을지 or 한 서비스 안에 여러 레포 참조하는 게 좋을지)



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-148