### PR TITLE
[OING-172] hotfix: 회원가입 시, profileImgUrl이 있다면 이미지 키 추출해서 저장하도록 로직 수정

### DIFF
--- a/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
@@ -21,10 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -80,7 +77,7 @@ class CalendarApiTest {
                         "testUser1",
                         "testUser1",
                         LocalDate.of(1999, 10, 18),
-                        "profile.com"
+                        "https://bucket.com/image.jpg"
                 )
         ).getId();
         TEST_MEMBER1_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER1_ID).accessToken();
@@ -91,7 +88,7 @@ class CalendarApiTest {
                         "testUser2",
                         "testUser2",
                         LocalDate.of(2000, 10, 18),
-                        "profile.com"
+                        "https://bucket.com/image.jpg"
                 )
         ).getId();
         TEST_MEMBER2_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER2_ID).accessToken();
@@ -102,7 +99,7 @@ class CalendarApiTest {
                         "testUser3",
                         "testUser3",
                         LocalDate.of(2001, 10, 18),
-                        "profile.com"
+                        "https://bucket.com/image.jpg"
                 )
         ).getId();
         TEST_MEMBER3_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER3_ID).accessToken();

--- a/member/src/main/java/com/oing/domain/Member.java
+++ b/member/src/main/java/com/oing/domain/Member.java
@@ -39,6 +39,10 @@ public class Member extends DeletableBaseAuditEntity {
     @Column(name = "profile_img_key")
     private String profileImgKey;
 
+    public void setProfileImgKey(String profileImgKey) {
+        this.profileImgKey = profileImgKey;
+    }
+
     public void updateProfileImg(String profileImgUrl, String profileImgKey) {
         this.profileImgUrl = profileImgUrl;
         this.profileImgKey = profileImgKey;

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -11,6 +11,7 @@ import com.oing.exception.MemberNotFoundException;
 import com.oing.repository.MemberRepository;
 import com.oing.repository.SocialMemberRepository;
 import com.oing.util.IdentityGenerator;
+import com.oing.util.PreSignedUrlGenerator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,6 +30,7 @@ public class MemberService {
     private final SocialMemberRepository socialMemberRepository;
 
     private final IdentityGenerator identityGenerator;
+    private final PreSignedUrlGenerator preSignedUrlGenerator;
 
     public Member findMemberById(String memberId) {
         return memberRepository
@@ -70,6 +72,10 @@ public class MemberService {
                 createNewUserDTO.identifier(),
                 member);
         socialMemberRepository.save(socialMember);
+
+        if (createNewUserDTO.profileImgUrl() != null) {
+            member.setProfileImgKey(preSignedUrlGenerator.extractImageKey(createNewUserDTO.profileImgUrl()));
+        }
 
         return member;
     }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
회원가입 시, 프로필 이미지 값이 있다면 이미지 키 값도 함께 저장하도록 로직을 추가했습니다.

## ➕ 추가/변경된 기능

---
- 회원가입 시, 프로필 이미지 키 추출해서 저장하도록 로직 수정

## 🥺 리뷰어에게 하고싶은 말

---
이 부분 말고도 이미지 키 추출해서 저장해야 하는 곳이 있다면 알려주세요~


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-172