### PR TITLE
[OING-158] feat: 피드 리얼이모지 조회 API 구현

### DIFF
--- a/gateway/src/test/java/com/oing/restapi/MemberPostRealEmojiApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostRealEmojiApiTest.java
@@ -21,8 +21,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDate;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -108,5 +107,82 @@ public class MemberPostRealEmojiApiTest {
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void 게시물_리얼이모지_요약_조회_테스트() throws Exception {
+        //given
+        PostRealEmojiRequest request = new PostRealEmojiRequest(TEST_REAL_EMOJI_ID);
+        mockMvc.perform(
+                post("/v1/posts/{postId}/real-emoji", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/v1/posts/{postId}/real-emoji/summary", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.postId").value(TEST_POST_ID))
+                .andExpect(jsonPath("$.results[0].realEmojiId").value(TEST_REAL_EMOJI_ID))
+                .andExpect(jsonPath("$.results[0].count").value(1));
+    }
+
+    @Test
+    void 게시물_리얼이모지_목록_조회_테스트() throws Exception {
+        //given
+        PostRealEmojiRequest request = new PostRealEmojiRequest(TEST_REAL_EMOJI_ID);
+        mockMvc.perform(
+                post("/v1/posts/{postId}/real-emoji", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/v1/posts/{postId}/real-emoji", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results[0].postId").value(TEST_POST_ID))
+                .andExpect(jsonPath("$.results[0].memberId").value(TEST_MEMBER_ID))
+                .andExpect(jsonPath("$.results[0].realEmojiId").value(TEST_REAL_EMOJI_ID))
+                .andExpect(jsonPath("$.results[0].emojiImageUrl").value("https://test.com/bucket/real-emoji.jpg"));
+    }
+
+    @Test
+    void 게시물_리얼이모지_남긴_멤버_조회_테스트() throws Exception {
+        //given
+        PostRealEmojiRequest request = new PostRealEmojiRequest(TEST_REAL_EMOJI_ID);
+        mockMvc.perform(
+                post("/v1/posts/{postId}/real-emoji", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/v1/posts/{postId}/real-emoji/member", TEST_POST_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.emojiMemberIdsList['01HGW2N7EHJVJ4CJ999RRS2A97'][0]").value(TEST_MEMBER_ID));
     }
 }

--- a/post/src/main/java/com/oing/controller/MemberPostReactionController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostReactionController.java
@@ -106,7 +106,7 @@ public class MemberPostReactionController implements MemberPostReactionApi {
 
     @Override
     @Transactional
-    public PostReactionsResponse getPostReactionMembers(String postId) {
+    public PostReactionMemberResponse getPostReactionMembers(String postId) {
         List<MemberPostReaction> reactions = memberPostReactionService.getMemberPostReactionsByPostId(postId);
         List<Emoji> emojiList = Emoji.getEmojiList();
 
@@ -117,6 +117,6 @@ public class MemberPostReactionController implements MemberPostReactionApi {
                 ));
         emojiList.forEach(emoji -> emojiMemberIdsMap.putIfAbsent(emoji.getTypeKey(), Collections.emptyList()));
 
-        return new PostReactionsResponse(emojiMemberIdsMap);
+        return new PostReactionMemberResponse(emojiMemberIdsMap);
     }
 }

--- a/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
@@ -147,6 +147,11 @@ public class MemberPostRealEmojiController implements MemberPostRealEmojiApi {
         return new PostRealEmojiMemberResponse(result);
     }
 
+    /**
+     * 리얼 이모지를 남긴 멤버 목록을 리얼 이모지 별로 그룹화합니다
+     * @param realEmojis 리얼 이모지 목록
+     * @return 리얼 이모지 별로 그룹화된 멤버 목록
+     */
     private Map<MemberRealEmoji, List<String>> groupByRealEmoji(List<MemberPostRealEmoji> realEmojis) {
         return realEmojis.stream()
                 .collect(Collectors.groupingBy(

--- a/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -135,17 +136,22 @@ public class MemberPostRealEmojiController implements MemberPostRealEmojiApi {
     @Override
     public PostRealEmojiMemberResponse getPostRealEmojiMembers(String postId) {
         MemberPost post = memberPostService.getMemberPostById(postId);
-        return new PostRealEmojiMemberResponse(post.getRealEmojis()
-                .stream()
-                .collect(Collectors.groupingBy(MemberPostRealEmoji::getRealEmoji))
-                .entrySet()
+
+        Map<MemberRealEmoji, List<String>> realEmojiMemberMap = groupByRealEmoji(post.getRealEmojis());
+        Map<String, List<String>> result = realEmojiMemberMap.entrySet()
                 .stream()
                 .collect(Collectors.toMap(
                         entry -> entry.getKey().getId(),
-                        entry -> entry.getValue().stream()
-                                .map(MemberPostRealEmoji::getMemberId)
-                                .toList()
-                ))
-        );
+                        Map.Entry::getValue
+                ));
+        return new PostRealEmojiMemberResponse(result);
+    }
+
+    private Map<MemberRealEmoji, List<String>> groupByRealEmoji(List<MemberPostRealEmoji> realEmojis) {
+        return realEmojis.stream()
+                .collect(Collectors.groupingBy(
+                        MemberPostRealEmoji::getRealEmoji,
+                        Collectors.mapping(MemberPostRealEmoji::getMemberId, Collectors.toList())
+                ));
     }
 }

--- a/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
@@ -5,9 +5,7 @@ import com.oing.domain.MemberPost;
 import com.oing.domain.MemberPostRealEmoji;
 import com.oing.domain.MemberRealEmoji;
 import com.oing.dto.request.PostRealEmojiRequest;
-import com.oing.dto.response.ArrayResponse;
-import com.oing.dto.response.DefaultResponse;
-import com.oing.dto.response.PostRealEmojiResponse;
+import com.oing.dto.response.*;
 import com.oing.exception.AuthorizationFailedException;
 import com.oing.exception.RealEmojiAlreadyExistsException;
 import com.oing.exception.RegisteredRealEmojiNotFoundException;
@@ -22,13 +20,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 
-import java.util.Collections;
-import com.oing.restapi.MemberPostRealEmojiApi;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
-
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Controller
@@ -92,17 +85,67 @@ public class MemberPostRealEmojiController implements MemberPostRealEmojiApi {
         return DefaultResponse.ok();
     }
 
+    /**
+     * 게시물에 등록된 리얼 이모지 요약을 조회합니다
+     * @param postId 게시물 ID
+     * @return 리얼 이모지 요약
+     */
+    @Override
+    @Transactional
+    public PostRealEmojiSummaryResponse getPostRealEmojiSummary(String postId) {
+        MemberPost post = memberPostService.findMemberPostById(postId);
+        List<PostRealEmojiSummaryResponse.PostRealEmojiSummaryResponseElement> results = post.getRealEmojis()
+                .stream()
+                .collect(Collectors.groupingBy(MemberPostRealEmoji::getRealEmoji))
+                .values()
+                .stream().map(element ->
+                        new PostRealEmojiSummaryResponse.PostRealEmojiSummaryResponseElement(
+                                element.get(0).getRealEmoji().getId(),
+                                element.size()
+                        )
+                )
+                .toList();
+        return new PostRealEmojiSummaryResponse(
+                post.getId(),
+                results
+        );
+    }
+
+    /**
+     * 게시물에 등록된 리얼 이모지 목록을 조회합니다
+     * @param postId 게시물 ID
+     * @return 리얼 이모지 목록
+     */
+    @Transactional
     @Override
     public ArrayResponse<PostRealEmojiResponse> getPostRealEmojis(String postId) {
-        List<PostRealEmojiResponse> mockResponses = Arrays.asList(
-                new PostRealEmojiResponse("01HGW2N7EHJVJ4CJ999RRS2E97", "emoji_1", postId,
-                        "01HUUDFAOHJVJ4CJ999RRS2E97", "http://test.com/images/test1.jpg"),
-                new PostRealEmojiResponse("01HGW2N7EHJVJ4CJ999RRS2E97", "emoji_2", postId,
-                        "01HGW2N7EHJVJ4CJ999RRS2E97", "http://test.com/images/test2.jpg"),
-                new PostRealEmojiResponse("01DGW2N7EFFFEDFAG9RRS2E976", "emoji_2", postId,
-                        "01HGW2N7EHJVJEEFD99RRS2E97", "http://test.com/images/test2.jpg")
+        MemberPost post = memberPostService.getMemberPostById(postId);
+        return ArrayResponse.of(post.getRealEmojis().stream()
+                .map(PostRealEmojiResponse::from)
+                .toList()
         );
+    }
 
-        return ArrayResponse.of(mockResponses);
+    /**
+     * 게시물에 등록된 리얼 이모지를 남긴 멤버 목록을 조회합니다
+     * @param postId 게시물 ID
+     * @return 리얼 이모지를 남긴 멤버 목록
+     */
+    @Transactional
+    @Override
+    public PostRealEmojiMemberResponse getPostRealEmojiMembers(String postId) {
+        MemberPost post = memberPostService.getMemberPostById(postId);
+        return new PostRealEmojiMemberResponse(post.getRealEmojis()
+                .stream()
+                .collect(Collectors.groupingBy(MemberPostRealEmoji::getRealEmoji))
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().getId(),
+                        entry -> entry.getValue().stream()
+                                .map(MemberPostRealEmoji::getMemberId)
+                                .toList()
+                ))
+        );
     }
 }

--- a/post/src/main/java/com/oing/dto/response/PostReactionMemberResponse.java
+++ b/post/src/main/java/com/oing/dto/response/PostReactionMemberResponse.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 @Schema(description = "피드 게시물 이모지 응답")
-public record PostReactionsResponse(
+public record PostReactionMemberResponse(
         @Schema(description = "이모지를 누른 사용자 ID 목록")
         Map<String, List<String>> emojiMemberIdsList
 ) {

--- a/post/src/main/java/com/oing/dto/response/PostRealEmojiMemberResponse.java
+++ b/post/src/main/java/com/oing/dto/response/PostRealEmojiMemberResponse.java
@@ -1,0 +1,13 @@
+package com.oing.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "피드 게시물 이모지 응답")
+public record PostRealEmojiMemberResponse(
+        @Schema(description = "이모지를 누른 사용자 ID 목록")
+        Map<String, List<String>> emojiMemberIdsList
+) {
+}

--- a/post/src/main/java/com/oing/dto/response/PostRealEmojiSummaryResponse.java
+++ b/post/src/main/java/com/oing/dto/response/PostRealEmojiSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.oing.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "피드 게시물 리얼 이모지 요약")
+public record PostRealEmojiSummaryResponse(
+        @Schema(description = "피드 게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String postId,
+
+        @Schema(description = "피드 게시물 리얼 이모지 요약", example = "")
+        List<PostRealEmojiSummaryResponseElement> results
+) {
+    @Schema(description = "피드 게시물 반응 요약 내용")
+    public static record PostRealEmojiSummaryResponseElement(
+            @Schema(description = "리얼 이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            String realEmojiId,
+
+            @Schema(description = "반응 개수", example = "3")
+            int count
+    ) {
+
+    }
+}

--- a/post/src/main/java/com/oing/restapi/MemberPostReactionApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostReactionApi.java
@@ -55,7 +55,7 @@ public interface MemberPostReactionApi {
 
     @Operation(summary = "게시물 반응을 남긴 전체 멤버 조회", description = "게시물에 반응을 남긴 모든 멤버 목록을 조회합니다.")
     @GetMapping("/member")
-    PostReactionsResponse getPostReactionMembers(
+    PostReactionMemberResponse getPostReactionMembers(
             @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String postId

--- a/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
@@ -1,9 +1,7 @@
 package com.oing.restapi;
 
 import com.oing.dto.request.PostRealEmojiRequest;
-import com.oing.dto.response.ArrayResponse;
-import com.oing.dto.response.DefaultResponse;
-import com.oing.dto.response.PostRealEmojiResponse;
+import com.oing.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,9 +38,25 @@ public interface MemberPostRealEmojiApi {
             String realEmojiId
     );
 
+    @Operation(summary = "게시물의 리얼 이모지 요약 조회", description = "게시물에 달린 리얼 이모지 요약을 조회합니다.")
+    @GetMapping("/summary")
+    PostRealEmojiSummaryResponse getPostRealEmojiSummary(
+            @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String postId
+    );
+
     @Operation(summary = "게시물의 리얼 이모지 전체 조회", description = "게시물에 달린 모든 리얼 이모지 목록을 조회합니다.")
     @GetMapping
     ArrayResponse<PostRealEmojiResponse> getPostRealEmojis(
+            @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String postId
+    );
+
+    @Operation(summary = "게시물의 리얼 이모지를 남긴 전체 멤버 조회", description = "게시물에 리얼 이모지를 남긴 모든 멤버 목록을 조회합니다.")
+    @GetMapping("/member")
+    PostRealEmojiMemberResponse getPostRealEmojiMembers(
             @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String postId

--- a/post/src/test/java/com/oing/controller/MemberPostReactionControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostReactionControllerTest.java
@@ -4,7 +4,7 @@ import com.oing.domain.Emoji;
 import com.oing.domain.MemberPost;
 import com.oing.domain.MemberPostReaction;
 import com.oing.dto.request.PostReactionRequest;
-import com.oing.dto.response.PostReactionsResponse;
+import com.oing.dto.response.PostReactionMemberResponse;
 import com.oing.exception.EmojiAlreadyExistsException;
 import com.oing.exception.EmojiNotFoundException;
 import com.oing.service.MemberPostReactionService;
@@ -122,7 +122,7 @@ public class MemberPostReactionControllerTest {
         when(memberPostReactionService.getMemberPostReactionsByPostId(post.getId())).thenReturn(mockReactions);
 
         //when
-        PostReactionsResponse response = memberPostReactionController.getPostReactionMembers(post.getId());
+        PostReactionMemberResponse response = memberPostReactionController.getPostReactionMembers(post.getId());
 
         //then
         assertTrue(response.emojiMemberIdsList().get(Emoji.EMOJI_1.getTypeKey()).contains(memberId));

--- a/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
@@ -5,7 +5,10 @@ import com.oing.domain.MemberPost;
 import com.oing.domain.MemberPostRealEmoji;
 import com.oing.domain.MemberRealEmoji;
 import com.oing.dto.request.PostRealEmojiRequest;
+import com.oing.dto.response.ArrayResponse;
+import com.oing.dto.response.PostRealEmojiMemberResponse;
 import com.oing.dto.response.PostRealEmojiResponse;
+import com.oing.dto.response.PostRealEmojiSummaryResponse;
 import com.oing.exception.AuthorizationFailedException;
 import com.oing.exception.RealEmojiAlreadyExistsException;
 import com.oing.exception.RegisteredRealEmojiNotFoundException;
@@ -15,17 +18,23 @@ import com.oing.service.MemberPostService;
 import com.oing.service.MemberRealEmojiService;
 import com.oing.util.AuthenticationHolder;
 import com.oing.util.IdentityGenerator;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+@Transactional
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 public class MemberPostRealEmojiControllerTest {
     @InjectMocks
@@ -147,5 +156,51 @@ public class MemberPostRealEmojiControllerTest {
         //then
         assertThrows(RegisteredRealEmojiNotFoundException.class,
                 () -> memberPostRealEmojiController.deletePostRealEmoji(post.getId(), realEmoji.getId()));
+    }
+
+    @Test
+    void 게시물_리얼이모지_요약_조회_테스트() {
+        //given
+        String memberId = "1";
+        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        PostRealEmojiSummaryResponse summary = memberPostRealEmojiController.getPostRealEmojiSummary(post.getId());
+
+        //then
+        assertEquals(0, summary.results().size());
+    }
+
+    @Test
+    void 게시물_리얼이모지_목록_조회_테스트() {
+        //given
+        String memberId = "1";
+        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        ArrayResponse<PostRealEmojiResponse> response = memberPostRealEmojiController.getPostRealEmojis(post.getId());
+
+        //then
+        assertEquals(0, response.results().size());
+        assertEquals(List.of(), response.results());
+    }
+
+    @Test
+    void 게시물_리얼이모지_멤버_조회_테스트() {
+        //given
+        String memberId = "1";
+        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        PostRealEmojiMemberResponse response = memberPostRealEmojiController.getPostRealEmojiMembers(post.getId());
+
+        //then
+        assertEquals(0, response.emojiMemberIdsList().size());
     }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
피드 리얼이모지 요약/리스트/멤버 조회 API를 구현했습니다.

## ➕ 추가/변경된 기능

---
- 피드 리얼이모지 요약/리스트/멤버 조회 API 구현
- 해당 PR에서 구현한 기능에 대해 단위 테스트 코드 작성
- 해당 PR에서 구현한 기능에 대해 인수 테스트 코드 작성

## 🥺 리뷰어에게 하고싶은 말

---
해당 PR에서 구현한 기능들 모두 repository를 접근해서 데이터를 가져오는 로직이 아니어서 단위 테스트 코드의 경우 호출했을 때 예외가 나지 않는지 정도만 체크했습니다.



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-158