### PR TITLE
[OING-165] feat: 추억캘린더 새 배너 API 설계 및 모킹

### DIFF
--- a/gateway/src/main/java/com/oing/controller/CalendarController.java
+++ b/gateway/src/main/java/com/oing/controller/CalendarController.java
@@ -4,6 +4,7 @@ import com.oing.component.TokenAuthenticationHolder;
 import com.oing.domain.MemberPost;
 import com.oing.domain.MemberPostDailyCalendarDTO;
 import com.oing.dto.response.ArrayResponse;
+import com.oing.dto.response.BannerResponse;
 import com.oing.dto.response.CalendarResponse;
 import com.oing.restapi.CalendarApi;
 import com.oing.service.MemberPostService;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Controller;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.IntStream;
 
 @Controller
@@ -74,5 +76,14 @@ public class CalendarController implements CalendarApi {
 
         List<CalendarResponse> calendarResponses = getCalendarResponses(familyIds, startDate, endDate);
         return new ArrayResponse<>(calendarResponses);
+    }
+
+
+    @Override
+    public BannerResponse getBanner(String yearMonth) {
+        return new BannerResponse(
+                new Random().nextInt(0, 101),
+                new Random().nextInt(0, 28)
+        );
     }
 }

--- a/gateway/src/main/java/com/oing/dto/response/BannerResponse.java
+++ b/gateway/src/main/java/com/oing/dto/response/BannerResponse.java
@@ -1,0 +1,13 @@
+package com.oing.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "배너 응답")
+public record BannerResponse(
+        @Schema(description = "가족 활성도의 상위 백분율", example = "50")
+        Integer familyTopPercentage,
+
+        @Schema(description = "가족 구성원 모두가 업로드한 날의 수", example = "3")
+        Integer allFamilyMembersUploadedDays
+) {
+}

--- a/gateway/src/main/java/com/oing/restapi/CalendarApi.java
+++ b/gateway/src/main/java/com/oing/restapi/CalendarApi.java
@@ -1,6 +1,7 @@
 package com.oing.restapi;
 
 import com.oing.dto.response.ArrayResponse;
+import com.oing.dto.response.BannerResponse;
 import com.oing.dto.response.CalendarResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,6 +27,14 @@ public interface CalendarApi {
     @Operation(summary = "월별 캘린더 조회", description = "월별 캘린더를 조회합니다.")
     @GetMapping(params = {"type=MONTHLY"})
     ArrayResponse<CalendarResponse> getMonthlyCalendar(
+            @RequestParam(required = false)
+            @Parameter(description = "조회할 년월", example = "2021-12")
+            String yearMonth
+    );
+
+    @Operation(summary = "캘린더 베너 조회", description = "캘린더 상단의 베너를 조회합니다.")
+    @GetMapping("/banner")
+    BannerResponse getBanner(
             @RequestParam(required = false)
             @Parameter(description = "조회할 년월", example = "2021-12")
             String yearMonth


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
추억캘린더의 2차 MVP 기능에 해당하는 새로운 배너를 위한 API입니다.

## ➕ 추가/변경된 기능

---
- getBanner API in CalendarApi 추가
- getBanner request in CalendarController 모킹
- getBanner 기본 조회를 위한 통합테스트 추가

## 🥺 리뷰어에게 하고싶은 말

---
늦어서 죄송..



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-165