### PR TITLE
[OING-105] test: Widget API 테스트 코드 추가

### DIFF
--- a/gateway/src/main/resources/application-test.yaml
+++ b/gateway/src/main/resources/application-test.yaml
@@ -53,3 +53,4 @@ cloud:
       bucket: bucket
     image-optimizer-cdn: https://cdn.com
     thumbnail-optimizer-query: ?type=f&w=96&h=96&quality=70&align=4&faceopt=false&anilimit=1
+    kb-optimizer-query: ?type=f&w=480&h=480&faceopt=false&quality=50&autorotate=false

--- a/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
@@ -1,0 +1,150 @@
+package com.oing.controller;
+
+import com.oing.component.TokenAuthenticationHolder;
+import com.oing.domain.Member;
+import com.oing.domain.MemberPost;
+import com.oing.dto.response.SingleRecentPostWidgetResponse;
+import com.oing.service.MemberPostService;
+import com.oing.service.MemberService;
+import com.oing.util.OptimizedImageUrlGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class WidgetControllerTest {
+
+    @InjectMocks
+    private WidgetController widgetController;
+
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private MemberPostService memberPostService;
+    @Mock
+    private TokenAuthenticationHolder tokenAuthenticationHolder;
+    @Mock
+    private OptimizedImageUrlGenerator optimizedImageUrlGenerator;
+
+
+    private final Member testMember1 = new Member(
+            "testMember1",
+            "testFamily",
+            LocalDate.of(1999, 10, 18),
+            "testMember1",
+            "profile.com/1",
+            "1"
+    );
+
+    private final Member testMember2 = new Member(
+            "testMember2",
+            "testFamily",
+            LocalDate.of(1999, 10, 18),
+            "testMember2",
+            "profile.com/2",
+            "2"
+    );
+
+    private final MemberPost testPost1 = new MemberPost(
+            "testPost1",
+            testMember1.getId(),
+            "post.com/1",
+            "1",
+            "testPost"
+    );
+
+    private final List<String> familyIds = List.of(testMember1.getId(), testMember2.getId());
+
+
+    @Test
+    void 최근_게시글_싱글_위젯_정상_조회_테스트() {
+        // given
+        String date = "2024-10-18";
+
+        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
+        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
+        when(memberPostService.findLatestPostOfEveryday(familyIds, LocalDate.parse(date), LocalDate.parse(date).plusDays(1))).thenReturn(List.of(testPost1));
+        when(memberService.findMemberById(testPost1.getMemberId())).thenReturn(testMember1);
+        when(optimizedImageUrlGenerator.getKBImageUrlGenerator(testMember1.getProfileImgUrl())).thenReturn(testMember1.getProfileImgUrl());
+        when(optimizedImageUrlGenerator.getKBImageUrlGenerator(testPost1.getPostImgUrl())).thenReturn(testPost1.getPostImgUrl());
+
+        // when
+        ResponseEntity<SingleRecentPostWidgetResponse> response = widgetController.getSingleRecentFamilyPostWidget(date);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody())
+                .extracting(
+                        SingleRecentPostWidgetResponse::authorName,
+                        SingleRecentPostWidgetResponse::authorProfileImageUrl,
+                        SingleRecentPostWidgetResponse::postImageUrl,
+                        SingleRecentPostWidgetResponse::postContent
+                ).containsExactly(
+                        testMember1.getName(),
+                        testMember1.getProfileImgUrl(),
+                        testPost1.getPostImgUrl(),
+                        testPost1.getContent()
+                );
+    }
+
+    @Test
+    void 최근_게시글_싱글_위젯_null_파라미터_조회_테스트() {
+        // given
+        String date = null;
+
+        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
+        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
+        when(memberPostService.findLatestPostOfEveryday(familyIds, LocalDate.now(), LocalDate.now().plusDays(1))).thenReturn(List.of(testPost1));
+        when(memberService.findMemberById(testPost1.getMemberId())).thenReturn(testMember1);
+        when(optimizedImageUrlGenerator.getKBImageUrlGenerator(testMember1.getProfileImgUrl())).thenReturn(testMember1.getProfileImgUrl());
+        when(optimizedImageUrlGenerator.getKBImageUrlGenerator(testPost1.getPostImgUrl())).thenReturn(testPost1.getPostImgUrl());
+
+        // when
+        ResponseEntity<SingleRecentPostWidgetResponse> response = widgetController.getSingleRecentFamilyPostWidget(date);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody())
+                .extracting(
+                        SingleRecentPostWidgetResponse::authorName,
+                        SingleRecentPostWidgetResponse::authorProfileImageUrl,
+                        SingleRecentPostWidgetResponse::postImageUrl,
+                        SingleRecentPostWidgetResponse::postContent
+                ).containsExactly(
+                        testMember1.getName(),
+                        testMember1.getProfileImgUrl(),
+                        testPost1.getPostImgUrl(),
+                        testPost1.getContent()
+                );
+    }
+
+    @Test
+    void 최근_게시글_싱글_위젯_빈_게시글_조회_테스트() {
+        // given
+        String date = "2024-10-18";
+
+        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
+        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
+        when(memberPostService.findLatestPostOfEveryday(familyIds, LocalDate.parse(date), LocalDate.parse(date).plusDays(1))).thenReturn(List.of());
+
+        // when
+        ResponseEntity<SingleRecentPostWidgetResponse> response = widgetController.getSingleRecentFamilyPostWidget(date);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+}

--- a/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
@@ -1,0 +1,222 @@
+package com.oing.restapi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oing.domain.CreateNewUserDTO;
+import com.oing.domain.Member;
+import com.oing.domain.MemberPost;
+import com.oing.domain.SocialLoginProvider;
+import com.oing.dto.request.JoinFamilyRequest;
+import com.oing.dto.response.DeepLinkResponse;
+import com.oing.dto.response.FamilyResponse;
+import com.oing.service.*;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@AutoConfigureMockMvc
+class WidgetApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberPostService memberPostService;
+    @Autowired
+    private FamilyService familyService;
+    @Autowired
+    private DeepLinkService deepLinkService;
+    @Autowired
+    private TokenGenerator tokenGenerator;
+
+
+    private Member TEST_MEMBER1;
+    private String TEST_MEMBER1_TOKEN;
+    private Member TEST_MEMBER2;
+    private String TEST_MEMBER2_TOKEN;
+    private Member TEST_MEMBER3;
+    private String TEST_MEMBER3_TOKEN;
+    private List<String> TEST_FAMILIES_IDS;
+
+
+    @Value("${cloud.ncp.image-optimizer-cdn}")
+    private String imageOptimizerCdn;
+    @Value("${cloud.ncp.kb-optimizer-query}")
+    private String kbOptimizerQuery;
+
+
+    @BeforeEach
+    void setUp() throws Exception {
+        TEST_MEMBER1 = memberService.createNewMember(
+                new CreateNewUserDTO(
+                        SocialLoginProvider.fromString("APPLE"),
+                        "testUser1",
+                        "testUser1",
+                        LocalDate.of(1999, 10, 18),
+                        "storage.com/images/1"
+                )
+        );
+        TEST_MEMBER1_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER1.getId()).accessToken();
+
+        TEST_MEMBER2 = memberService.createNewMember(
+                new CreateNewUserDTO(
+                        SocialLoginProvider.fromString("APPLE"),
+                        "testUser2",
+                        "testUser2",
+                        LocalDate.of(2000, 10, 18),
+                        "storage.com/images/2"
+                )
+        );
+        TEST_MEMBER2_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER2.getId()).accessToken();
+
+        String familyId = objectMapper.readValue(
+                mockMvc.perform(post("/v1/me/create-family").header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
+                        .andExpect(status().isOk())
+                        .andReturn().getResponse().getContentAsString(), FamilyResponse.class
+        ).familyId();
+        String inviteCode = objectMapper.readValue(
+                mockMvc.perform(post("/v1/links/family/{familyId}", familyId).header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN))
+                        .andExpect(status().isOk())
+                        .andReturn().getResponse().getContentAsString(), DeepLinkResponse.class
+        ).getLinkId();
+        mockMvc.perform(post("/v1/me/join-family")
+                .header("X-AUTH-TOKEN", TEST_MEMBER2_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new JoinFamilyRequest(inviteCode)))
+        ).andExpect(status().isOk());
+
+        TEST_MEMBER3 = memberService.createNewMember(
+                new CreateNewUserDTO(
+                        SocialLoginProvider.fromString("APPLE"),
+                        "testUser3",
+                        "testUser3",
+                        LocalDate.of(2001, 10, 18),
+                        "storage.com/images/3"
+                )
+        );
+        TEST_MEMBER3_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER3.getId()).accessToken();
+
+        TEST_FAMILIES_IDS = List.of(TEST_MEMBER1.getId(), TEST_MEMBER2.getId());
+    }
+
+
+    @Test
+    void 최근_게시글_싱글_위젯_정상_조회_테스트() throws Exception {
+        // given
+        MemberPost testPost1 = new MemberPost(
+                "testPost1",
+                TEST_MEMBER1.getId(),
+                "storage.com/images/1",
+                "1",
+                "testPos1"
+        );
+        MemberPost testPost2 = new MemberPost(
+                "testPost2",
+                TEST_MEMBER2.getId(),
+                "storage.com/images/2",
+                "2",
+                "testPos2"
+        );
+        MemberPost testPost3 = new MemberPost(
+                "testPost3",
+                TEST_MEMBER3.getId(),
+                "storage.com/images/3",
+                "3",
+                "testPos3"
+        );
+        memberPostService.save(testPost1);
+        memberPostService.save(testPost2);
+        memberPostService.save(testPost3);
+
+
+        // when & then
+        mockMvc.perform(get("/v1/widgets/single-recent-family-post")
+                        .param("date", LocalDate.now().format(DateTimeFormatter.ISO_DATE))
+                        .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authorName").value(TEST_MEMBER2.getName()))
+                .andExpect(jsonPath("$.authorProfileImageUrl").value(imageOptimizerCdn + "/images/2" + kbOptimizerQuery))
+                .andExpect(jsonPath("$.postImageUrl").value(imageOptimizerCdn + "/images/2" + kbOptimizerQuery))
+                .andExpect(jsonPath("$.postContent").value(testPost2.getContent()));
+
+    }
+
+
+    @Test
+    void 최근_게시글_싱글_위젯_파라미터_없이_조회_테스트() throws Exception {
+        // given
+        MemberPost testPost1 = new MemberPost(
+                "testPost1",
+                TEST_MEMBER1.getId(),
+                "storage.com/images/1",
+                "1",
+                "testPos1"
+        );
+        MemberPost testPost2 = new MemberPost(
+                "testPost2",
+                TEST_MEMBER2.getId(),
+                "storage.com/images/2",
+                "2",
+                "testPos2"
+        );
+        MemberPost testPost3 = new MemberPost(
+                "testPost3",
+                TEST_MEMBER3.getId(),
+                "storage.com/images/3",
+                "3",
+                "testPos3"
+        );
+        memberPostService.save(testPost1);
+        memberPostService.save(testPost2);
+        memberPostService.save(testPost3);
+
+
+        // when & then
+        mockMvc.perform(get("/v1/widgets/single-recent-family-post")
+                        .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authorName").value(TEST_MEMBER2.getName()))
+                .andExpect(jsonPath("$.authorProfileImageUrl").value(imageOptimizerCdn + "/images/2" + kbOptimizerQuery))
+                .andExpect(jsonPath("$.postImageUrl").value(imageOptimizerCdn + "/images/2" + kbOptimizerQuery))
+                .andExpect(jsonPath("$.postContent").value(testPost2.getContent()));
+
+    }
+
+
+    @Test
+    void 최근_게시글_싱글_위젯_게시글_없이_조회_테스트() throws Exception {
+        // when & then
+        mockMvc.perform(get("/v1/widgets/single-recent-family-post")
+                        .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
+                )
+                .andExpect(status().isNoContent());
+
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
계속 미뤄지던 Widget API 코드 들에 대한 테스트 코드를 추가했습니다. Repository 비즈니스 로직은 Calendar와 같은 로직을 사용하고 있어 이전에 추가한  #104 #81 에서 이미 반영되었습니다.

## ➕ 추가/변경된 기능

---
- WidgetController에 대한 단위 테스트 추가
- WidgetApi에 대한 통합 테스트 추가

## 🥺 리뷰어에게 하고싶은 말

---
파이팅 ㅠ



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-105