### PR TITLE
[OING-189] hotfix: THUMBNAIL_OPTIMIZER_QUERY_STRING 오타 수정

### DIFF
--- a/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
 
-    public static final String THUMBNAIL_OPTIMIZER_QUERY_STRING = "type=f&w=96&h=96&quality=70&autorotate=false&faceopt=false";
+    public static final String THUMBNAIL_OPTIMIZER_QUERY_STRING = "?type=f&w=96&h=96&quality=70&autorotate=false&faceopt=false";
     public static final String KB_IMAGE_OPTIMIZER_QUERY_STRING = "?type=f&w=480&h=480&faceopt=false&quality=50&autorotate=false";
 
     @Value("${cloud.ncp.image-optimizer-cdn}")


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
썸네일 에러 원인이 오타 같아서 수정했습니다.

## ➕ 추가/변경된 기능

---
썸에일 쿼리 스트링 수정

## 🥺 리뷰어에게 하고싶은 말

---
main으로 머지되면 레디스 서버에 있는 캐시값들 다 지워주세요.



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-189