### PR TITLE
[OING-168] fix: 단일 게시물 조회 API 이모지 개수 반환 로직 수정

### DIFF
--- a/post/src/main/java/com/oing/dto/response/PostResponse.java
+++ b/post/src/main/java/com/oing/dto/response/PostResponse.java
@@ -40,7 +40,7 @@ public record PostResponse(
                 post.getId(),
                 post.getMemberId(),
                 post.getCommentCnt(),
-                post.getReactionCnt(),
+                post.getReactionCnt() + post.getRealEmojiCnt(),
                 post.getPostImgUrl(),
                 post.getContent(),
                 post.getCreatedAt().atZone(ZoneId.systemDefault())


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
단일 게시물 조회할 때 반환되는 이모지 개수에 리얼 이모지 개수까지 포함되도록 했습니다.

## ➕ 추가/변경된 기능

---
- 단일 게시물 조회 API 이모지 개수 반환 로직 수정

## 🥺 리뷰어에게 하고싶은 말

---
리뷰 부탁드립니다~

