### PR TITLE
[OING-194] feat: 회원 프로필 이미지 삭제 API 구현

### DIFF
--- a/gateway/src/test/java/com/oing/restapi/MemberApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberApiTest.java
@@ -52,13 +52,29 @@ public class MemberApiTest {
                         TEST_MEMBER_ID,
                         "testUser1",
                         LocalDate.now(),
-                        "", "", "",
+                        "", "http://test.com/test-profile.jpg", "/test-profile.jpg",
                         LocalDateTime.now()
                 )
         );
         TEST_MEMBER_TOKEN = tokenGenerator
                 .generateTokenPair(TEST_MEMBER_ID)
                 .accessToken();
+    }
+
+    @Test
+    void 회원_프로필이미지_삭제_테스트() throws Exception {
+        // given
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/v1/members/profile-image-url/{memberId}", TEST_MEMBER_ID)
+                        .header("X-AUTH-TOKEN", TEST_MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -68,6 +68,16 @@ public class MemberController implements MemberApi {
 
     @Override
     @Transactional
+    public MemberResponse deleteMemberProfileImageUrl(String memberId) {
+        validateMemberId(memberId);
+        Member member = memberService.findMemberById(memberId);
+        member.deleteProfileImg();
+
+        return MemberResponse.of(member);
+    }
+
+    @Override
+    @Transactional
     public MemberResponse updateMemberName(String memberId, UpdateMemberNameRequest request) {
         validateMemberId(memberId);
         Member member = memberService.findMemberById(memberId);

--- a/member/src/main/java/com/oing/domain/Member.java
+++ b/member/src/main/java/com/oing/domain/Member.java
@@ -54,6 +54,11 @@ public class Member extends DeletableBaseAuditEntity {
         this.profileImgKey = profileImgKey;
     }
 
+    public void deleteProfileImg() {
+        this.profileImgUrl = null;
+        this.profileImgKey = null;
+    }
+
     public void updateName(String name) {
         this.name = name;
     }

--- a/member/src/main/java/com/oing/restapi/MemberApi.java
+++ b/member/src/main/java/com/oing/restapi/MemberApi.java
@@ -61,6 +61,14 @@ public interface MemberApi {
             UpdateMemberProfileImageUrlRequest request
     );
 
+    @Operation(summary = "회원 프로필 이미지 삭제", description = "회원 프로필 이미지를 삭제합니다.")
+    @DeleteMapping("/profile-image-url/{memberId}")
+    MemberResponse deleteMemberProfileImageUrl(
+            @Parameter(description = "프로필 이미지를 삭제할 회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String memberId
+    );
+
     @Operation(summary = "회원 이름 수정", description = "회원 이름을 수정합니다.")
     @PutMapping("/name/{memberId}")
     MemberResponse updateMemberName(

--- a/member/src/test/java/com/oing/controller/MemberControllerTest.java
+++ b/member/src/test/java/com/oing/controller/MemberControllerTest.java
@@ -179,6 +179,23 @@ public class MemberControllerTest {
     }
 
     @Test
+    void 멤버_프로필이미지_삭제_테스트() {
+        // given
+        Member member = new Member("1", "1", LocalDate.of(2000, 7, 8),
+                "testMember1", "http://test.com/test-profile.jpg", null,
+                LocalDateTime.now());
+        when(memberService.findMemberById(any())).thenReturn(member);
+        when(authenticationHolder.getUserId()).thenReturn("1");
+
+        // when
+        memberController.deleteMemberProfileImageUrl(member.getId());
+
+        // then
+        assertEquals(null, member.getProfileImgUrl());
+        assertEquals(null, member.getProfileImgKey());
+    }
+
+    @Test
     void 멤버_탈퇴_테스트() {
         // given
         Member member = new Member("1", "1", LocalDate.of(2000, 7, 8),


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
프론트의 요청으로 회원 프로필 이미지 삭제 API를 추가했습니다.

## ➕ 추가/변경된 기능

---
- 회원 프로필 이미지 삭제 API 구현
- 회원 프로필 이미지 삭제 테스트코드 추가

## 🥺 리뷰어에게 하고싶은 말

---
프로필 이미지 삭제 로직 안에서 해당 회원의 프로필 이미지가 설정되어 있는지 검증하는 로직은 필요없다 생각하여 뺐는데 필요하다면 알려주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-194