### PR TITLE
[OING-159] feat: 피드에 등록된 리얼이모지 리스트 조회 API 모킹

### DIFF
--- a/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
@@ -1,29 +1,16 @@
 package com.oing.controller;
 
 
-import com.oing.domain.MemberPost;
-import com.oing.domain.PaginationDTO;
-import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PostRealEmojiRequest;
-import com.oing.dto.request.PreSignedUrlRequest;
-import com.oing.dto.response.*;
-import com.oing.exception.DuplicatePostUploadException;
-import com.oing.exception.InvalidUploadTimeException;
-import com.oing.restapi.MemberPostApi;
+import com.oing.dto.response.ArrayResponse;
+import com.oing.dto.response.DefaultResponse;
+import com.oing.dto.response.PostRealEmojiResponse;
 import com.oing.restapi.MemberPostRealEmojiApi;
-import com.oing.service.MemberBridge;
-import com.oing.service.MemberPostService;
-import com.oing.util.AuthenticationHolder;
-import com.oing.util.IdentityGenerator;
-import com.oing.util.PreSignedUrlGenerator;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Controller
@@ -41,6 +28,15 @@ public class MemberPostRealEmojiController implements MemberPostRealEmojiApi {
 
     @Override
     public ArrayResponse<PostRealEmojiResponse> getPostRealEmojis(String postId) {
-        return ArrayResponse.of(Collections.emptyList());
+        List<PostRealEmojiResponse> mockResponses = Arrays.asList(
+                new PostRealEmojiResponse("01HGW2N7EHJVJ4CJ999RRS2E97", "emoji_1", postId,
+                        "01HUUDFAOHJVJ4CJ999RRS2E97", "http://test.com/images/test1.jpg"),
+                new PostRealEmojiResponse("01HGW2N7EHJVJ4CJ999RRS2E97", "emoji_2", postId,
+                        "01HGW2N7EHJVJ4CJ999RRS2E97", "http://test.com/images/test2.jpg"),
+                new PostRealEmojiResponse("01DGW2N7EFFFEDFAG9RRS2E976", "emoji_2", postId,
+                        "01HGW2N7EHJVJEEFD99RRS2E97", "http://test.com/images/test2.jpg")
+        );
+
+        return ArrayResponse.of(mockResponses);
     }
 }

--- a/post/src/main/java/com/oing/dto/response/PostRealEmojiResponse.java
+++ b/post/src/main/java/com/oing/dto/response/PostRealEmojiResponse.java
@@ -1,11 +1,13 @@
 package com.oing.dto.response;
 
-import com.oing.domain.MemberPostReaction;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "피드 게시물 응답")
+@Schema(description = "피드 게시물 리얼 이모지 응답")
 public record PostRealEmojiResponse(
         @Schema(description = "피드 게시물 리얼 이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String postRealEmojiId,
+
+        @Schema(description = "리얼 이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
         String realEmojiId,
 
         @Schema(description = "피드 게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
피드에 등록된 리얼이모지 리스트를 조회하는 API를 모킹했습니다.

## ➕ 추가/변경된 기능

---
- 피드에 등록된 리얼이모지 리스트 조회 API 모킹

## 🥺 리뷰어에게 하고싶은 말

---
응답 필드에 추가적으로 들어가야 하는 필드가 있는지 확인해주시면 감사합니다!
현재 브랜치에서 캘린더 단위테스트 하나가 깨지는 거 참고해주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-159