### PR TITLE
[OING-156] refactor: 이미지의 예상되지 않은 url 패턴으로 인한 OptimizedImageProvider의 런타임 예외를 방지

### DIFF
--- a/common/src/main/java/com/oing/exception/StringEmptyWhiteSpaceException.java
+++ b/common/src/main/java/com/oing/exception/StringEmptyWhiteSpaceException.java
@@ -1,0 +1,7 @@
+package com.oing.exception;
+
+public class StringEmptyWhiteSpaceException extends RuntimeException {
+    public StringEmptyWhiteSpaceException() {
+        super();
+    }
+}

--- a/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
@@ -1,5 +1,6 @@
 package com.oing.config.support;
 
+import com.oing.exception.StringEmptyWhiteSpaceException;
 import com.oing.util.OptimizedImageUrlGenerator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -31,12 +32,17 @@ public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
      */
     @Override
     public String getThumbnailUrlGenerator(String bucketImageUrl) {
-        if (bucketImageUrl == null) {
-            return null;
-        }
+        try {
+            validateUrlEmptyOrWhiteSpace(bucketImageUrl);
 
-        String imagePath = bucketImageUrl.substring(bucketImageUrl.indexOf("/images"));
-        return imageOptimizerCdnUrl + imagePath + THUMBNAIL_OPTIMIZER_QUERY_STRING;
+            String imagePath = bucketImageUrl.substring(bucketImageUrl.indexOf("/images"));
+            return imageOptimizerCdnUrl + imagePath + THUMBNAIL_OPTIMIZER_QUERY_STRING;
+
+        } catch (StringEmptyWhiteSpaceException e) {
+            return null;
+        } catch (IndexOutOfBoundsException e) {
+            return bucketImageUrl;
+        }
     }
 
 
@@ -47,11 +53,22 @@ public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
      */
     @Override
     public String getKBImageUrlGenerator(String bucketImageUrl) {
-        if (bucketImageUrl == null) {
-            return null;
-        }
+        try {
+            validateUrlEmptyOrWhiteSpace(bucketImageUrl);
 
-        String imagePath = bucketImageUrl.substring(bucketImageUrl.indexOf("/images"));
-        return imageOptimizerCdnUrl + imagePath + KB_IMAGE_OPTIMIZER_QUERY_STRING;
+            String imagePath = bucketImageUrl.substring(bucketImageUrl.indexOf("/images"));
+            return imageOptimizerCdnUrl + imagePath + KB_IMAGE_OPTIMIZER_QUERY_STRING;
+
+        } catch (StringEmptyWhiteSpaceException e) {
+            return null;
+        } catch (IndexOutOfBoundsException e) {
+            return bucketImageUrl;
+        }
+    }
+
+    private void validateUrlEmptyOrWhiteSpace(String url) throws StringEmptyWhiteSpaceException {
+        if (url == null || url.trim().isEmpty()) {
+            throw new StringEmptyWhiteSpaceException();
+        }
     }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
이미지 url 중에 null이 아닌 빈 문자열이 디비에 저장된 경우가 있었고, 이로인해 OptimizedImageProvider가 런타임 예외를 발생시키고 있었음.

## ➕ 추가/변경된 기능

---
- StringEmptyWhiteSpaceException 추가
- OptimizedImageProvider에서 url이 null or 빈 문자열인 경우 null을 반환하도록 예외 처리
- OptimizedImageProvider에서 url이 비정상적인 패턴인 경우, 압축하지 않고 그대로 반환하도록 예외 처리

## 🥺 리뷰어에게 하고싶은 말

---
핫픽스 머지 부탁드려요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-156