### PR TITLE
[OING-192] hotfix: 게시물 생성/조회에서 그룹을 탈퇴한 회원 대응 가능하도록 로직 수정

### DIFF
--- a/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
@@ -69,7 +69,7 @@ public class MemberPostRepositoryCustomImpl implements MemberPostRepositoryCusto
                 .select(memberPost)
                 .from(memberPost)
                 .leftJoin(member).on(memberPost.memberId.eq(member.id))
-                .where(member.familyId.eq(familyId), eqDate(date), eqMemberId(memberId))
+                .where(memberPost.familyId.eq(familyId), eqDate(date), eqMemberId(memberId))
                 .orderBy(asc ? memberPost.id.asc() : memberPost.id.desc())
                 .offset((long) (page - 1) * size)
                 .limit(size)
@@ -100,7 +100,7 @@ public class MemberPostRepositoryCustomImpl implements MemberPostRepositoryCusto
     }
 
     @Override
-    public boolean existsByMemberIdAndCreatedAt(String memberId, LocalDate postDate) {
+    public boolean existsByMemberIdAndCreatedAt(String memberId, String familyId, LocalDate postDate) {
         DateTimeTemplate<LocalDate> createdAtDate = Expressions.dateTimeTemplate(LocalDate.class,
                 "DATE({0})", memberPost.createdAt);
 
@@ -108,6 +108,7 @@ public class MemberPostRepositoryCustomImpl implements MemberPostRepositoryCusto
                 .select(memberPost.id)
                 .from(memberPost)
                 .where(memberPost.memberId.eq(memberId)
+                        .and(memberPost.familyId.eq(familyId))
                         .and(createdAtDate.eq(postDate)))
                 .fetchFirst() != null;
     }

--- a/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
@@ -100,7 +100,7 @@ public class MemberPostRepositoryCustomImpl implements MemberPostRepositoryCusto
     }
 
     @Override
-    public boolean existsByMemberIdAndCreatedAt(String memberId, String familyId, LocalDate postDate) {
+    public boolean existsByMemberIdAndFamilyIdAndCreatedAt(String memberId, String familyId, LocalDate postDate) {
         DateTimeTemplate<LocalDate> createdAtDate = Expressions.dateTimeTemplate(LocalDate.class,
                 "DATE({0})", memberPost.createdAt);
 

--- a/gateway/src/main/resources/db/migration/V202402061321__add_familyId_column.sql
+++ b/gateway/src/main/resources/db/migration/V202402061321__add_familyId_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `member_post` ADD COLUMN (`family_id` CHAR(26) NOT NULL COMMENT 'ULID');

--- a/gateway/src/main/resources/db/migration/V202402061321__add_familyId_column.sql
+++ b/gateway/src/main/resources/db/migration/V202402061321__add_familyId_column.sql
@@ -1,1 +1,3 @@
-ALTER TABLE `member_post` ADD COLUMN (`family_id` CHAR(26) NOT NULL COMMENT 'ULID');
+ALTER TABLE `member_post` ADD COLUMN (`family_id` CHAR(26) NOT NULL DEFAULT '0' COMMENT 'ULID');
+UPDATE member_post JOIN member ON member_post.member_id = member.member_id
+SET member_post.family_id = member.family_id;

--- a/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
@@ -75,6 +75,7 @@ class CalendarControllerTest {
         MemberPost testPost1 = new MemberPost(
                 "1",
                 testMember1.getId(),
+                "1",
                 "post.com/1",
                 "1",
                 "test1"
@@ -83,6 +84,7 @@ class CalendarControllerTest {
         MemberPost testPost2 = new MemberPost(
                 "2",
                 testMember2.getId(),
+                "1",
                 "post.com/2",
                 "2",
                 "test2"
@@ -91,6 +93,7 @@ class CalendarControllerTest {
         MemberPost testPost3 = new MemberPost(
                 "3",
                 testMember1.getId(),
+                "1",
                 "post.com/3",
                 "3",
                 "test3"
@@ -99,6 +102,7 @@ class CalendarControllerTest {
         MemberPost testPost4 = new MemberPost(
                 "4",
                 testMember2.getId(),
+                "1",
                 "post.com/4",
                 "4",
                 "test4"

--- a/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
@@ -63,6 +63,7 @@ class WidgetControllerTest {
     private final MemberPost testPost1 = new MemberPost(
             "testPost1",
             testMember1.getId(),
+            "1",
             "post.com/1",
             "1",
             "testPost"

--- a/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
@@ -81,14 +81,14 @@ class MemberPostRepositoryCustomTest {
         memberRepository.save(testMember3);
 
         // Posts
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('1', '" + testMember1.getId() + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('2', '" + testMember2.getId() + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('3', '" + testMember3.getId() + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('4', '" + testMember1.getId() + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('1', '" + testMember1.getId() + "', '" + testMember1.getFamilyId() + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('2', '" + testMember2.getId() + "', '" + testMember2.getFamilyId() + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('3', '" + testMember3.getId() + "', '" + testMember3.getFamilyId() + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('4', '" + testMember1.getId() + "', '" + testMember1.getFamilyId() + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
     }
 
 
@@ -120,7 +120,8 @@ class MemberPostRepositoryCustomTest {
         LocalDate postDate = LocalDate.of(2023, 11, 1);
 
         // when
-        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndCreatedAt(testMember1.getId(), postDate);
+        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndCreatedAt(testMember1.getId(),
+                testMember1.getFamilyId(), postDate);
 
         // then
         assertThat(exists).isTrue();
@@ -132,7 +133,8 @@ class MemberPostRepositoryCustomTest {
         LocalDate postDate = LocalDate.of(2023, 11, 8);
 
         // when
-        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndCreatedAt(testMember1.getId(), postDate);
+        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndCreatedAt(testMember1.getId(),
+                testMember1.getFamilyId(), postDate);
 
         // then
         assertThat(exists).isFalse();

--- a/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
@@ -120,7 +120,7 @@ class MemberPostRepositoryCustomTest {
         LocalDate postDate = LocalDate.of(2023, 11, 1);
 
         // when
-        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndCreatedAt(testMember1.getId(),
+        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndFamilyIdAndCreatedAt(testMember1.getId(),
                 testMember1.getFamilyId(), postDate);
 
         // then
@@ -133,7 +133,7 @@ class MemberPostRepositoryCustomTest {
         LocalDate postDate = LocalDate.of(2023, 11, 8);
 
         // when
-        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndCreatedAt(testMember1.getId(),
+        boolean exists = memberPostRepositoryCustomImpl.existsByMemberIdAndFamilyIdAndCreatedAt(testMember1.getId(),
                 testMember1.getFamilyId(), postDate);
 
         // then

--- a/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
@@ -114,22 +114,22 @@ class CalendarApiTest {
         String yearMonth = "2023-11";
 
         // posts
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('1', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('2', '" + TEST_MEMBER2_ID + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('3', '" + TEST_MEMBER3_ID + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('4', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('5', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/5', 0, 0, '2023-11-29 14:00:00', '2023-11-29 14:00:00', 'post5555', '5');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('6', '" + TEST_MEMBER2_ID + "', 'https://storage.com/images/6', 0, 0, '2023-11-29 15:00:00', '2023-11-29 15:00:00', 'post6666', '6');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('7', '" + TEST_MEMBER3_ID + "', 'https://storage.com/images/7', 0, 0, '2023-11-29 17:00:00', '2023-11-29 17:00:00', 'post7777', '7');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('8', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/8', 0, 0, '2023-11-30 14:00:00', '2023-11-30 14:00:00', 'post8888', '8');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('1', '" + TEST_MEMBER1_ID + "', '" + TEST_FAMILIES_IDS.get(0) + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('2', '" + TEST_MEMBER2_ID + "', '" + TEST_FAMILIES_IDS.get(1) + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('3', '" + TEST_MEMBER3_ID + "', '" + TEST_FAMILIES_IDS.get(1) + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('4', '" + TEST_MEMBER1_ID + "', '" + TEST_FAMILIES_IDS.get(0) + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('5', '" + TEST_MEMBER1_ID + "', '" + TEST_FAMILIES_IDS.get(0) + "', 'https://storage.com/images/5', 0, 0, '2023-11-29 14:00:00', '2023-11-29 14:00:00', 'post5555', '5');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('6', '" + TEST_MEMBER2_ID + "', '" + TEST_FAMILIES_IDS.get(1) + "', 'https://storage.com/images/6', 0, 0, '2023-11-29 15:00:00', '2023-11-29 15:00:00', 'post6666', '6');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('7', '" + TEST_MEMBER3_ID + "', '" + TEST_FAMILIES_IDS.get(1) + "', 'https://storage.com/images/7', 0, 0, '2023-11-29 17:00:00', '2023-11-29 17:00:00', 'post7777', '7');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('8', '" + TEST_MEMBER1_ID + "', '" + TEST_FAMILIES_IDS.get(0) + "', 'https://storage.com/images/8', 0, 0, '2023-11-30 14:00:00', '2023-11-30 14:00:00', 'post8888', '8');");
 
         // family
         String familyId = objectMapper.readValue(
@@ -182,22 +182,22 @@ class CalendarApiTest {
         String yearMonth = "2023-11";
 
         // posts
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('1', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('2', '" + TEST_MEMBER2_ID + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('3', '" + TEST_MEMBER3_ID + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('4', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('5', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/5', 0, 0, '2023-11-29 14:00:00', '2023-11-29 14:00:00', 'post5555', '5');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('6', '" + TEST_MEMBER2_ID + "', 'https://storage.com/images/6', 0, 0, '2023-11-29 15:00:00', '2023-11-29 15:00:00', 'post6666', '6');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('7', '" + TEST_MEMBER3_ID + "', 'https://storage.com/images/7', 0, 0, '2023-11-29 17:00:00', '2023-11-29 17:00:00', 'post7777', '7');");
-        jdbcTemplate.execute("insert into member_post (post_id, member_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('8', '" + TEST_MEMBER1_ID + "', 'https://storage.com/images/8', 0, 0, '2023-11-30 14:00:00', '2023-11-30 14:00:00', 'post8888', '8');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('1', '" + TEST_MEMBER1_ID + "', '" + TEST_FAMILIES_IDS.get(0) + "', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('2', '" + TEST_MEMBER2_ID + "', '" + TEST_FAMILIES_IDS.get(1) + "', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('3', '" + TEST_MEMBER3_ID + "', '" + TEST_FAMILIES_IDS.get(1) + "', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('4', '" + TEST_MEMBER1_ID + "', '" + TEST_FAMILIES_IDS.get(0) + "', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('5', '" + TEST_MEMBER1_ID + "', '" + TEST_FAMILIES_IDS.get(0) + "', 'https://storage.com/images/5', 0, 0, '2023-11-29 14:00:00', '2023-11-29 14:00:00', 'post5555', '5');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('6', '" + TEST_MEMBER2_ID + "', '" + TEST_FAMILIES_IDS.get(1) + "', 'https://storage.com/images/6', 0, 0, '2023-11-29 15:00:00', '2023-11-29 15:00:00', 'post6666', '6');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('7', '" + TEST_MEMBER3_ID + "', '" + TEST_FAMILIES_IDS.get(1) + "', 'https://storage.com/images/7', 0, 0, '2023-11-29 17:00:00', '2023-11-29 17:00:00', 'post7777', '7');");
+        jdbcTemplate.execute("insert into member_post (post_id, member_id, family_id, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
+                "values ('8', '" + TEST_MEMBER1_ID + "', '" + TEST_FAMILIES_IDS.get(0) + "', 'https://storage.com/images/8', 0, 0, '2023-11-30 14:00:00', '2023-11-30 14:00:00', 'post8888', '8');");
 
         // family
         String familyId = objectMapper.readValue(

--- a/gateway/src/test/java/com/oing/restapi/MemberPostApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostApiTest.java
@@ -43,6 +43,7 @@ public class MemberPostApiTest {
 
     private String TEST_MEMBER_ID = "01HGW2N7EHJVJ4CJ999RRS2E97";
     private String TEST_POST_ID = "01HGW2N7EHJVJ4CJ999RRS2A97";
+    private String TEST_FAMILY_ID = "01HGW2N7EHJVJ4CJ999RRS2E44";
     private String TEST_MEMBER_TOKEN;
 
     @Autowired
@@ -110,7 +111,7 @@ public class MemberPostApiTest {
     @Test
     void 게시물_삭제_테스트() throws Exception {
         //given
-        memberPostRepository.save(new MemberPost(TEST_POST_ID, TEST_MEMBER_ID, "img", "img",
+        memberPostRepository.save(new MemberPost(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, "img", "img",
                 "content"));
 
         //when

--- a/gateway/src/test/java/com/oing/restapi/MemberPostApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostApiTest.java
@@ -23,8 +23,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -41,10 +40,12 @@ public class MemberPostApiTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private String TEST_MEMBER_ID = "01HGW2N7EHJVJ4CJ999RRS2E97";
+    private String TEST_MEMBER1_ID = "01HGW2N7EHJVJ4CJ999RRS2E97";
+    private String TEST_MEMBER2_ID = "01HGW2N7EHJVJ4CJ99IIFIFE94";
     private String TEST_POST_ID = "01HGW2N7EHJVJ4CJ999RRS2A97";
     private String TEST_FAMILY_ID = "01HGW2N7EHJVJ4CJ999RRS2E44";
-    private String TEST_MEMBER_TOKEN;
+    private String TEST_MEMBER1_TOKEN;
+    private String TEST_MEMBER2_TOKEN;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -55,15 +56,27 @@ public class MemberPostApiTest {
     void setUp() {
         memberRepository.save(
                 new Member(
-                        TEST_MEMBER_ID,
-                        "testUser1",
+                        TEST_MEMBER1_ID,
+                        TEST_FAMILY_ID,
                         LocalDate.now(),
                         "", "", "",
                         LocalDateTime.now()
                 )
         );
-        TEST_MEMBER_TOKEN = tokenGenerator
-                .generateTokenPair(TEST_MEMBER_ID)
+        TEST_MEMBER1_TOKEN = tokenGenerator
+                .generateTokenPair(TEST_MEMBER1_ID)
+                .accessToken();
+        memberRepository.save(
+                new Member(
+                        TEST_MEMBER2_ID,
+                        TEST_FAMILY_ID,
+                        LocalDate.now(),
+                        "", "", "",
+                        LocalDateTime.now()
+                )
+        );
+        TEST_MEMBER2_TOKEN = tokenGenerator
+                .generateTokenPair(TEST_MEMBER2_ID)
                 .accessToken();
     }
 
@@ -75,7 +88,7 @@ public class MemberPostApiTest {
         //when
         ResultActions resultActions = mockMvc.perform(
                 post("/v1/posts/image-upload-request")
-                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new PreSignedUrlRequest(imageName)))
         );
@@ -95,7 +108,7 @@ public class MemberPostApiTest {
         //when
         ResultActions resultActions = mockMvc.perform(
                 post("/v1/posts")
-                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
         );
@@ -103,7 +116,7 @@ public class MemberPostApiTest {
         //then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.authorId").value(TEST_MEMBER_ID))
+                .andExpect(jsonPath("$.authorId").value(TEST_MEMBER1_ID))
                 .andExpect(jsonPath("$.imageUrl").value(request.imageUrl()))
                 .andExpect(jsonPath("$.content").value(request.content()));
     }
@@ -111,13 +124,13 @@ public class MemberPostApiTest {
     @Test
     void 게시물_삭제_테스트() throws Exception {
         //given
-        memberPostRepository.save(new MemberPost(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, "img", "img",
+        memberPostRepository.save(new MemberPost(TEST_POST_ID, TEST_MEMBER1_ID, TEST_FAMILY_ID, "img", "img",
                 "content"));
 
         //when
         ResultActions resultActions = mockMvc.perform(
                 delete("/v1/posts/{postId}", TEST_POST_ID)
-                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
         );
 
@@ -125,5 +138,32 @@ public class MemberPostApiTest {
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void 그룹에서_탈퇴한_회원_게시물_조회_테스트() throws Exception {
+        //given
+        memberPostRepository.save(new MemberPost(TEST_POST_ID, TEST_MEMBER1_ID, TEST_FAMILY_ID, "img", "img",
+                "content"));
+        mockMvc.perform(
+                post("/v1/me/quit-family")
+                        .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/v1/posts")
+                        .header("X-AUTH-TOKEN", TEST_MEMBER2_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.currentPage").value(1))
+                .andExpect(jsonPath("$.results[0].postId").value(TEST_POST_ID))
+                .andExpect(jsonPath("$.results[0].authorId").value(TEST_MEMBER1_ID))
+                .andExpect(jsonPath("$.results[0].content").value("content"));
     }
 }

--- a/gateway/src/test/java/com/oing/restapi/MemberPostCommentApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostCommentApiTest.java
@@ -1,13 +1,14 @@
 package com.oing.restapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.oing.domain.*;
+import com.oing.domain.Member;
+import com.oing.domain.MemberPost;
+import com.oing.domain.MemberPostComment;
 import com.oing.dto.request.CreatePostCommentRequest;
 import com.oing.dto.request.UpdatePostCommentRequest;
 import com.oing.repository.MemberPostCommentRepository;
 import com.oing.repository.MemberPostRepository;
 import com.oing.repository.MemberRepository;
-import com.oing.service.MemberService;
 import com.oing.service.TokenGenerator;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +44,7 @@ public class MemberPostCommentApiTest {
 
     private String TEST_MEMBER_ID = "01HGW2N7EHJVJ4CJ999RRS2E97";
     private String TEST_POST_ID = "01HGW2N7EHJVJ4CJ999RRS2A97";
+    private String TEST_FAMILY_ID = "01HGW2N7EHJVJ4CJ999RRS2E44";
     private String TEST_MEMBER_TOKEN;
 
     @Autowired
@@ -71,6 +73,7 @@ public class MemberPostCommentApiTest {
                 new MemberPost(
                         TEST_POST_ID,
                         TEST_MEMBER_ID,
+                        TEST_FAMILY_ID,
                         "img",
                         "img",
                         "content"

--- a/gateway/src/test/java/com/oing/restapi/MemberPostReactionApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostReactionApiTest.java
@@ -43,6 +43,7 @@ public class MemberPostReactionApiTest {
 
     private String TEST_MEMBER_ID = "01HGW2N7EHJVJ4CJ999RRS2E97";
     private String TEST_POST_ID = "01HGW2N7EHJVJ4CJ999RRS2A97";
+    private String TEST_FAMILY_ID = "01HGW2N7EHJVJ4CJ999RRS2E44";
     private String TEST_MEMBER_TOKEN;
 
     @Autowired
@@ -70,6 +71,7 @@ public class MemberPostReactionApiTest {
                 new MemberPost(
                         TEST_POST_ID,
                         TEST_MEMBER_ID,
+                        TEST_FAMILY_ID,
                         "img",
                         "img",
                         "content"

--- a/gateway/src/test/java/com/oing/restapi/MemberPostRealEmojiApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostRealEmojiApiTest.java
@@ -41,6 +41,7 @@ public class MemberPostRealEmojiApiTest {
 
     private String TEST_MEMBER_ID = "01HGW2N7EHJVJ4CJ999RRS2E97";
     private String TEST_POST_ID = "01HGW2N7EHJVJ4CJ999RRS2A97";
+    private String TEST_FAMILY_ID = "01HGW2N7EHJVJ4CJ999RRS2F97";
     private String TEST_REAL_EMOJI_ID = "01HGW2N7EHJVJ4CJ999RRS2A97";
     private String TEST_MEMBER_TOKEN;
 
@@ -60,7 +61,7 @@ public class MemberPostRealEmojiApiTest {
                 LocalDateTime.now()));
         TEST_MEMBER_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER_ID).accessToken();
 
-        memberPostRepository.save(new MemberPost(TEST_POST_ID, TEST_MEMBER_ID, "img", "img",
+        memberPostRepository.save(new MemberPost(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, "img", "img",
                 "content"));
 
         memberRealEmojiRepository.save(new MemberRealEmoji(TEST_REAL_EMOJI_ID, TEST_MEMBER_ID, Emoji.EMOJI_1,

--- a/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
@@ -130,6 +130,7 @@ class WidgetApiTest {
         MemberPost testPost1 = new MemberPost(
                 "testPost1",
                 TEST_MEMBER1.getId(),
+                "1",
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -137,6 +138,7 @@ class WidgetApiTest {
         MemberPost testPost2 = new MemberPost(
                 "testPost2",
                 TEST_MEMBER2.getId(),
+                "1",
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -144,6 +146,7 @@ class WidgetApiTest {
         MemberPost testPost3 = new MemberPost(
                 "testPost3",
                 TEST_MEMBER3.getId(),
+                "1",
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"
@@ -173,6 +176,7 @@ class WidgetApiTest {
         MemberPost testPost1 = new MemberPost(
                 "testPost1",
                 TEST_MEMBER1.getId(),
+                "1",
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -180,6 +184,7 @@ class WidgetApiTest {
         MemberPost testPost2 = new MemberPost(
                 "testPost2",
                 TEST_MEMBER2.getId(),
+                "1",
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -187,6 +192,7 @@ class WidgetApiTest {
         MemberPost testPost3 = new MemberPost(
                 "testPost3",
                 TEST_MEMBER3.getId(),
+                "1",
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"

--- a/post/src/main/java/com/oing/controller/MemberPostController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostController.java
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Controller;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * no5ing-server
@@ -42,8 +41,6 @@ public class MemberPostController implements MemberPostApi {
     private final PreSignedUrlGenerator preSignedUrlGenerator;
     private final MemberPostService memberPostService;
     private final MemberBridge memberBridge;
-
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
 
     @Transactional
     @Override
@@ -74,20 +71,20 @@ public class MemberPostController implements MemberPostApi {
         String postId = identityGenerator.generateIdentity();
         ZonedDateTime uploadTime = request.uploadTime();
 
-        validateUserHasNotCreatedPostToday(memberId, uploadTime);
+        validateUserHasNotCreatedPostToday(memberId, familyId, uploadTime);
         validateUploadTime(uploadTime);
 
         String postImgKey = preSignedUrlGenerator.extractImageKey(request.imageUrl());
-        MemberPost post = new MemberPost(postId, memberId, request.imageUrl(),
+        MemberPost post = new MemberPost(postId, memberId, familyId, request.imageUrl(),
                 postImgKey, request.content());
         MemberPost savedPost = memberPostService.save(post);
 
         return PostResponse.from(savedPost);
     }
 
-    private void validateUserHasNotCreatedPostToday(String memberId, ZonedDateTime uploadTime) {
+    private void validateUserHasNotCreatedPostToday(String memberId, String familyId, ZonedDateTime uploadTime) {
         LocalDate today = uploadTime.toLocalDate();
-        if (memberPostService.hasUserCreatedPostToday(memberId, today)) {
+        if (memberPostService.hasUserCreatedPostToday(memberId, familyId, today)) {
             throw new DuplicatePostUploadException();
         }
     }

--- a/post/src/main/java/com/oing/domain/MemberPost.java
+++ b/post/src/main/java/com/oing/domain/MemberPost.java
@@ -25,6 +25,9 @@ public class MemberPost extends BaseAuditEntity {
     @Column(name = "member_id", columnDefinition = "CHAR(26)", nullable = false)
     private String memberId;
 
+    @Column(name = "family_id", columnDefinition = "CHAR(26)", nullable = false)
+    private String familyId;
+
     @Column(name = "post_img_url", nullable = false)
     private String postImgUrl;
 
@@ -52,10 +55,11 @@ public class MemberPost extends BaseAuditEntity {
     @OneToMany(mappedBy = "post")
     private List<MemberPostRealEmoji> realEmojis = new ArrayList<>();
 
-    public MemberPost(String id, String memberId, String postImgUrl, String postImgKey, String content) {
+    public MemberPost(String id, String memberId, String familyId, String postImgUrl, String postImgKey, String content) {
         validateContent(content);
         this.id = id;
         this.memberId = memberId;
+        this.familyId = familyId;
         this.postImgUrl = postImgUrl;
         this.postImgKey = postImgKey;
         this.content = content;

--- a/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
@@ -19,5 +19,5 @@ public interface MemberPostRepositoryCustom {
 
     long countMonthlyPostByFamilyId(int year, int month, String familyId);
 
-    boolean existsByMemberIdAndCreatedAt(String memberId, String familyId, LocalDate postDate);
+    boolean existsByMemberIdAndFamilyIdAndCreatedAt(String memberId, String familyId, LocalDate postDate);
 }

--- a/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
@@ -19,5 +19,5 @@ public interface MemberPostRepositoryCustom {
 
     long countMonthlyPostByFamilyId(int year, int month, String familyId);
 
-    boolean existsByMemberIdAndCreatedAt(String memberId, LocalDate postDate);
+    boolean existsByMemberIdAndCreatedAt(String memberId, String familyId, LocalDate postDate);
 }

--- a/post/src/main/java/com/oing/service/MemberPostService.java
+++ b/post/src/main/java/com/oing/service/MemberPostService.java
@@ -69,7 +69,7 @@ public class MemberPostService {
      * @return 오늘 회원이 작성한 글이 있는지 반환
      */
     public boolean hasUserCreatedPostToday(String memberId, String familyId, LocalDate today) {
-        return memberPostRepository.existsByMemberIdAndCreatedAt(memberId, familyId, today);
+        return memberPostRepository.existsByMemberIdAndFamilyIdAndCreatedAt(memberId, familyId, today);
     }
 
     @Transactional

--- a/post/src/main/java/com/oing/service/MemberPostService.java
+++ b/post/src/main/java/com/oing/service/MemberPostService.java
@@ -68,8 +68,8 @@ public class MemberPostService {
      * @param today    조회 날짜
      * @return 오늘 회원이 작성한 글이 있는지 반환
      */
-    public boolean hasUserCreatedPostToday(String memberId, LocalDate today) {
-        return memberPostRepository.existsByMemberIdAndCreatedAt(memberId, today);
+    public boolean hasUserCreatedPostToday(String memberId, String familyId, LocalDate today) {
+        return memberPostRepository.existsByMemberIdAndCreatedAt(memberId, familyId, today);
     }
 
     @Transactional

--- a/post/src/test/java/com/oing/controller/MemberPostCommentControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostCommentControllerTest.java
@@ -53,6 +53,7 @@ public class MemberPostCommentControllerTest {
                 "1",
                 "1",
                 "1",
+                "1",
                 "1"
         );
         MemberPostComment memberPostComment = spy(new MemberPostComment(
@@ -82,6 +83,7 @@ public class MemberPostCommentControllerTest {
     void 게시물_댓글_생성_내_가족이_아닌_경우_테스트() {
         //given
         MemberPost memberPost = new MemberPost(
+                "1",
                 "1",
                 "1",
                 "1",
@@ -117,6 +119,7 @@ public class MemberPostCommentControllerTest {
                 "1",
                 "1",
                 "1",
+                "1",
                 "1"
         ));
         MemberPostComment memberPostComment = spy(new MemberPostComment(
@@ -148,6 +151,7 @@ public class MemberPostCommentControllerTest {
                 "1",
                 "1",
                 "1",
+                "1",
                 "1"
         );
         MemberPostComment othersMemberPostComment = new MemberPostComment(
@@ -174,6 +178,7 @@ public class MemberPostCommentControllerTest {
     void 게시물_댓글_수정_테스트() {
         //given
         MemberPost memberPost = new MemberPost(
+                "1",
                 "1",
                 "1",
                 "1",
@@ -212,6 +217,7 @@ public class MemberPostCommentControllerTest {
                 "1",
                 "1",
                 "1",
+                "1",
                 "1"
         );
         MemberPostComment othersMemberPostComment = new MemberPostComment(
@@ -240,6 +246,7 @@ public class MemberPostCommentControllerTest {
     void 게시물_댓글_목록_조회_테스트() {
         //given
         MemberPost memberPost = new MemberPost(
+                "1",
                 "1",
                 "1",
                 "1",

--- a/post/src/test/java/com/oing/controller/MemberPostControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostControllerTest.java
@@ -53,7 +53,7 @@ public class MemberPostControllerTest {
     void 피드_삭제_테스트() {
         // given
         String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1", "1");
 
         // when
         memberPostController.deletePost(post.getId());

--- a/post/src/test/java/com/oing/controller/MemberPostReactionControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostReactionControllerTest.java
@@ -42,7 +42,7 @@ public class MemberPostReactionControllerTest {
         //given
         String memberId = "1";
         when(authenticationHolder.getUserId()).thenReturn(memberId);
-        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1", "1");
         MemberPostReaction reaction = new MemberPostReaction("1", post, memberId, Emoji.EMOJI_1);
         when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
         when(memberPostReactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(false);
@@ -62,7 +62,7 @@ public class MemberPostReactionControllerTest {
         //given
         String memberId = "1";
         when(authenticationHolder.getUserId()).thenReturn(memberId);
-        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1", "1");
         when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
 
         //when
@@ -79,7 +79,7 @@ public class MemberPostReactionControllerTest {
         //given
         String memberId = "1";
         when(authenticationHolder.getUserId()).thenReturn(memberId);
-        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1", "1");
         MemberPostReaction reaction = new MemberPostReaction("1", post, memberId, Emoji.EMOJI_1);
         when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
         when(memberPostReactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(true);
@@ -98,7 +98,7 @@ public class MemberPostReactionControllerTest {
         //given
         String memberId = "1";
         when(authenticationHolder.getUserId()).thenReturn(memberId);
-        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1", "1");
         when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
 
         //when
@@ -114,7 +114,7 @@ public class MemberPostReactionControllerTest {
     void 리액션_남긴_멤버_조회_테스트() {
         //given
         String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "1", "1", "1");
+        MemberPost post = new MemberPost("1", memberId, "1", "1", "1", "1");
         List<MemberPostReaction> mockReactions = Arrays.asList(
                 new MemberPostReaction("1", post, memberId, Emoji.EMOJI_1),
                 new MemberPostReaction("2", post, memberId, Emoji.EMOJI_2)

--- a/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
@@ -59,7 +59,7 @@ public class MemberPostRealEmojiControllerTest {
         String memberId = "1";
         when(authenticationHolder.getUserId()).thenReturn(memberId);
         when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
-        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -84,7 +84,7 @@ public class MemberPostRealEmojiControllerTest {
         // given
         String memberId = "1";
         when(authenticationHolder.getUserId()).thenReturn(memberId);
-        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -105,7 +105,7 @@ public class MemberPostRealEmojiControllerTest {
         String memberId = "1";
         when(authenticationHolder.getUserId()).thenReturn(memberId);
         when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
-        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji realEmoji = new MemberRealEmoji("1",  memberId, Emoji.EMOJI_1,
                 "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -125,7 +125,7 @@ public class MemberPostRealEmojiControllerTest {
     void 게시물_리얼이모지_삭제_테스트() {
         //given
         String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -143,7 +143,7 @@ public class MemberPostRealEmojiControllerTest {
         //given
         String memberId = "1";
         when(authenticationHolder.getUserId()).thenReturn(memberId);
-        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+        MemberPost post = new MemberPost("1", memberId, "1","https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -162,7 +162,7 @@ public class MemberPostRealEmojiControllerTest {
     void 게시물_리얼이모지_요약_조회_테스트() {
         //given
         String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
 
@@ -177,7 +177,7 @@ public class MemberPostRealEmojiControllerTest {
     void 게시물_리얼이모지_목록_조회_테스트() {
         //given
         String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -193,7 +193,7 @@ public class MemberPostRealEmojiControllerTest {
     void 게시물_리얼이모지_멤버_조회_테스트() {
         //given
         String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "https://oing.com/post.jpg", "post.jpg",
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
 

--- a/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostCommentTest.java
@@ -16,12 +16,13 @@ public class MemberPostCommentTest {
         // Given
         String postId = "samplePostId";
         String memberId = "sampleMemberId";
+        String familyId = "sampleFamilyId";
         String imageUrl = "https://picsum.photos/200/300?random=1";
         String imageKey = "/200/300?random=1";
         String content = "밥 맛있다!";
         String commentId = "sampleCommentId";
         String commentContents = "sampleCommentContents";
-        MemberPost post = new MemberPost(postId, memberId, imageUrl, imageKey, content, 0,
+        MemberPost post = new MemberPost(postId, memberId, familyId, imageUrl, imageKey, content, 0,
                 0, 0, null, null, null);
 
         // When

--- a/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostReactionTest.java
@@ -17,12 +17,13 @@ public class MemberPostReactionTest {
         // Given
         String postId = "samplePostId";
         String memberId = "sampleMemberId";
+        String familyId = "sampleFamilyId";
         String imageUrl = "https://picsum.photos/200/300?random=1";
         String imageKey = "/200/300?random=1";
         String content = "밥 맛있다!";
         String reactionId = "sampleCommentId";
         Emoji emoji = Emoji.EMOJI_1;
-        MemberPost post = new MemberPost(postId, memberId, imageUrl, imageKey, content, 0,
+        MemberPost post = new MemberPost(postId, memberId, familyId, imageUrl, imageKey, content, 0,
                 0, 0, null, null, null);
 
         // When

--- a/post/src/test/java/com/oing/domain/model/MemberPostTest.java
+++ b/post/src/test/java/com/oing/domain/model/MemberPostTest.java
@@ -4,8 +4,6 @@ import com.oing.domain.MemberPost;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -17,12 +15,13 @@ public class MemberPostTest {
         // Given
         String postId = "samplePostId";
         String memberId = "sampleMemberId";
+        String familyId = "sampleFamilyId";
         String imageUrl = "https://picsum.photos/200/300?random=1";
         String imageKey = "/200/300?random=1";
         String content = "밥 맛있다!";
 
         // When
-        MemberPost post = new MemberPost(postId, memberId, imageUrl, imageKey, content, 0,
+        MemberPost post = new MemberPost(postId, memberId, familyId, imageUrl, imageKey, content, 0,
                 0, 0, null, null, null);
 
         // Then

--- a/post/src/test/java/com/oing/service/MemberPostCommentServiceTest.java
+++ b/post/src/test/java/com/oing/service/MemberPostCommentServiceTest.java
@@ -53,6 +53,7 @@ public class MemberPostCommentServiceTest {
                 "1",
                 "1",
                 "1",
+                "1",
                 "1"
         );
         MemberPostComment memberPostComment = new MemberPostComment(
@@ -75,6 +76,7 @@ public class MemberPostCommentServiceTest {
     void 게시물_댓글_조회_게시물ID_댓글ID_불일치_테스트() {
         //given
         MemberPost memberPost = new MemberPost(
+                "1",
                 "1",
                 "1",
                 "1",
@@ -130,6 +132,7 @@ public class MemberPostCommentServiceTest {
     void 게시물_댓글_검색_테스트() {
         //given
         MemberPost memberPost = new MemberPost(
+                "1",
                 "1",
                 "1",
                 "1",


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
게시물 생성/조회에서 그룹을 탈퇴한 회원 대응 가능하도록 로직 수정하였습니다.

## ➕ 추가/변경된 기능

---
- 포스트 도메인에 familyId 컬럼 추가
- 게시물 생성에서 그룹을 탈퇴한 회원 대응 가능하도록 로직 수정
  - 탈퇴한 그룹에서 오늘 날짜에 포스트를 작성했어도 새 그룹에서 오늘 날짜에 포스트 작성 가능하도록 수정
- 게시물 조회에서 그룹을 탈퇴한 회원 대응 가능하도록 로직 수정
  - 그룹을 탈퇴한 회원의 글들은 탈퇴한 그룹에서만 보이도록 로직 수정

## 🥺 리뷰어에게 하고싶은 말

---
로직이 바뀜에 따라 테스트코드가 자잘하게 수정되었는데 옳게 수정되었는지 확인해주세요~ 테스트들은 다 통과됩니다.



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-192