### PR TITLE
hotfix: iOS에서의 EXIF 이슈로 인해 NCP Image Optimizer에서 제외했던 auto-rotate를 활성화

### DIFF
--- a/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
+++ b/gateway/src/main/java/com/oing/config/support/OptimizedImageUrlProvider.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class OptimizedImageUrlProvider implements OptimizedImageUrlGenerator {
 
-    public static final String THUMBNAIL_OPTIMIZER_QUERY_STRING = "?type=f&w=96&h=96&quality=70&autorotate=false&faceopt=false";
-    public static final String KB_IMAGE_OPTIMIZER_QUERY_STRING = "?type=f&w=480&h=480&faceopt=false&quality=50&autorotate=false";
+    public static final String THUMBNAIL_OPTIMIZER_QUERY_STRING = "?type=f&w=96&h=96&quality=70&align=4&faceopt=false&anilimit=1";
+    public static final String KB_IMAGE_OPTIMIZER_QUERY_STRING = "?type=f&w=480&h=480&faceopt=false&quality=50";
 
     @Value("${cloud.ncp.image-optimizer-cdn}")
     private String imageOptimizerCdnUrl;


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
iOS에서의 EXIF 이슈로 인해 NCP Image Optimizer에서 제외했던 auto-rotate를 활성화합니다.

## ➕ 추가/변경된 기능

---
- NCP Image Optimizer 쿼리에서auto-rotate 활성화

## 🥺 리뷰어에게 하고싶은 말

---
main release까지 바로 핫픽스 마이너 릴리즈해야됩니다

