### PR TITLE
[OING-162] test: Post PresignedUrl/POST/DELETE 테스트 코드 추가

### DIFF
--- a/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
@@ -110,4 +110,28 @@ class MemberPostRepositoryCustomTest {
                 .extracting(MemberPostDailyCalendarDTO::dailyPostCount)
                 .containsExactly(2L, 1L);
     }
+
+    @Test
+    void 특정_날짜에_게시글이_존재하는지_확인한다() {
+        // given
+        LocalDate postDate = LocalDate.of(2023, 11, 1);
+
+        // when
+        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndCreatedAt(testMember1.getId(), postDate);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void 특정_날짜에_게시글이_존재하지_않는지_확인한다() {
+        // given
+        LocalDate postDate = LocalDate.of(2023, 11, 8);
+
+        // when
+        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndCreatedAt(testMember1.getId(), postDate);
+
+        // then
+        assertThat(exists).isFalse();
+    }
 }

--- a/gateway/src/test/java/com/oing/restapi/MemberPostApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostApiTest.java
@@ -1,0 +1,126 @@
+package com.oing.restapi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oing.domain.Member;
+import com.oing.domain.MemberPost;
+import com.oing.dto.request.CreatePostRequest;
+import com.oing.dto.request.PreSignedUrlRequest;
+import com.oing.repository.MemberPostRepository;
+import com.oing.repository.MemberRepository;
+import com.oing.service.TokenGenerator;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class MemberPostApiTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TokenGenerator tokenGenerator;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String TEST_MEMBER_ID = "01HGW2N7EHJVJ4CJ999RRS2E97";
+    private String TEST_POST_ID = "01HGW2N7EHJVJ4CJ999RRS2A97";
+    private String TEST_MEMBER_TOKEN;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MemberPostRepository memberPostRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.save(
+                new Member(
+                        TEST_MEMBER_ID,
+                        "testUser1",
+                        LocalDate.now(),
+                        "", "", ""
+                )
+        );
+        TEST_MEMBER_TOKEN = tokenGenerator
+                .generateTokenPair(TEST_MEMBER_ID)
+                .accessToken();
+    }
+
+    @Test
+    void 게시물_이미지_업로드_URL_요청_테스트() throws Exception {
+        //given
+        String imageName = "feed.jpg";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                post("/v1/posts/image-upload-request")
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new PreSignedUrlRequest(imageName)))
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.url").exists());
+    }
+
+    @Test
+    void 게시물_추가_테스트() throws Exception {
+        //given
+        CreatePostRequest request = new CreatePostRequest("https://test.com/bucket/images/feed.jpg",
+                "content", ZonedDateTime.now());
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                post("/v1/posts")
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authorId").value(TEST_MEMBER_ID))
+                .andExpect(jsonPath("$.imageUrl").value(request.imageUrl()))
+                .andExpect(jsonPath("$.content").value(request.content()));
+    }
+
+    @Test
+    void 게시물_삭제_테스트() throws Exception {
+        //given
+        memberPostRepository.save(new MemberPost(TEST_POST_ID, TEST_MEMBER_ID, "img", "img",
+                "content"));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/v1/posts/{postId}", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+}

--- a/post/src/main/java/com/oing/controller/MemberPostController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostController.java
@@ -41,6 +41,7 @@ public class MemberPostController implements MemberPostApi {
     private final MemberPostService memberPostService;
     private final MemberBridge memberBridge;
 
+    @Transactional
     @Override
     public PreSignedUrlResponse requestPresignedUrl(PreSignedUrlRequest request) {
         String imageName = request.imageName();

--- a/post/src/test/java/com/oing/controller/MemberPostControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostControllerTest.java
@@ -1,0 +1,64 @@
+package com.oing.controller;
+
+import com.oing.domain.MemberPost;
+import com.oing.dto.request.PreSignedUrlRequest;
+import com.oing.dto.response.PreSignedUrlResponse;
+import com.oing.service.MemberBridge;
+import com.oing.service.MemberPostService;
+import com.oing.util.AuthenticationHolder;
+import com.oing.util.IdentityGenerator;
+import com.oing.util.PreSignedUrlGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberPostControllerTest {
+    @InjectMocks
+    private MemberPostController memberPostController;
+
+    @Mock
+    private AuthenticationHolder authenticationHolder;
+    @Mock
+    private IdentityGenerator identityGenerator;
+    @Mock
+    private MemberPostService memberPostService;
+    @Mock
+    private MemberBridge memberBridge;
+    @Mock
+    private PreSignedUrlGenerator preSignedUrlGenerator;
+
+    @Test
+    void 피드_이미지_업로드_URL_요청_테스트() {
+        // given
+        String newFeedImage = "feed.jpg";
+
+        // when
+        PreSignedUrlRequest request = new PreSignedUrlRequest(newFeedImage);
+        PreSignedUrlResponse dummyResponse = new PreSignedUrlResponse("https://test.com/presigend-request-url");
+        when(preSignedUrlGenerator.getFeedPreSignedUrl(any())).thenReturn(dummyResponse);
+        PreSignedUrlResponse response = memberPostController.requestPresignedUrl(request);
+
+        // then
+        assertNotNull(response.url());
+    }
+
+    @Test
+    void 피드_삭제_테스트() {
+        // given
+        String memberId = "1";
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+
+        // when
+        memberPostController.deletePost(post.getId());
+
+        // then
+        // nothing. just check no exception
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
post 도메인 중 PresignedUrl 발급과 게시글 등록/삭제 기능에 대해 테스트 코드를 추가했습니다.

## ➕ 추가/변경된 기능

---
- Post PresignedUrl/DELETE 단위 테스트 코드 추가
- Post PresignedUrl/POST/DELETE 통합 테스트 코드 추가
- `existsByMemberIdAndCreatedAt` 레포지토리 테스트 코드 추가

## 🥺 리뷰어에게 하고싶은 말

---
게시글 등록에 대해 단위 테스트를 실행하려면 post 객체의 `createdAt`을 테스트 코드 내에서 설정해야 하는데 저희 프로젝트에서는 `@EnableJpaAuditing`로 처리를 하고 있어 테스트 코드를 작성하기 어렵네요. 좋은 아이디어 있다면 알려주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-162