### PR TITLE
[OING-179] fix: 파라미터가 잘못 사용된 SingleRecentPostWidgetResponse 생성자를 고침

### DIFF
--- a/gateway/src/main/java/com/oing/controller/WidgetController.java
+++ b/gateway/src/main/java/com/oing/controller/WidgetController.java
@@ -46,8 +46,8 @@ public class WidgetController implements WidgetApi {
         Member author = memberService.findMemberById(latestPost.getMemberId());
         return ResponseEntity.ok(new SingleRecentPostWidgetResponse(
                 author.getName(),
-                latestPost.getId(),
                 optimizedImageUrlGenerator.getKBImageUrlGenerator(author.getProfileImgUrl()),
+                latestPost.getId(),
                 optimizedImageUrlGenerator.getKBImageUrlGenerator(latestPost.getPostImgUrl()),
                 latestPost.getContent()
         ));


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
#128 PR에서 생성자 파라미터 사용 실수로 발생한 버그 수정

## ➕ 추가/변경된 기능

---
파라미터가 잘못 사용된 SingleRecentPostWidgetResponse 생성자를 고침

## 🥺 리뷰어에게 하고싶은 말

---




## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-179