### PR TITLE
[OING-171] hotfix: 포스트에 달린 리얼이모지 삭제 로직 버그 해결

### DIFF
--- a/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
@@ -79,7 +79,7 @@ public class MemberPostRealEmojiController implements MemberPostRealEmojiApi {
         String memberId = authenticationHolder.getUserId();
         MemberPost post = memberPostService.getMemberPostById(postId);
         MemberPostRealEmoji postRealEmoji = memberPostRealEmojiService
-                .getMemberPostRealEmojiByRealEmojiIdAndMemberId(realEmojiId, memberId);
+                .getMemberPostRealEmojiByRealEmojiIdAndMemberIdAndPostId(realEmojiId, memberId, postId);
 
         memberPostRealEmojiService.deletePostRealEmoji(postRealEmoji);
         post.removeRealEmoji(postRealEmoji);

--- a/post/src/main/java/com/oing/repository/MemberPostRealEmojiRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRealEmojiRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface MemberPostRealEmojiRepository extends JpaRepository<MemberPostRealEmoji, String> {
     boolean existsByPostAndMemberIdAndRealEmoji(MemberPost post, String memberId, MemberRealEmoji emoji);
 
-    Optional<MemberPostRealEmoji> findByRealEmojiIdAndMemberId(String realEmojiId, String memberId);
+    Optional<MemberPostRealEmoji> findByRealEmojiIdAndMemberIdAndPostId(String realEmojiId, String memberId, String postId);
 }

--- a/post/src/main/java/com/oing/service/MemberPostRealEmojiService.java
+++ b/post/src/main/java/com/oing/service/MemberPostRealEmojiService.java
@@ -40,8 +40,9 @@ public class MemberPostRealEmojiService {
      * @return 게시물에 등록된 리얼 이모지
      * @throws RegisteredRealEmojiNotFoundException 등록된 리얼 이모지가 없는 경우
      */
-    public MemberPostRealEmoji getMemberPostRealEmojiByRealEmojiIdAndMemberId(String realEmojiId, String memberId) {
-        return memberPostRealEmojiRepository.findByRealEmojiIdAndMemberId(realEmojiId, memberId)
+    public MemberPostRealEmoji getMemberPostRealEmojiByRealEmojiIdAndMemberIdAndPostId(String realEmojiId, String memberId,
+                                                                                       String postId) {
+        return memberPostRealEmojiRepository.findByRealEmojiIdAndMemberIdAndPostId(realEmojiId, memberId, postId)
                 .orElseThrow(RegisteredRealEmojiNotFoundException::new);
     }
 

--- a/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
@@ -150,7 +150,7 @@ public class MemberPostRealEmojiControllerTest {
         when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
 
         //when
-        when(memberPostRealEmojiService.getMemberPostRealEmojiByRealEmojiIdAndMemberId("1", memberId))
+        when(memberPostRealEmojiService.getMemberPostRealEmojiByRealEmojiIdAndMemberIdAndPostId("1", memberId, post.getId()))
                 .thenThrow(RegisteredRealEmojiNotFoundException.class);
 
         //then


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
기존의 포스트 리얼 이모지 삭제 로직에서는 memberId와 realEmojiId로만 postRealEmoji를 찾으려 했습니다. 그렇기에 다른 게시글에도 같은 리얼 이모지를 남긴 경우 서버에서는 어떤 postRealEmoji를 삭제해야 할지 모르기 때문에 500 에러가 반환됐습니다. postId도 추가해서 함께 찾도록 하여 해결했습니다.

## ➕ 추가/변경된 기능

---
- 포스트에 달린 리얼이모지 삭제 로직 버그 해결

## 🥺 리뷰어에게 하고싶은 말

---
리뷰 부탁드려요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-171