### PR TITLE
[OING-161] test: 피드 리액션 등록/삭제/남긴 멤버 조회 기능 테스트 코드 작성

### DIFF
--- a/gateway/src/test/java/com/oing/restapi/MemberPostReactionApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostReactionApiTest.java
@@ -1,0 +1,139 @@
+package com.oing.restapi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oing.domain.Emoji;
+import com.oing.domain.Member;
+import com.oing.domain.MemberPost;
+import com.oing.domain.MemberPostReaction;
+import com.oing.dto.request.PostReactionRequest;
+import com.oing.repository.MemberPostReactionRepository;
+import com.oing.repository.MemberPostRepository;
+import com.oing.repository.MemberRepository;
+import com.oing.service.TokenGenerator;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class MemberPostReactionApiTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TokenGenerator tokenGenerator;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String TEST_MEMBER_ID = "01HGW2N7EHJVJ4CJ999RRS2E97";
+    private String TEST_POST_ID = "01HGW2N7EHJVJ4CJ999RRS2A97";
+    private String TEST_MEMBER_TOKEN;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MemberPostRepository memberPostRepository;
+    @Autowired
+    private MemberPostReactionRepository memberPostReactionRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.save(
+                new Member(
+                        TEST_MEMBER_ID,
+                        "testUser1",
+                        LocalDate.now(),
+                        "", "", ""
+                )
+        );
+        TEST_MEMBER_TOKEN = tokenGenerator
+                .generateTokenPair(TEST_MEMBER_ID)
+                .accessToken();
+        memberPostRepository.save(
+                new MemberPost(
+                        TEST_POST_ID,
+                        TEST_MEMBER_ID,
+                        "img",
+                        "img",
+                        "content"
+                )
+        );
+    }
+
+    @Test
+    void 게시물_리액션_추가_테스트() throws Exception {
+        //given
+        Emoji emoji = Emoji.EMOJI_1;
+        PostReactionRequest request = new PostReactionRequest(emoji.getTypeKey());
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                post("/v1/posts/{postId}/reactions", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void 게시물_리액션_삭제_테스트() throws Exception {
+        //given
+        Emoji emoji = Emoji.EMOJI_1;
+        PostReactionRequest request = new PostReactionRequest(emoji.getTypeKey());
+        memberPostReactionRepository.save(new MemberPostReaction("1", memberPostRepository.getReferenceById(TEST_POST_ID),
+                TEST_MEMBER_ID, emoji));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/v1/posts/{postId}/reactions", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void 게시물_리액션_남긴_멤버_조회() throws Exception {
+        //given
+        Emoji emoji = Emoji.EMOJI_3;
+        memberPostReactionRepository.save(new MemberPostReaction("1", memberPostRepository.getReferenceById(TEST_POST_ID),
+                TEST_MEMBER_ID, emoji));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/v1/posts/{postId}/reactions/member", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.emojiMemberIdsList.emoji_3[0]").value(TEST_MEMBER_ID));
+    }
+}

--- a/post/src/main/java/com/oing/controller/MemberPostReactionController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostReactionController.java
@@ -66,6 +66,12 @@ public class MemberPostReactionController implements MemberPostReactionApi {
         return DefaultResponse.ok();
     }
 
+    private void validatePostReactionForDeletion(MemberPost post, String memberId, Emoji emoji) {
+        if (!memberPostReactionService.isMemberPostReactionExists(post, memberId, emoji)) {
+            throw new EmojiNotFoundException();
+        }
+    }
+
     @Override
     @Transactional
     public PostReactionSummaryResponse getPostReactionSummary(String postId) {
@@ -112,11 +118,5 @@ public class MemberPostReactionController implements MemberPostReactionApi {
         emojiList.forEach(emoji -> emojiMemberIdsMap.putIfAbsent(emoji.getTypeKey(), Collections.emptyList()));
 
         return new PostReactionsResponse(emojiMemberIdsMap);
-    }
-
-    private void validatePostReactionForDeletion(MemberPost post, String memberId, Emoji emoji) {
-        if (!memberPostReactionService.isMemberPostReactionExists(post, memberId, emoji)) {
-            throw new EmojiNotFoundException();
-        }
     }
 }

--- a/post/src/main/java/com/oing/dto/request/PostReactionRequest.java
+++ b/post/src/main/java/com/oing/dto/request/PostReactionRequest.java
@@ -12,8 +12,7 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(description = "피드 게시물 반응 생성 및 삭제 요청")
 public record PostReactionRequest(
         @NotBlank
-        @Schema(description = "이모지", example = "smile",
-                allowableValues = {"heart", "slightly_smiling_face", "shining_face", "smiling_face", "smile"})
+        @Schema(description = "이모지", example = "emoji_1")
         String content
 ) {
 }

--- a/post/src/test/java/com/oing/controller/MemberPostReactionControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostReactionControllerTest.java
@@ -1,0 +1,134 @@
+package com.oing.controller;
+
+import com.oing.domain.Emoji;
+import com.oing.domain.MemberPost;
+import com.oing.domain.MemberPostReaction;
+import com.oing.dto.request.PostReactionRequest;
+import com.oing.dto.response.PostReactionsResponse;
+import com.oing.exception.EmojiAlreadyExistsException;
+import com.oing.exception.EmojiNotFoundException;
+import com.oing.service.MemberPostReactionService;
+import com.oing.service.MemberPostService;
+import com.oing.util.AuthenticationHolder;
+import com.oing.util.IdentityGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberPostReactionControllerTest {
+    @InjectMocks
+    private MemberPostReactionController memberPostReactionController;
+
+    @Mock
+    private AuthenticationHolder authenticationHolder;
+    @Mock
+    private IdentityGenerator identityGenerator;
+    @Mock
+    private MemberPostService memberPostService;
+    @Mock
+    private MemberPostReactionService memberPostReactionService;
+
+    @Test
+    void 게시물_리액션_생성_테스트() {
+        //given
+        String memberId = "1";
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        MemberPostReaction reaction = new MemberPostReaction("1", post, memberId, Emoji.EMOJI_1);
+        when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
+        when(memberPostReactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(false);
+        when(identityGenerator.generateIdentity()).thenReturn(reaction.getId());
+        when(memberPostReactionService.createPostReaction(reaction.getId(), post, memberId, Emoji.EMOJI_1)).thenReturn(reaction);
+
+        //when
+        PostReactionRequest request = new PostReactionRequest("emoji_1");
+        memberPostReactionController.createPostReaction(post.getId(), request);
+
+        //then
+        //nothing. just check no exception
+    }
+
+    @Test
+    void 게시물_중복된_리액션_등록_예외_테스트() {
+        //given
+        String memberId = "1";
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        when(memberPostReactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(true);
+        PostReactionRequest request = new PostReactionRequest("emoji_1");
+
+        //then
+        assertThrows(EmojiAlreadyExistsException.class,
+                () -> memberPostReactionController.createPostReaction(post.getId(), request));
+    }
+
+    @Test
+    void 게시물_리액션_삭제_테스트() {
+        //given
+        String memberId = "1";
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        MemberPostReaction reaction = new MemberPostReaction("1", post, memberId, Emoji.EMOJI_1);
+        when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
+        when(memberPostReactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(true);
+        when(memberPostReactionService.findReaction(post, memberId, Emoji.EMOJI_1)).thenReturn(reaction);
+
+        //when
+        PostReactionRequest request = new PostReactionRequest("emoji_1");
+        memberPostReactionController.deletePostReaction(post.getId(), request);
+
+        //then
+        //nothing. just check no exception
+    }
+
+    @Test
+    void 게시물_존재하지_않는_리액션_삭제_예외_테스트() {
+        //given
+        String memberId = "1";
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        when(memberPostReactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(false);
+        PostReactionRequest request = new PostReactionRequest("emoji_1");
+
+        //then
+        assertThrows(EmojiNotFoundException.class,
+                () -> memberPostReactionController.deletePostReaction(post.getId(), request));
+    }
+
+    @Test
+    void 리액션_남긴_멤버_조회_테스트() {
+        //given
+        String memberId = "1";
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        List<MemberPostReaction> mockReactions = Arrays.asList(
+                new MemberPostReaction("1", post, memberId, Emoji.EMOJI_1),
+                new MemberPostReaction("2", post, memberId, Emoji.EMOJI_2)
+        );
+        when(memberPostReactionService.getMemberPostReactionsByPostId(post.getId())).thenReturn(mockReactions);
+
+        //when
+        PostReactionsResponse response = memberPostReactionController.getPostReactionMembers(post.getId());
+
+        //then
+        assertTrue(response.emojiMemberIdsList().get(Emoji.EMOJI_1.getTypeKey()).contains(memberId));
+        assertTrue(response.emojiMemberIdsList().get(Emoji.EMOJI_2.getTypeKey()).contains(memberId));
+        assertFalse(response.emojiMemberIdsList().get(Emoji.EMOJI_3.getTypeKey()).contains(memberId));
+        assertFalse(response.emojiMemberIdsList().get(Emoji.EMOJI_4.getTypeKey()).contains(memberId));
+        assertFalse(response.emojiMemberIdsList().get(Emoji.EMOJI_5.getTypeKey()).contains(memberId));
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
피드 리액션 중, 제가 맡은 등록/삭제/남긴 멤버 조회 기능에 대해 테스트 코드 작성했습니다.

## ➕ 추가/변경된 기능

---
- 리액션 등록/삭제/남긴 멤버 조회 기능 단위 테스트코드 작성
- 리액션 등록/삭제/남긴 멤버 조회 기능 통합 테스트코드 작성

## 🥺 리뷰어에게 하고싶은 말

---
리뷰 부탁드려요~

<img width="1117" alt="스크린샷 2024-01-17 오후 7 57 09" src="https://github.com/depromeet/14th-team5-BE/assets/69844138/a9869104-77df-43ae-8a92-a6f368266b43">



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-161