### PR TITLE
[OING-154] feat: 회원의 리얼이모지 조회 API 구현

### DIFF
--- a/gateway/src/test/java/com/oing/restapi/MemberRealEmojiApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberRealEmojiApiTest.java
@@ -23,8 +23,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDate;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -133,5 +132,34 @@ public class MemberRealEmojiApiTest {
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.imageUrl").value(realEmojiImageUrl));
+    }
+
+    @Test
+    void 회원_리얼이모지_조회_테스트() throws Exception {
+        //given
+        String realEmojiImageUrl = "https://test.com/bucket/images/realEmoji.jpg";
+        memberRealEmojiRepository.save(
+                new MemberRealEmoji(
+                        TEST_MEMBER_REAL_EMOJI_ID,
+                        TEST_MEMBER_ID,
+                        Emoji.EMOJI_1,
+                        realEmojiImageUrl,
+                        "images/defaultEmoji.jpg"
+                )
+        );
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/v1/members/{memberId}/real-emoji", TEST_MEMBER_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.myRealEmojiList[0].realEmojiId").value(TEST_MEMBER_REAL_EMOJI_ID))
+                .andExpect(jsonPath("$.myRealEmojiList[0].type").value(Emoji.EMOJI_1.getTypeKey()))
+                .andExpect(jsonPath("$.myRealEmojiList[0].imageUrl").value(realEmojiImageUrl));
     }
 }

--- a/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
@@ -20,6 +20,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Controller
 public class MemberRealEmojiController implements MemberRealEmojiApi {
@@ -39,7 +42,7 @@ public class MemberRealEmojiController implements MemberRealEmojiApi {
 
     @Transactional
     @Override
-    public RealEmojiResponse createMyRealEmoji(String memberId, CreateMyRealEmojiRequest request) {
+    public RealEmojiResponse createMemberRealEmoji(String memberId, CreateMyRealEmojiRequest request) {
         validateMemberId(memberId);
         String emojiId = identityGenerator.generateIdentity();
         String emojiImgKey = preSignedUrlGenerator.extractImageKey(request.imageUrl());
@@ -59,7 +62,7 @@ public class MemberRealEmojiController implements MemberRealEmojiApi {
 
     @Transactional
     @Override
-    public RealEmojiResponse changeMyRealEmoji(String memberId, String realEmojiId, UpdateMyRealEmojiRequest request) {
+    public RealEmojiResponse changeMemberRealEmoji(String memberId, String realEmojiId, UpdateMyRealEmojiRequest request) {
         validateMemberId(memberId);
         String emojiImgKey = preSignedUrlGenerator.extractImageKey(request.imageUrl());
 
@@ -69,8 +72,14 @@ public class MemberRealEmojiController implements MemberRealEmojiApi {
     }
 
     @Override
-    public RealEmojisResponse getMyRealEmojis(String memberId) {
-        return new RealEmojisResponse(null);
+    public RealEmojisResponse getMemberRealEmojis(String memberId) {
+        validateMemberId(memberId);
+
+        List<MemberRealEmoji> realEmojis = memberRealEmojiService.findRealEmojisByMemberId(memberId);
+        List<RealEmojiResponse> emojiResponses = realEmojis.stream()
+                .map(RealEmojiResponse::from)
+                .collect(Collectors.toList());
+        return new RealEmojisResponse(emojiResponses);
     }
 
     private void validateMemberId(String memberId) {

--- a/post/src/main/java/com/oing/dto/response/RealEmojiResponse.java
+++ b/post/src/main/java/com/oing/dto/response/RealEmojiResponse.java
@@ -3,7 +3,7 @@ package com.oing.dto.response;
 import com.oing.domain.MemberRealEmoji;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "자신이 생성한 리얼 이모지 응답")
+@Schema(description = "회원이 생성한 리얼 이모지 응답")
 public record RealEmojiResponse (
         @Schema(description = "리얼 이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
         String realEmojiId,

--- a/post/src/main/java/com/oing/dto/response/RealEmojisResponse.java
+++ b/post/src/main/java/com/oing/dto/response/RealEmojisResponse.java
@@ -4,9 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(description = "자신이 생성한 리얼 이모지 리스트 응답")
+@Schema(description = "회원이 생성한 리얼 이모지 리스트 응답")
 public record RealEmojisResponse(
-        @Schema(description = "자신이 생성한 리얼 이모지 정보")
+        @Schema(description = "회원이 생성한 리얼 이모지 정보")
         List<RealEmojiResponse> myRealEmojiList
 ) {
 }

--- a/post/src/main/java/com/oing/repository/MemberRealEmojiRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberRealEmojiRepository.java
@@ -4,9 +4,12 @@ import com.oing.domain.Emoji;
 import com.oing.domain.MemberRealEmoji;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRealEmojiRepository extends JpaRepository<MemberRealEmoji, String> {
 
     Optional<MemberRealEmoji> findByType(Emoji emoji);
+
+    List<MemberRealEmoji> findAllByMemberId(String memberId);
 }

--- a/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
@@ -30,9 +30,9 @@ public interface MemberRealEmojiApi {
             PreSignedUrlRequest request
     );
 
-    @Operation(summary = "자신의 리얼 이모지 추가", description = "자신의 리얼 이모지를 추가합니다.")
+    @Operation(summary = "회원의 리얼 이모지 추가", description = "자신의 리얼 이모지를 추가합니다.")
     @PostMapping
-    RealEmojiResponse createMyRealEmoji(
+    RealEmojiResponse createMemberRealEmoji(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String memberId,
@@ -42,9 +42,9 @@ public interface MemberRealEmojiApi {
             CreateMyRealEmojiRequest request
     );
 
-    @Operation(summary = "자신의 리얼 이모지 변경", description = "자신의 리얼 이모지 사진을 변경합니다.")
+    @Operation(summary = "회원의 리얼 이모지 변경", description = "자신의 리얼 이모지 사진을 변경합니다.")
     @PutMapping("/{realEmojiId}")
-    RealEmojiResponse changeMyRealEmoji(
+    RealEmojiResponse changeMemberRealEmoji(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String memberId,
@@ -60,7 +60,7 @@ public interface MemberRealEmojiApi {
 
     @Operation(summary = "회원의 리얼 이모지 조회", description = "자신의 리얼 이모지를 조회합니다.")
     @GetMapping
-    RealEmojisResponse getMyRealEmojis(
+    RealEmojisResponse getMemberRealEmojis(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String memberId

--- a/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
@@ -30,7 +30,7 @@ public interface MemberRealEmojiApi {
             PreSignedUrlRequest request
     );
 
-    @Operation(summary = "회원의 리얼 이모지 추가", description = "자신의 리얼 이모지를 추가합니다.")
+    @Operation(summary = "회원의 리얼 이모지 추가", description = "회원의 리얼 이모지를 추가합니다.")
     @PostMapping
     RealEmojiResponse createMemberRealEmoji(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
@@ -42,7 +42,7 @@ public interface MemberRealEmojiApi {
             CreateMyRealEmojiRequest request
     );
 
-    @Operation(summary = "회원의 리얼 이모지 변경", description = "자신의 리얼 이모지 사진을 변경합니다.")
+    @Operation(summary = "회원의 리얼 이모지 변경", description = "회원의 리얼 이모지 사진을 변경합니다.")
     @PutMapping("/{realEmojiId}")
     RealEmojiResponse changeMemberRealEmoji(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
@@ -58,7 +58,7 @@ public interface MemberRealEmojiApi {
             UpdateMyRealEmojiRequest request
     );
 
-    @Operation(summary = "회원의 리얼 이모지 조회", description = "자신의 리얼 이모지를 조회합니다.")
+    @Operation(summary = "회원의 리얼 이모지 조회", description = "회원의 리얼 이모지를 조회합니다.")
     @GetMapping
     RealEmojisResponse getMemberRealEmojis(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")

--- a/post/src/main/java/com/oing/service/MemberRealEmojiService.java
+++ b/post/src/main/java/com/oing/service/MemberRealEmojiService.java
@@ -7,6 +7,8 @@ import com.oing.repository.MemberRealEmojiRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberRealEmojiService {
@@ -27,5 +29,9 @@ public class MemberRealEmojiService {
         return memberRealEmojiRepository
                 .findByType(emoji)
                 .isPresent();
+    }
+
+    public List<MemberRealEmoji> findRealEmojisByMemberId(String memberId) {
+        return memberRealEmojiRepository.findAllByMemberId(memberId);
     }
 }

--- a/post/src/test/java/com/oing/controller/MemberPostCommentControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostCommentControllerTest.java
@@ -66,6 +66,7 @@ public class MemberPostCommentControllerTest {
         when(authenticationHolder.getUserId()).thenReturn("1");
         when(memberBridge.isInSameFamily("1", "1")).thenReturn(true);
         when(identityGenerator.generateIdentity()).thenReturn(memberPost.getId());
+        when(memberPostCommentService.savePostComment(any())).thenReturn(memberPostComment);
 
         //when
         PostCommentResponse response = memberPostCommentController.createPostComment(

--- a/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
@@ -7,6 +7,7 @@ import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.request.UpdateMyRealEmojiRequest;
 import com.oing.dto.response.PreSignedUrlResponse;
 import com.oing.dto.response.RealEmojiResponse;
+import com.oing.dto.response.RealEmojisResponse;
 import com.oing.exception.AuthorizationFailedException;
 import com.oing.exception.DuplicateRealEmojiException;
 import com.oing.service.MemberRealEmojiService;
@@ -20,6 +21,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -70,7 +73,7 @@ public class MemberRealEmojiControllerTest {
         CreateMyRealEmojiRequest request = new CreateMyRealEmojiRequest(emoji.getTypeKey(), realEmojiImageUrl);
         when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("1", memberId, emoji,
                 realEmojiImageUrl, "realEmoji.jpg"));
-        RealEmojiResponse response = memberRealEmojiController.createMyRealEmoji(memberId, request);
+        RealEmojiResponse response = memberRealEmojiController.createMemberRealEmoji(memberId, request);
 
         // then
         assertEquals(emoji.getTypeKey(), response.type());
@@ -90,7 +93,7 @@ public class MemberRealEmojiControllerTest {
 
         // then
         assertThrows(AuthorizationFailedException.class,
-                () -> memberRealEmojiController.createMyRealEmoji(memberId, request));
+                () -> memberRealEmojiController.createMemberRealEmoji(memberId, request));
     }
 
     @Test
@@ -107,7 +110,7 @@ public class MemberRealEmojiControllerTest {
 
         // then
         assertThrows(DuplicateRealEmojiException.class,
-                () -> memberRealEmojiController.createMyRealEmoji(memberId, request));
+                () -> memberRealEmojiController.createMemberRealEmoji(memberId, request));
     }
 
     @Test
@@ -122,9 +125,44 @@ public class MemberRealEmojiControllerTest {
         UpdateMyRealEmojiRequest request = new UpdateMyRealEmojiRequest(realEmojiImageUrl);
         when(memberRealEmojiService.findRealEmojiById(realEmojiId)).thenReturn(new MemberRealEmoji("1", memberId,
                 Emoji.EMOJI_1, realEmojiImageUrl, "realEmoji.jpg"));
-        RealEmojiResponse response = memberRealEmojiController.changeMyRealEmoji(memberId, realEmojiId, request);
+        RealEmojiResponse response = memberRealEmojiController.changeMemberRealEmoji(memberId, realEmojiId, request);
 
         // then
         assertEquals(request.imageUrl(), response.imageUrl());
+    }
+
+    @Test
+    void 회원_리얼이모지_조회_테스트() {
+        // given
+        String memberId = "1";
+        String realEmojiImageUrl1 = "https://test.com/realEmoji1.jpg";
+        String realEmojiImageUrl2 = "https://test.com/realEmoji2.jpg";
+        Emoji emoji1 = Emoji.EMOJI_1;
+        Emoji emoji2 = Emoji.EMOJI_4;
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        CreateMyRealEmojiRequest request1 = new CreateMyRealEmojiRequest(emoji1.getTypeKey(), realEmojiImageUrl1);
+        CreateMyRealEmojiRequest request2 = new CreateMyRealEmojiRequest(emoji1.getTypeKey(), realEmojiImageUrl2);
+        when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("1", memberId, emoji1,
+                realEmojiImageUrl1, "realEmoji1.jpg"));
+        memberRealEmojiController.createMemberRealEmoji(memberId, request1);
+        when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("2", memberId, emoji2,
+                realEmojiImageUrl2, "realEmoji2.jpg"));
+        memberRealEmojiController.createMemberRealEmoji(memberId, request2);
+
+        // when
+        when(memberRealEmojiService.findRealEmojisByMemberId(memberId)).thenReturn(List.of(
+                new MemberRealEmoji("1", memberId, emoji1, realEmojiImageUrl1, "realEmoji1.jpg"),
+                new MemberRealEmoji("2", memberId, emoji2, realEmojiImageUrl2, "realEmoji2.jpg")
+        ));
+        RealEmojisResponse response = memberRealEmojiController.getMemberRealEmojis(memberId);
+
+        // then
+        assertEquals(2, response.myRealEmojiList().size());
+        assertEquals("1", response.myRealEmojiList().get(0).realEmojiId());
+        assertEquals("2", response.myRealEmojiList().get(1).realEmojiId());
+        assertEquals(emoji1.getTypeKey(), response.myRealEmojiList().get(0).type());
+        assertEquals(emoji2.getTypeKey(), response.myRealEmojiList().get(1).type());
+        assertEquals(request1.imageUrl(), response.myRealEmojiList().get(0).imageUrl());
+        assertEquals(request2.imageUrl(), response.myRealEmojiList().get(1).imageUrl());
     }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
회원의 리얼이모지 조회 API mock을 했어야 했는데 모르고 구현을 해버렸습니다...

## ➕ 추가/변경된 기능

---
- 회원의 리얼이모지 조회 API 구현
- 회원의 리얼이모지 조회 단위테스트 코드 작성
- 회원의 리얼이모지 조회 인수테스트 코드 작성
- 코멘트 단위테스트 코드 에러 수정

## 🥺 리뷰어에게 하고싶은 말

---
현재 브랜치에서 캘린더 단위테스트 하나가 깨지는 거 참고해주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-154