### PR TITLE
fix: 썸네일 이미지 압축 쿼리에서 사진 자동 회전 비활성화

### DIFF
--- a/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
 
-    private static final String THUMBNAIL_OPTIMIZER_QUERY_STRING = "?type=f&w=96&h=96&quality=70&align=4&faceopt=false&anilimit=1";
+    private static final String THUMBNAIL_OPTIMIZER_QUERY_STRING = "type=f&w=96&h=96&quality=70&autorotate=false&faceopt=false";
     private static final String KB_IMAGE_OPTIMIZER_QUERY_STRING = "?type=f&w=480&h=480&faceopt=false&quality=50&autorotate=false";
 
     @Value("${cloud.ncp.image-optimizer-cdn}")

--- a/gateway/src/main/resources/data.sql
+++ b/gateway/src/main/resources/data.sql
@@ -1,0 +1,5 @@
+INSERT INTO family(family_id, score, created_at)
+VALUES ('11111111111111111111111111', 0, '2018-01-01T00:00:00.000Z');
+
+INSERT INTO member(member_id, family_id, family_join_at, day_of_birth, name, profile_img_url, profile_img_key, created_at, updated_at, deleted_at)
+VALUES (1, '11111111111111111111111111', '2024-01-31T13:00:00.000Z', '1990-01-01', '김철수', 'https://s3.ap-northeast-2.amazonaws.com/our-family/profile/1.jpg', 'profile/1.jpg', '2018-01-01T00:00:00.000Z', '2018-01-01T00:00:00.000Z', null);


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
iOS 팀에서 원인을 알 수 없는 사진 회전 현상이 있다고 하여, ncp image optimzer에서 제공하는 이미지 자동 회전을 끈 쿼리로 변경하였습니다. 이 것이 미상의 현상의 원인이라고 장담할 수 는 없습니다.

## ➕ 추가/변경된 기능

---
- 썸네일 이미지 압축 쿼리 변경

## 🥺 리뷰어에게 하고싶은 말

---
파이팅

