### PR TITLE
[OING-105] feat: 캘린더 API를 위한 테스트 추가

### DIFF
--- a/common/src/test/java/com/oing/QueryDslTestConfig.java
+++ b/common/src/test/java/com/oing/QueryDslTestConfig.java
@@ -1,0 +1,19 @@
+package com.oing;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class QueryDslTestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/gateway/src/main/java/com/oing/controller/CalendarController.java
+++ b/gateway/src/main/java/com/oing/controller/CalendarController.java
@@ -10,9 +10,13 @@ import com.oing.service.MemberPostService;
 import com.oing.service.MemberService;
 import com.oing.util.OptimizedImageUrlGenerator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Controller;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -64,10 +68,15 @@ public class CalendarController implements CalendarApi {
     }
 
     @Override
-    public ArrayResponse<CalendarResponse> getWeeklyCalendar(String yearMonth, Long week) {
-        List<String> familyIds = getFamilyIds();
-        LocalDate startDate = LocalDate.parse(yearMonth + "-01").plusWeeks(week - 1);
+    public ArrayResponse<CalendarResponse> getWeeklyCalendar(String yearMonth, Integer week) {
+        if (yearMonth == null) yearMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        if (week == null) week = LocalDate.now().get(WeekFields.of(DayOfWeek.MONDAY, 1).weekOfMonth());
+
+        // 1주 = 해당 주차 (+ 0), 2주 이상 = 주차 추가 (+ (week - 1))
+        LocalDate startDate = LocalDate.parse(yearMonth + "-01").plusWeeks(week - 1); // yyyy-MM-dd 패턴으로 파싱
         LocalDate endDate = startDate.plusWeeks(1);
+        List<String> familyIds = getFamilyIds();
+
 
         List<CalendarResponse> calendarResponses = getCalendarResponses(familyIds, startDate, endDate);
         return new ArrayResponse<>(calendarResponses);
@@ -75,9 +84,11 @@ public class CalendarController implements CalendarApi {
 
     @Override
     public ArrayResponse<CalendarResponse> getMonthlyCalendar(String yearMonth) {
-        List<String> familyIds = getFamilyIds();
-        LocalDate startDate = LocalDate.parse(yearMonth + "-01");
+        if (yearMonth == null) yearMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+
+        LocalDate startDate = LocalDate.parse(yearMonth + "-01"); // yyyy-MM-dd 패턴으로 파싱
         LocalDate endDate = startDate.plusMonths(1);
+        List<String> familyIds = getFamilyIds();
 
         List<CalendarResponse> calendarResponses = getCalendarResponses(familyIds, startDate, endDate);
         return new ArrayResponse<>(calendarResponses);

--- a/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
@@ -2,7 +2,6 @@ package com.oing.repository;
 
 import com.oing.domain.MemberPost;
 import com.oing.domain.MemberPostDailyCalendarDTO;
-import com.oing.exception.FamilyNotFoundException;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.Projections;
@@ -21,7 +20,7 @@ import static com.oing.domain.QMember.member;
 import static com.oing.domain.QMemberPost.memberPost;
 
 @RequiredArgsConstructor
-public class MemberPostRepositoryImpl implements MemberPostRepositoryCustom {
+public class MemberPostRepositoryCustomImpl implements MemberPostRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 

--- a/gateway/src/main/java/com/oing/restapi/CalendarApi.java
+++ b/gateway/src/main/java/com/oing/restapi/CalendarApi.java
@@ -33,7 +33,7 @@ public interface CalendarApi {
 
             @RequestParam(required = false)
             @Parameter(description = "조회할 주차", example = "1")
-            Long week
+            Integer week
     );
 
     @Operation(summary = "월별 캘린더 조회", description = "월별 캘린더를 조회합니다.")

--- a/gateway/src/main/resources/application-test.yaml
+++ b/gateway/src/main/resources/application-test.yaml
@@ -10,11 +10,12 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
         create_empty_composites:
           enabled: true
         show_sql: false
         format_sql: false
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    database-platform: org.hibernate.dialect.MySQL8Dialect
 app:
   external-urls:
     slack-webhook: https://www.naver.com # Must Be Replaced

--- a/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
@@ -1,0 +1,243 @@
+package com.oing.controller;
+
+import com.oing.component.TokenAuthenticationHolder;
+import com.oing.domain.Member;
+import com.oing.domain.MemberPost;
+import com.oing.domain.MemberPostDailyCalendarDTO;
+import com.oing.dto.response.ArrayResponse;
+import com.oing.dto.response.CalendarResponse;
+import com.oing.service.MemberPostService;
+import com.oing.service.MemberService;
+import com.oing.util.OptimizedImageUrlGenerator;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class CalendarControllerTest {
+
+    @InjectMocks
+    private CalendarController calendarController;
+
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private MemberPostService memberPostService;
+    @Mock
+    private TokenAuthenticationHolder tokenAuthenticationHolder;
+    @Mock
+    private OptimizedImageUrlGenerator optimizedImageUrlGenerator;
+
+
+    private final Member testMember1 = new Member(
+            "testMember1",
+            "testFamily",
+            LocalDate.of(1999, 10, 18),
+            "testMember1",
+            "profile.com/1",
+            "1"
+    );
+
+    private final Member testMember2 = new Member(
+            "testMember2",
+            "testFamily",
+            LocalDate.of(1999, 10, 18),
+            "testMember2",
+            "profile.com/2",
+            "2"
+    );
+
+    private final List<String> familyIds = List.of(testMember1.getId(), testMember2.getId());
+
+
+    @Test
+    void 주간_캘린더_조회_테스트() {
+        // Given
+        String yearMonth = "2023-11";
+        Integer week = 1;
+
+        LocalDate startDate = LocalDate.of(2023, 11, 1);
+        LocalDate endDate = startDate.plusWeeks(1);
+        MemberPost testPost1 = new MemberPost(
+                "1",
+                testMember1.getId(),
+                "post.com/1",
+                "1",
+                "test1"
+        );
+        ReflectionTestUtils.setField(testPost1, "createdAt", LocalDateTime.of(2023, 11, 1, 13, 0));
+        MemberPost testPost2 = new MemberPost(
+                "2",
+                testMember2.getId(),
+                "post.com/2",
+                "2",
+                "test2"
+        );
+        ReflectionTestUtils.setField(testPost2, "createdAt", LocalDateTime.of(2023, 11, 2, 13, 0));
+        List<MemberPost> representativePosts = List.of(testPost1, testPost2);
+        List<MemberPostDailyCalendarDTO> calendarDTOs = List.of(
+                new MemberPostDailyCalendarDTO(2L),
+                new MemberPostDailyCalendarDTO(1L)
+        );
+        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
+        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
+        when(memberPostService.findLatestPostOfEveryday(familyIds, startDate, endDate)).thenReturn(representativePosts);
+        when(memberPostService.findPostDailyCalendarDTOs(familyIds, startDate, endDate)).thenReturn(calendarDTOs);
+
+        // When
+        ArrayResponse<CalendarResponse> weeklyCalendar = calendarController.getWeeklyCalendar(yearMonth, week);
+
+        // Then
+        assertThat(weeklyCalendar.results())
+                .extracting(CalendarResponse::representativePostId, CalendarResponse::allFamilyMembersUploaded)
+                .containsExactly(
+                        Tuple.tuple("1", true),
+                        Tuple.tuple("2", false)
+                );
+    }
+
+    @Test
+    void 주간_캘린더_파라미터_없이_조회_테스트() {
+        // Given
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = startDate.plusWeeks(1);
+        MemberPost testPost1 = new MemberPost(
+                "1",
+                testMember1.getId(),
+                "post.com/1",
+                "1",
+                "test1"
+        );
+        ReflectionTestUtils.setField(testPost1, "createdAt", LocalDateTime.now());
+        List<MemberPost> representativePosts = List.of(testPost1);
+        List<MemberPostDailyCalendarDTO> calendarDTOs = List.of(
+                new MemberPostDailyCalendarDTO(1L)
+        );
+        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
+        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
+        when(memberPostService.findLatestPostOfEveryday(familyIds, startDate, endDate)).thenReturn(representativePosts);
+        when(memberPostService.findPostDailyCalendarDTOs(familyIds, startDate, endDate)).thenReturn(calendarDTOs);
+
+        // When
+        ArrayResponse<CalendarResponse> weeklyCalendar = calendarController.getWeeklyCalendar(null, null);
+
+        // Then
+        assertThat(weeklyCalendar.results())
+                .extracting(CalendarResponse::representativePostId, CalendarResponse::allFamilyMembersUploaded)
+                .containsExactly(
+                        Tuple.tuple("1", false)
+                );
+    }
+
+    @Test
+    void 월별_캘린더_조회_테스트() {
+        // Given
+        String yearMonth = "2023-11";
+
+        LocalDate startDate = LocalDate.of(2023, 11, 1);
+        LocalDate endDate = startDate.plusMonths(1);
+        MemberPost testPost1 = new MemberPost(
+                "1",
+                testMember1.getId(),
+                "post.com/1",
+                "1",
+                "test1"
+        );
+        ReflectionTestUtils.setField(testPost1, "createdAt", LocalDateTime.of(2023, 11, 1, 13, 0));
+        MemberPost testPost2 = new MemberPost(
+                "2",
+                testMember2.getId(),
+                "post.com/2",
+                "2",
+                "test2"
+        );
+        ReflectionTestUtils.setField(testPost2, "createdAt", LocalDateTime.of(2023, 11, 2, 13, 0));
+        MemberPost testPost3 = new MemberPost(
+                "3",
+                testMember1.getId(),
+                "post.com/3",
+                "3",
+                "test3"
+        );
+        ReflectionTestUtils.setField(testPost3, "createdAt", LocalDateTime.of(2023, 11, 8, 13, 0));
+        MemberPost testPost4 = new MemberPost(
+                "4",
+                testMember2.getId(),
+                "post.com/4",
+                "4",
+                "test4"
+        );
+        ReflectionTestUtils.setField(testPost4, "createdAt", LocalDateTime.of(2023, 11, 9, 13, 0));
+        List<MemberPost> representativePosts = List.of(testPost1, testPost2, testPost3, testPost4);
+        List<MemberPostDailyCalendarDTO> calendarDTOs = List.of(
+                new MemberPostDailyCalendarDTO(2L),
+                new MemberPostDailyCalendarDTO(1L),
+                new MemberPostDailyCalendarDTO(2L),
+                new MemberPostDailyCalendarDTO(1L)
+        );
+        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
+        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
+        when(memberPostService.findLatestPostOfEveryday(familyIds, startDate, endDate)).thenReturn(representativePosts);
+        when(memberPostService.findPostDailyCalendarDTOs(familyIds, startDate, endDate)).thenReturn(calendarDTOs);
+
+        // When
+        ArrayResponse<CalendarResponse> weeklyCalendar = calendarController.getMonthlyCalendar(yearMonth);
+
+        // Then
+        assertThat(weeklyCalendar.results())
+                .extracting(CalendarResponse::representativePostId, CalendarResponse::allFamilyMembersUploaded)
+                .containsExactly(
+                        Tuple.tuple("1", true),
+                        Tuple.tuple("2", false),
+                        Tuple.tuple("3", true),
+                        Tuple.tuple("4", false)
+                );
+    }
+
+    @Test
+    void 월별_캘린더_파라미터_없이_조회_테스트() {
+        // Given
+        LocalDate startDate = LocalDate.parse(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM")) + "-01");
+        LocalDate endDate = startDate.plusMonths(1);
+        MemberPost testPost1 = new MemberPost(
+                "1",
+                testMember1.getId(),
+                "post.com/1",
+                "1",
+                "test1"
+        );
+        ReflectionTestUtils.setField(testPost1, "createdAt", LocalDateTime.now());
+        List<MemberPost> representativePosts = List.of(testPost1);
+        List<MemberPostDailyCalendarDTO> calendarDTOs = List.of(
+                new MemberPostDailyCalendarDTO(1L)
+        );
+        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
+        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
+        when(memberPostService.findLatestPostOfEveryday(familyIds, startDate, endDate)).thenReturn(representativePosts);
+        when(memberPostService.findPostDailyCalendarDTOs(familyIds, startDate, endDate)).thenReturn(calendarDTOs);
+
+        // When
+        ArrayResponse<CalendarResponse> weeklyCalendar = calendarController.getMonthlyCalendar(null);
+
+        // Then
+        assertThat(weeklyCalendar.results())
+                .extracting(CalendarResponse::representativePostId, CalendarResponse::allFamilyMembersUploaded)
+                .containsExactly(
+                        Tuple.tuple("1", false)
+                );
+    }
+}

--- a/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
@@ -1,0 +1,113 @@
+package com.oing.repository;
+
+import com.oing.config.QuerydslConfig;
+import com.oing.domain.Family;
+import com.oing.domain.Member;
+import com.oing.domain.MemberPost;
+import com.oing.domain.MemberPostDailyCalendarDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // application-test.yaml의 데이터베이스 설정을 적용하기 위해서 필수
+@ActiveProfiles("test")
+@Import(QuerydslConfig.class)
+class MemberPostRepositoryCustomTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private MemberPostRepositoryCustomImpl memberPostRepositoryCustomImpl;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private FamilyRepository familyRepository;
+
+
+    private final Member testMember1 = new Member(
+            "testMember1",
+            "testFamily",
+            LocalDate.of(1999, 10, 18),
+            "testMember1",
+            "profile.com/1",
+            "1"
+    );
+
+    private final Member testMember2 = new Member(
+            "testMember2",
+            "testFamily",
+            LocalDate.of(1999, 10, 18),
+            "testMember2",
+            "profile.com/2",
+            "2"
+    );
+
+    private final Member testMember3 = new Member(
+            "testMember3",
+            "otherFamily",
+            LocalDate.of(1999, 10, 18),
+            "testMember3",
+            "profile.com/3",
+            "2"
+    );
+
+    private final List<String> familyIds = List.of(testMember1.getId(), testMember2.getId());
+
+
+    @BeforeEach
+    void setup() {
+        // Family & Members
+        familyRepository.save(new Family("testFamily"));
+        memberRepository.save(testMember1);
+        memberRepository.save(testMember2);
+        memberRepository.save(testMember3);
+
+        // Posts
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('1', '" + testMember1.getId() + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('2', '" + testMember2.getId() + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('3', '" + testMember3.getId() + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('4', '" + testMember1.getId() + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
+    }
+
+
+    @Test
+    void 각_날짜에서_가장_마지막으로_업로드된_게시글을_조회한다() {
+        // When
+        List<MemberPost> posts = memberPostRepositoryCustomImpl.findLatestPostOfEveryday(familyIds, LocalDateTime.of(2023, 11, 1, 0, 0, 0), LocalDateTime.of(2023, 12, 1, 0, 0, 0));
+
+        // Then
+        assertThat(posts)
+                .extracting(MemberPost::getId)
+                .containsExactly("2", "4");
+    }
+
+    @Test
+    void 데일리_게시글_캘린더를_구성하기_위한_정보를_조회한다() {
+        // when
+        List<MemberPostDailyCalendarDTO> postDailyCalendarDTOs = memberPostRepositoryCustomImpl.findPostDailyCalendarDTOs(familyIds, LocalDateTime.of(2023, 11, 1, 0, 0, 0), LocalDateTime.of(2023, 12, 1, 0, 0, 0));
+
+        // Then
+        assertThat(postDailyCalendarDTOs)
+                .extracting(MemberPostDailyCalendarDTO::dailyPostCount)
+                .containsExactly(2L, 1L);
+    }
+}

--- a/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
@@ -51,12 +51,12 @@ class CalendarApiTest {
     @Autowired
     private TokenGenerator tokenGenerator;
 
-    private String TEST_USER1_ID;
-    private String TEST_USER1_TOKEN;
-    private String TEST_USER2_ID;
-    private String TEST_USER2_TOKEN;
-    private String TEST_USER3_ID;
-    private String TEST_USER3_TOKEN;
+    private String TEST_MEMBER1_ID;
+    private String TEST_MEMBER1_TOKEN;
+    private String TEST_MEMBER2_ID;
+    private String TEST_MEMBER2_TOKEN;
+    private String TEST_MEMBER3_ID;
+    private String TEST_MEMBER3_TOKEN;
     private List<String> TEST_FAMILIES_IDS;
 
     @Value("${cloud.ncp.image-optimizer-cdn}")
@@ -67,7 +67,7 @@ class CalendarApiTest {
 
     @BeforeEach
     void setUp() {
-        TEST_USER1_ID = memberService.createNewMember(
+        TEST_MEMBER1_ID = memberService.createNewMember(
                 new CreateNewUserDTO(
                         SocialLoginProvider.fromString("APPLE"),
                         "testUser1",
@@ -76,9 +76,9 @@ class CalendarApiTest {
                         "profile.com"
                 )
         ).getId();
-        TEST_USER1_TOKEN = tokenGenerator.generateTokenPair(TEST_USER1_ID).accessToken();
+        TEST_MEMBER1_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER1_ID).accessToken();
 
-        TEST_USER2_ID = memberService.createNewMember(
+        TEST_MEMBER2_ID = memberService.createNewMember(
                 new CreateNewUserDTO(
                         SocialLoginProvider.fromString("APPLE"),
                         "testUser2",
@@ -87,9 +87,9 @@ class CalendarApiTest {
                         "profile.com"
                 )
         ).getId();
-        TEST_USER2_TOKEN = tokenGenerator.generateTokenPair(TEST_USER2_ID).accessToken();
+        TEST_MEMBER2_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER2_ID).accessToken();
 
-        TEST_USER3_ID = memberService.createNewMember(
+        TEST_MEMBER3_ID = memberService.createNewMember(
                 new CreateNewUserDTO(
                         SocialLoginProvider.fromString("APPLE"),
                         "testUser3",
@@ -98,9 +98,9 @@ class CalendarApiTest {
                         "profile.com"
                 )
         ).getId();
-        TEST_USER3_TOKEN = tokenGenerator.generateTokenPair(TEST_USER3_ID).accessToken();
+        TEST_MEMBER3_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER3_ID).accessToken();
 
-        TEST_FAMILIES_IDS = List.of(TEST_USER1_ID, TEST_USER2_ID);
+        TEST_FAMILIES_IDS = List.of(TEST_MEMBER1_ID, TEST_MEMBER2_ID);
     }
 
 
@@ -113,27 +113,27 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('1', '" + TEST_USER1_ID + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
+                "values ('1', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('2', '" + TEST_USER2_ID + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
+                "values ('2', '" + TEST_MEMBER2_ID + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('3', '" + TEST_USER3_ID + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
+                "values ('3', '" + TEST_MEMBER3_ID + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('4', '" + TEST_USER1_ID + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
+                "values ('4', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
 
         // family
         String familyId = objectMapper.readValue(
-                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
                         .andExpect(status().isOk())
                         .andReturn().getResponse().getContentAsString(), FamilyResponse.class
         ).familyId();
         String inviteCode = objectMapper.readValue(
-                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
                         .andExpect(status().isOk())
                         .andReturn().getResponse().getContentAsString(), DeepLinkResponse.class
         ).getLinkId();
         mockMvc.perform(post("/v1/me/join-family")
-                .header("X-AUTH-TOKEN", TEST_USER2_TOKEN)
+                .header("X-AUTH-TOKEN", TEST_MEMBER2_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(new JoinFamilyRequest(inviteCode)))
         ).andExpect(status().isOk());
@@ -144,7 +144,7 @@ class CalendarApiTest {
                         .param("type", "WEEKLY")
                         .param("yearMonth", yearMonth)
                         .param("week", week.toString())
-                        .header("X-AUTH-TOKEN", TEST_USER1_TOKEN)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.results[0].date").value("2023-11-01"))
@@ -163,21 +163,21 @@ class CalendarApiTest {
         // posts
         String now = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('1', '" + TEST_USER1_ID + "', 'https://storage.com/images/1', 0, 0, '" + now + "', '" + now + "', 'post1111', '1');");
+                "values ('1', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/1', 0, 0, '" + now + "', '" + now + "', 'post1111', '1');");
 
         // family
         String familyId = objectMapper.readValue(
-                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
                         .andExpect(status().isOk())
                         .andReturn().getResponse().getContentAsString(), FamilyResponse.class
         ).familyId();
         String inviteCode = objectMapper.readValue(
-                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
                         .andExpect(status().isOk())
                         .andReturn().getResponse().getContentAsString(), DeepLinkResponse.class
         ).getLinkId();
         mockMvc.perform(post("/v1/me/join-family")
-                .header("X-AUTH-TOKEN", TEST_USER2_TOKEN)
+                .header("X-AUTH-TOKEN", TEST_MEMBER2_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(new JoinFamilyRequest(inviteCode)))
         ).andExpect(status().isOk());
@@ -186,7 +186,7 @@ class CalendarApiTest {
         // When & Then
         mockMvc.perform(get("/v1/calendar")
                         .param("type", "WEEKLY")
-                        .header("X-AUTH-TOKEN", TEST_USER2_TOKEN)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER2_TOKEN)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.results[0].date").value(LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)))
@@ -203,35 +203,35 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('1', '" + TEST_USER1_ID + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
+                "values ('1', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('2', '" + TEST_USER2_ID + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
+                "values ('2', '" + TEST_MEMBER2_ID + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('3', '" + TEST_USER3_ID + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
+                "values ('3', '" + TEST_MEMBER3_ID + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('4', '" + TEST_USER1_ID + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
+                "values ('4', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('5', '" + TEST_USER1_ID + "', 'https://storage.com/images/5', 0, 0, '2023-11-29 14:00:00', '2023-11-29 14:00:00', 'post5555', '5');");
+                "values ('5', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/5', 0, 0, '2023-11-29 14:00:00', '2023-11-29 14:00:00', 'post5555', '5');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('6', '" + TEST_USER2_ID + "', 'https://storage.com/images/6', 0, 0, '2023-11-29 15:00:00', '2023-11-29 15:00:00', 'post6666', '6');");
+                "values ('6', '" + TEST_MEMBER2_ID + "', 'https://storage.com/images/6', 0, 0, '2023-11-29 15:00:00', '2023-11-29 15:00:00', 'post6666', '6');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('7', '" + TEST_USER3_ID + "', 'https://storage.com/images/7', 0, 0, '2023-11-29 17:00:00', '2023-11-29 17:00:00', 'post7777', '7');");
+                "values ('7', '" + TEST_MEMBER3_ID + "', 'https://storage.com/images/7', 0, 0, '2023-11-29 17:00:00', '2023-11-29 17:00:00', 'post7777', '7');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('8', '" + TEST_USER1_ID + "', 'https://storage.com/images/8', 0, 0, '2023-11-30 14:00:00', '2023-11-30 14:00:00', 'post8888', '8');");
+                "values ('8', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/8', 0, 0, '2023-11-30 14:00:00', '2023-11-30 14:00:00', 'post8888', '8');");
 
         // family
         String familyId = objectMapper.readValue(
-                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
                         .andExpect(status().isOk())
                         .andReturn().getResponse().getContentAsString(), FamilyResponse.class
         ).familyId();
         String inviteCode = objectMapper.readValue(
-                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
                         .andExpect(status().isOk())
                         .andReturn().getResponse().getContentAsString(), DeepLinkResponse.class
         ).getLinkId();
         mockMvc.perform(post("/v1/me/join-family")
-                .header("X-AUTH-TOKEN", TEST_USER2_TOKEN)
+                .header("X-AUTH-TOKEN", TEST_MEMBER2_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(new JoinFamilyRequest(inviteCode)))
         ).andExpect(status().isOk());
@@ -241,7 +241,7 @@ class CalendarApiTest {
         mockMvc.perform(get("/v1/calendar")
                         .param("type", "MONTHLY")
                         .param("yearMonth", yearMonth)
-                        .header("X-AUTH-TOKEN", TEST_USER1_TOKEN)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.results[0].date").value("2023-11-01"))
@@ -269,21 +269,21 @@ class CalendarApiTest {
         // posts
         String now = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('1', '" + TEST_USER1_ID + "', 'https://storage.com/images/1', 0, 0, '" + now + "', '" + now + "', 'post1111', '1');");
+                "values ('1', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/1', 0, 0, '" + now + "', '" + now + "', 'post1111', '1');");
 
         // family
         String familyId = objectMapper.readValue(
-                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
                         .andExpect(status().isOk())
                         .andReturn().getResponse().getContentAsString(), FamilyResponse.class
         ).familyId();
         String inviteCode = objectMapper.readValue(
-                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
                         .andExpect(status().isOk())
                         .andReturn().getResponse().getContentAsString(), DeepLinkResponse.class
         ).getLinkId();
         mockMvc.perform(post("/v1/me/join-family")
-                .header("X-AUTH-TOKEN", TEST_USER2_TOKEN)
+                .header("X-AUTH-TOKEN", TEST_MEMBER2_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(new JoinFamilyRequest(inviteCode)))
         ).andExpect(status().isOk());
@@ -292,7 +292,7 @@ class CalendarApiTest {
         // When & Then
         mockMvc.perform(get("/v1/calendar")
                         .param("type", "MONTHLY")
-                        .header("X-AUTH-TOKEN", TEST_USER2_TOKEN)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER2_TOKEN)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.results[0].date").value(LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)))

--- a/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
@@ -103,6 +103,59 @@ class CalendarApiTest {
 
 
     @Test
+    void 주간_캘린더_조회_테스트() throws Exception {
+        // Given
+        // parameters
+        String yearMonth = "2023-11";
+        Long week = 1L;
+
+        // posts
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('1', '" + TEST_USER1_ID + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('2', '" + TEST_USER2_ID + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('3', '" + TEST_USER3_ID + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('4', '" + TEST_USER1_ID + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
+
+        // family
+        String familyId = objectMapper.readValue(
+                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                        .andExpect(status().isOk())
+                        .andReturn().getResponse().getContentAsString(), FamilyResponse.class
+        ).familyId();
+        String inviteCode = objectMapper.readValue(
+                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_USER1_TOKEN))
+                        .andExpect(status().isOk())
+                        .andReturn().getResponse().getContentAsString(), DeepLinkResponse.class
+        ).getLinkId();
+        mockMvc.perform(post("/v1/me/join-family")
+                .header("X-AUTH-TOKEN", TEST_USER2_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new JoinFamilyRequest(inviteCode)))
+        ).andExpect(status().isOk());
+
+
+        // When & Then
+        mockMvc.perform(get("/v1/calendar")
+                        .param("type", "WEEKLY")
+                        .param("yearMonth", yearMonth)
+                        .param("week", week.toString())
+                        .header("X-AUTH-TOKEN", TEST_USER1_TOKEN)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results[0].date").value("2023-11-01"))
+                .andExpect(jsonPath("$.results[0].representativePostId").value("2"))
+                .andExpect(jsonPath("$.results[0].representativeThumbnailUrl").value(imageOptimizerCdn + "/images/2" + thumbnailOptimizerQuery))
+                .andExpect(jsonPath("$.results[0].allFamilyMembersUploaded").value(true))
+                .andExpect(jsonPath("$.results[1].date").value("2023-11-02"))
+                .andExpect(jsonPath("$.results[1].representativePostId").value("4"))
+                .andExpect(jsonPath("$.results[1].representativeThumbnailUrl").value(imageOptimizerCdn + "/images/4" + thumbnailOptimizerQuery))
+                .andExpect(jsonPath("$.results[1].allFamilyMembersUploaded").value(false));
+    }
+
+    @Test
     void 월별_캘린더_조회_테스트() throws Exception {
         // Given
         // parameters
@@ -117,6 +170,14 @@ class CalendarApiTest {
                 "values ('3', '" + TEST_USER3_ID + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
         jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
                 "values ('4', '" + TEST_USER1_ID + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('5', '" + TEST_USER1_ID + "', 'https://storage.com/images/5', 0, 0, '2023-11-29 14:00:00', '2023-11-29 14:00:00', 'post5555', '5');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('6', '" + TEST_USER2_ID + "', 'https://storage.com/images/6', 0, 0, '2023-11-29 15:00:00', '2023-11-29 15:00:00', 'post6666', '6');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('7', '" + TEST_USER3_ID + "', 'https://storage.com/images/7', 0, 0, '2023-11-29 17:00:00', '2023-11-29 17:00:00', 'post7777', '7');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('8', '" + TEST_USER1_ID + "', 'https://storage.com/images/8', 0, 0, '2023-11-30 14:00:00', '2023-11-30 14:00:00', 'post8888', '8');");
 
         // family
         String familyId = objectMapper.readValue(
@@ -150,6 +211,15 @@ class CalendarApiTest {
                 .andExpect(jsonPath("$.results[1].date").value("2023-11-02"))
                 .andExpect(jsonPath("$.results[1].representativePostId").value("4"))
                 .andExpect(jsonPath("$.results[1].representativeThumbnailUrl").value(imageOptimizerCdn + "/images/4" + thumbnailOptimizerQuery))
-                .andExpect(jsonPath("$.results[1].allFamilyMembersUploaded").value(false));
+                .andExpect(jsonPath("$.results[1].allFamilyMembersUploaded").value(false))
+                .andExpect(jsonPath("$.results[2].date").value("2023-11-29"))
+                .andExpect(jsonPath("$.results[2].representativePostId").value("6"))
+                .andExpect(jsonPath("$.results[2].representativeThumbnailUrl").value(imageOptimizerCdn + "/images/6" + thumbnailOptimizerQuery))
+                .andExpect(jsonPath("$.results[2].allFamilyMembersUploaded").value(true))
+                .andExpect(jsonPath("$.results[3].date").value("2023-11-30"))
+                .andExpect(jsonPath("$.results[3].representativePostId").value("8"))
+                .andExpect(jsonPath("$.results[3].representativeThumbnailUrl").value(imageOptimizerCdn + "/images/8" + thumbnailOptimizerQuery))
+                .andExpect(jsonPath("$.results[3].allFamilyMembersUploaded").value(false));
+
     }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
캘린더 API와 관련된 모든 코드에 테스트 코드를 작성했습니다.

## ➕ 추가/변경된 기능

---
- CalendarApiTest 통합 테스트 추가 (restapi interface는 jacoco 커버리지에서 관측안됨)

- CalendarControllerTest 단위 테스트 추가
<img width="1397" alt="스크린샷 2024-01-15 21 40 39" src="https://github.com/depromeet/14th-team5-BE/assets/49567744/3e942264-94b1-46a8-a0b7-6132ff9eafcf">

- MemberPostRepositoryCustom에서 캘린더에서 사용하는 메소드에 DataJpaTest 추가
<img width="1093" alt="스크린샷 2024-01-15 21 42 19" src="https://github.com/depromeet/14th-team5-BE/assets/49567744/803289d1-1c3d-48f8-8fd7-86d7dbad0759">



## 🥺 리뷰어에게 하고싶은 말

---
파이팅



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-105