### PR TITLE
[OING-193] feat: 회원 리얼이모지 familyId 컬럼 추가 및 로직 수정

### DIFF
--- a/gateway/src/main/resources/db/migration/V202402071837__add_familyId_column_to_MemberRealEmoji.sql
+++ b/gateway/src/main/resources/db/migration/V202402071837__add_familyId_column_to_MemberRealEmoji.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `member_real_emoji` ADD COLUMN (`family_id` CHAR(26) NOT NULL DEFAULT '0' COMMENT 'ULID');
+UPDATE member_real_emoji JOIN member ON member_real_emoji.member_id = member.member_id
+SET member_real_emoji.family_id = member.family_id;

--- a/gateway/src/test/java/com/oing/restapi/MemberPostRealEmojiApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostRealEmojiApiTest.java
@@ -56,7 +56,7 @@ public class MemberPostRealEmojiApiTest {
 
     @BeforeEach
     void setUp() {
-        memberRepository.save(new Member(TEST_MEMBER_ID, "testUser1", LocalDate.now(), "",
+        memberRepository.save(new Member(TEST_MEMBER_ID, TEST_FAMILY_ID, LocalDate.now(), "",
                 "", "",
                 LocalDateTime.now()));
         TEST_MEMBER_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER_ID).accessToken();
@@ -64,7 +64,7 @@ public class MemberPostRealEmojiApiTest {
         memberPostRepository.save(new MemberPost(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, "img", "img",
                 "content"));
 
-        memberRealEmojiRepository.save(new MemberRealEmoji(TEST_REAL_EMOJI_ID, TEST_MEMBER_ID, Emoji.EMOJI_1,
+        memberRealEmojiRepository.save(new MemberRealEmoji(TEST_REAL_EMOJI_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, Emoji.EMOJI_1,
                 "https://test.com/bucket/real-emoji.jpg", "bucket/real-emoji.jpg"));
 
     }

--- a/gateway/src/test/java/com/oing/restapi/MemberRealEmojiApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberRealEmojiApiTest.java
@@ -42,6 +42,7 @@ public class MemberRealEmojiApiTest {
     private ObjectMapper objectMapper;
 
     private String TEST_MEMBER_ID = "01HGW2N7EHJVJ4CJ999RRS2E97";
+    private String TEST_FAMILY_ID = "01HGW2N7EHJVJ4CJ999RRS2E44";
     private String TEST_MEMBER_REAL_EMOJI_ID = "01HGW2N7EHJVJ4CJ999RRS2A97";
     private String TEST_MEMBER_TOKEN;
 
@@ -55,7 +56,7 @@ public class MemberRealEmojiApiTest {
         memberRepository.save(
                 new Member(
                         TEST_MEMBER_ID,
-                        "testUser1",
+                        TEST_FAMILY_ID,
                         LocalDate.now(),
                         "", "", "",
                         LocalDateTime.now()
@@ -116,6 +117,7 @@ public class MemberRealEmojiApiTest {
                 new MemberRealEmoji(
                         TEST_MEMBER_REAL_EMOJI_ID,
                         TEST_MEMBER_ID,
+                        TEST_FAMILY_ID,
                         Emoji.EMOJI_1,
                         "https://test.com/bucket/images/defaultEmoji.jpg",
                         "images/defaultEmoji.jpg"
@@ -144,6 +146,7 @@ public class MemberRealEmojiApiTest {
                 new MemberRealEmoji(
                         TEST_MEMBER_REAL_EMOJI_ID,
                         TEST_MEMBER_ID,
+                        TEST_FAMILY_ID,
                         Emoji.EMOJI_1,
                         realEmojiImageUrl,
                         "images/defaultEmoji.jpg"

--- a/member/src/main/java/com/oing/domain/Member.java
+++ b/member/src/main/java/com/oing/domain/Member.java
@@ -44,10 +44,6 @@ public class Member extends DeletableBaseAuditEntity {
     private LocalDateTime familyJoinAt;
 
 
-    public void setProfileImgKey(String profileImgKey) {
-        this.profileImgKey = profileImgKey;
-    }
-
 
     public void updateProfileImg(String profileImgUrl, String profileImgKey) {
         this.profileImgUrl = profileImgUrl;

--- a/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
@@ -47,11 +47,12 @@ public class MemberPostRealEmojiController implements MemberPostRealEmojiApi {
     @Override
     public PostRealEmojiResponse createPostRealEmoji(String postId, PostRealEmojiRequest request) {
         String memberId = authenticationHolder.getUserId();
+        String familyId = memberBridge.getFamilyIdByMemberId(memberId);
         MemberPost post = memberPostService.getMemberPostById(postId);
         if (!memberBridge.isInSameFamily(memberId, post.getMemberId()))
             throw new AuthorizationFailedException();
 
-        MemberRealEmoji realEmoji = memberRealEmojiService.getMemberRealEmojiById(request.realEmojiId());
+        MemberRealEmoji realEmoji = memberRealEmojiService.getMemberRealEmojiByIdAndFamilyId(request.realEmojiId(), familyId);
         validatePostRealEmojiForAddition(post, memberId, realEmoji);
         MemberPostRealEmoji postRealEmoji = new MemberPostRealEmoji(identityGenerator.generateIdentity(), realEmoji,
                 post, memberId);

--- a/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberPostRealEmojiController.java
@@ -45,9 +45,8 @@ public class MemberPostRealEmojiController implements MemberPostRealEmojiApi {
      */
     @Transactional
     @Override
-    public PostRealEmojiResponse createPostRealEmoji(String postId, PostRealEmojiRequest request) {
+    public PostRealEmojiResponse createPostRealEmoji(String postId, String familyId, PostRealEmojiRequest request) {
         String memberId = authenticationHolder.getUserId();
-        String familyId = memberBridge.getFamilyIdByMemberId(memberId);
         MemberPost post = memberPostService.getMemberPostById(postId);
         if (!memberBridge.isInSameFamily(memberId, post.getMemberId()))
             throw new AuthorizationFailedException();

--- a/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
+++ b/post/src/main/java/com/oing/controller/MemberRealEmojiController.java
@@ -12,7 +12,6 @@ import com.oing.dto.response.RealEmojisResponse;
 import com.oing.exception.AuthorizationFailedException;
 import com.oing.exception.DuplicateRealEmojiException;
 import com.oing.restapi.MemberRealEmojiApi;
-import com.oing.service.MemberBridge;
 import com.oing.service.MemberRealEmojiService;
 import com.oing.util.AuthenticationHolder;
 import com.oing.util.IdentityGenerator;
@@ -31,7 +30,6 @@ public class MemberRealEmojiController implements MemberRealEmojiApi {
     private final AuthenticationHolder authenticationHolder;
     private final IdentityGenerator identityGenerator;
     private final PreSignedUrlGenerator preSignedUrlGenerator;
-    private final MemberBridge memberBridge;
     private final MemberRealEmojiService memberRealEmojiService;
 
     @Transactional
@@ -44,9 +42,8 @@ public class MemberRealEmojiController implements MemberRealEmojiApi {
 
     @Transactional
     @Override
-    public RealEmojiResponse createMemberRealEmoji(String memberId, CreateMyRealEmojiRequest request) {
+    public RealEmojiResponse createMemberRealEmoji(String memberId, String familyId, CreateMyRealEmojiRequest request) {
         validateMemberId(memberId);
-        String familyId = memberBridge.getFamilyIdByMemberId(memberId);
         String emojiId = identityGenerator.generateIdentity();
         String emojiImgKey = preSignedUrlGenerator.extractImageKey(request.imageUrl());
         Emoji emoji = Emoji.fromString(request.type());
@@ -65,9 +62,8 @@ public class MemberRealEmojiController implements MemberRealEmojiApi {
 
     @Transactional
     @Override
-    public RealEmojiResponse changeMemberRealEmoji(String memberId, String realEmojiId, UpdateMyRealEmojiRequest request) {
+    public RealEmojiResponse changeMemberRealEmoji(String memberId, String familyId, String realEmojiId, UpdateMyRealEmojiRequest request) {
         validateMemberId(memberId);
-        String familyId = memberBridge.getFamilyIdByMemberId(memberId);
         String emojiImgKey = preSignedUrlGenerator.extractImageKey(request.imageUrl());
 
         MemberRealEmoji findEmoji = memberRealEmojiService.getMemberRealEmojiByIdAndFamilyId(realEmojiId, familyId);
@@ -76,9 +72,8 @@ public class MemberRealEmojiController implements MemberRealEmojiApi {
     }
 
     @Override
-    public RealEmojisResponse getMemberRealEmojis(String memberId) {
+    public RealEmojisResponse getMemberRealEmojis(String memberId, String familyId) {
         validateMemberId(memberId);
-        String familyId = memberBridge.getFamilyIdByMemberId(memberId);
 
         List<MemberRealEmoji> realEmojis = memberRealEmojiService.findRealEmojisByMemberIdAndFamilyId(memberId, familyId);
         List<RealEmojiResponse> emojiResponses = realEmojis.stream()

--- a/post/src/main/java/com/oing/domain/MemberRealEmoji.java
+++ b/post/src/main/java/com/oing/domain/MemberRealEmoji.java
@@ -20,6 +20,9 @@ public class MemberRealEmoji extends BaseAuditEntity {
     @Column(name = "member_id", columnDefinition = "CHAR(26)", nullable = false)
     private String memberId;
 
+    @Column(name = "family_id", columnDefinition = "CHAR(26)", nullable = false)
+    private String familyId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private Emoji type;

--- a/post/src/main/java/com/oing/repository/MemberRealEmojiRepository.java
+++ b/post/src/main/java/com/oing/repository/MemberRealEmojiRepository.java
@@ -9,7 +9,9 @@ import java.util.Optional;
 
 public interface MemberRealEmojiRepository extends JpaRepository<MemberRealEmoji, String> {
 
-    Optional<MemberRealEmoji> findByTypeAndMemberId(Emoji emoji, String memberId);
+    Optional<MemberRealEmoji> findByIdAndFamilyId(String realEmojiId, String familyId);
 
-    List<MemberRealEmoji> findAllByMemberId(String memberId);
+    Optional<MemberRealEmoji> findByTypeAndMemberIdAndFamilyId(Emoji emoji, String memberId, String familyId);
+
+    List<MemberRealEmoji> findAllByMemberIdAndFamilyId(String memberId, String familyId);
 }

--- a/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostRealEmojiApi.java
@@ -2,6 +2,7 @@ package com.oing.restapi;
 
 import com.oing.dto.request.PostRealEmojiRequest;
 import com.oing.dto.response.*;
+import com.oing.util.security.FamilyId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,6 +21,10 @@ public interface MemberPostRealEmojiApi {
             @Parameter(description = "게시물 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String postId,
+
+            @Parameter(hidden = true)
+            @FamilyId
+            String familyId,
 
             @Valid
             @RequestBody

--- a/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberRealEmojiApi.java
@@ -6,6 +6,7 @@ import com.oing.dto.request.UpdateMyRealEmojiRequest;
 import com.oing.dto.response.PreSignedUrlResponse;
 import com.oing.dto.response.RealEmojiResponse;
 import com.oing.dto.response.RealEmojisResponse;
+import com.oing.util.security.FamilyId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,6 +38,10 @@ public interface MemberRealEmojiApi {
             @PathVariable
             String memberId,
 
+            @Parameter(hidden = true)
+            @FamilyId
+            String familyId,
+
             @Valid
             @RequestBody
             CreateMyRealEmojiRequest request
@@ -48,6 +53,10 @@ public interface MemberRealEmojiApi {
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
             String memberId,
+
+            @Parameter(hidden = true)
+            @FamilyId
+            String familyId,
 
             @Parameter(description = "리얼 이모지 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
@@ -63,6 +72,10 @@ public interface MemberRealEmojiApi {
     RealEmojisResponse getMemberRealEmojis(
             @Parameter(description = "회원 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             @PathVariable
-            String memberId
+            String memberId,
+
+            @Parameter(hidden = true)
+            @FamilyId
+            String familyId
     );
 }

--- a/post/src/main/java/com/oing/service/MemberRealEmojiService.java
+++ b/post/src/main/java/com/oing/service/MemberRealEmojiService.java
@@ -16,8 +16,9 @@ public class MemberRealEmojiService {
     private final MemberRealEmojiRepository memberRealEmojiRepository;
 
 
-    public MemberRealEmoji getMemberRealEmojiById(String realEmojiId) {
-        return memberRealEmojiRepository.findById(realEmojiId)
+    public MemberRealEmoji getMemberRealEmojiByIdAndFamilyId(String realEmojiId, String familyId) {
+        return memberRealEmojiRepository
+                .findByIdAndFamilyId(realEmojiId, familyId)
                 .orElseThrow(RealEmojiNotFoundException::new);
     }
 
@@ -25,20 +26,14 @@ public class MemberRealEmojiService {
         return memberRealEmojiRepository.save(emoji);
     }
 
-    public MemberRealEmoji findRealEmojiById(String realEmojiId) {
+    public boolean findRealEmojiByEmojiTypeAndMemberIdAndFamilyId(Emoji emoji, String memberId, String familyId) {
         return memberRealEmojiRepository
-                .findById(realEmojiId)
-                .orElseThrow(RealEmojiNotFoundException::new);
-    }
-
-    public boolean findRealEmojiByEmojiTypeAndMemberId(Emoji emoji, String memberId) {
-        return memberRealEmojiRepository
-                .findByTypeAndMemberId(emoji, memberId)
+                .findByTypeAndMemberIdAndFamilyId(emoji, memberId, familyId)
                 .isPresent();
     }
 
-    public List<MemberRealEmoji> findRealEmojisByMemberId(String memberId) {
-        return memberRealEmojiRepository.findAllByMemberId(memberId);
+    public List<MemberRealEmoji> findRealEmojisByMemberIdAndFamilyId(String memberId, String familyId) {
+        return memberRealEmojiRepository.findAllByMemberIdAndFamilyId(memberId, familyId);
     }
 
 }

--- a/post/src/main/java/com/oing/service/MemberRealEmojiService.java
+++ b/post/src/main/java/com/oing/service/MemberRealEmojiService.java
@@ -35,5 +35,4 @@ public class MemberRealEmojiService {
     public List<MemberRealEmoji> findRealEmojisByMemberIdAndFamilyId(String memberId, String familyId) {
         return memberRealEmojiRepository.findAllByMemberIdAndFamilyId(memberId, familyId);
     }
-
 }

--- a/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
@@ -1,206 +1,211 @@
-//package com.oing.controller;
-//
-//import com.oing.domain.Emoji;
-//import com.oing.domain.MemberPost;
-//import com.oing.domain.MemberPostRealEmoji;
-//import com.oing.domain.MemberRealEmoji;
-//import com.oing.dto.request.PostRealEmojiRequest;
-//import com.oing.dto.response.ArrayResponse;
-//import com.oing.dto.response.PostRealEmojiMemberResponse;
-//import com.oing.dto.response.PostRealEmojiResponse;
-//import com.oing.dto.response.PostRealEmojiSummaryResponse;
-//import com.oing.exception.AuthorizationFailedException;
-//import com.oing.exception.RealEmojiAlreadyExistsException;
-//import com.oing.exception.RegisteredRealEmojiNotFoundException;
-//import com.oing.service.MemberBridge;
-//import com.oing.service.MemberPostRealEmojiService;
-//import com.oing.service.MemberPostService;
-//import com.oing.service.MemberRealEmojiService;
-//import com.oing.util.AuthenticationHolder;
-//import com.oing.util.IdentityGenerator;
-//import jakarta.transaction.Transactional;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.test.context.ActiveProfiles;
-//
-//import java.util.List;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.when;
-//
-//@Transactional
-//@ActiveProfiles("test")
-//@ExtendWith(MockitoExtension.class)
-//public class MemberPostRealEmojiControllerTest {
-//    @InjectMocks
-//    private MemberPostRealEmojiController memberPostRealEmojiController;
-//
-//    @Mock
-//    private AuthenticationHolder authenticationHolder;
-//    @Mock
-//    private IdentityGenerator identityGenerator;
-//    @Mock
-//    private MemberPostService memberPostService;
-//    @Mock
-//    private MemberPostRealEmojiService memberPostRealEmojiService;
-//    @Mock
-//    private MemberRealEmojiService memberRealEmojiService;
-//    @Mock
-//    private MemberBridge memberBridge;
-//
-//    @Test
-//    void 게시물_리얼이모지_등록_테스트() {
-//        //given
-//        String memberId = "1";
-//        when(authenticationHolder.getUserId()).thenReturn(memberId);
-//        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
-//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-//                "안녕.오잉.");
-//        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
-//                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-//        when(memberRealEmojiService.getMemberRealEmojiById(realEmoji.getId())).thenReturn(realEmoji);
-//
-//        MemberPostRealEmoji postRealEmoji = new MemberPostRealEmoji("1", realEmoji, post, memberId);
-//        when(memberPostRealEmojiService.savePostRealEmoji(any(MemberPostRealEmoji.class))).thenReturn(postRealEmoji);
-//        when(identityGenerator.generateIdentity()).thenReturn(postRealEmoji.getId());
-//        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
-//
-//        //when
-//        PostRealEmojiResponse response = memberPostRealEmojiController.createPostRealEmoji(post.getId(), request);
-//
-//        //then
-//        assertEquals(post.getId(), response.postId());
-//        assertEquals(request.realEmojiId(), response.realEmojiId());
-//    }
-//
-//    @Test
-//    void 권한없는_memberId로_게시물_리얼이모지_등록_예외_테스트() {
-//        // given
-//        String memberId = "1";
-//        when(authenticationHolder.getUserId()).thenReturn(memberId);
-//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-//                "안녕.오잉.");
-//        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
-//                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-//
-//        //when
-//        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(false);
-//        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
-//
-//        // then
-//        assertThrows(AuthorizationFailedException.class,
-//                () -> memberPostRealEmojiController.createPostRealEmoji(post.getId(), request));
-//    }
-//
-//    @Test
-//    void 게시물_중복된_리얼이모지_등록_예외_테스트() {
-//        //given
-//        String memberId = "1";
-//        when(authenticationHolder.getUserId()).thenReturn(memberId);
-//        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
-//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-//                "안녕.오잉.");
-//        MemberRealEmoji realEmoji = new MemberRealEmoji("1",  memberId, Emoji.EMOJI_1,
-//                "https://oing.com/emoji.jpg", "emoji.jpg");
-//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-//        when(memberRealEmojiService.getMemberRealEmojiById(realEmoji.getId())).thenReturn(realEmoji);
-//
-//        //when
-//        when(memberPostRealEmojiService.isMemberPostRealEmojiExists(post, memberId, realEmoji)).thenReturn(true);
-//        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
-//
-//        //then
-//        assertThrows(RealEmojiAlreadyExistsException.class,
-//                () -> memberPostRealEmojiController.createPostRealEmoji(post.getId(), request));
-//    }
-//
-//    @Test
-//    void 게시물_리얼이모지_삭제_테스트() {
-//        //given
-//        String memberId = "1";
-//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-//                "안녕.오잉.");
-//        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
-//                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-//
-//        //when
-//        memberPostRealEmojiController.deletePostRealEmoji(post.getId(), realEmoji.getId());
-//
-//        //then
-//        //nothing. just check no exception
-//    }
-//
-//    @Test
-//    void 게시물_등록되지_않은_리얼이모지_삭제_예외_테스트() {
-//        //given
-//        String memberId = "1";
-//        when(authenticationHolder.getUserId()).thenReturn(memberId);
-//        MemberPost post = new MemberPost("1", memberId, "1","https://oing.com/post.jpg", "post.jpg",
-//                "안녕.오잉.");
-//        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
-//                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-//
-//        //when
-//        when(memberPostRealEmojiService.getMemberPostRealEmojiByRealEmojiIdAndMemberIdAndPostId("1", memberId, post.getId()))
-//                .thenThrow(RegisteredRealEmojiNotFoundException.class);
-//
-//        //then
-//        assertThrows(RegisteredRealEmojiNotFoundException.class,
-//                () -> memberPostRealEmojiController.deletePostRealEmoji(post.getId(), realEmoji.getId()));
-//    }
-//
-//    @Test
-//    void 게시물_리얼이모지_요약_조회_테스트() {
-//        //given
-//        String memberId = "1";
-//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-//                "안녕.오잉.");
-//        when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
-//
-//        //when
-//        PostRealEmojiSummaryResponse summary = memberPostRealEmojiController.getPostRealEmojiSummary(post.getId());
-//
-//        //then
-//        assertEquals(0, summary.results().size());
-//    }
-//
-//    @Test
-//    void 게시물_리얼이모지_목록_조회_테스트() {
-//        //given
-//        String memberId = "1";
-//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-//                "안녕.오잉.");
-//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-//
-//        //when
-//        ArrayResponse<PostRealEmojiResponse> response = memberPostRealEmojiController.getPostRealEmojis(post.getId());
-//
-//        //then
-//        assertEquals(0, response.results().size());
-//        assertEquals(List.of(), response.results());
-//    }
-//
-//    @Test
-//    void 게시물_리얼이모지_멤버_조회_테스트() {
-//        //given
-//        String memberId = "1";
-//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-//                "안녕.오잉.");
-//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-//
-//        //when
-//        PostRealEmojiMemberResponse response = memberPostRealEmojiController.getPostRealEmojiMembers(post.getId());
-//
-//        //then
-//        assertEquals(0, response.emojiMemberIdsList().size());
-//    }
-//}
+package com.oing.controller;
+
+import com.oing.domain.Emoji;
+import com.oing.domain.MemberPost;
+import com.oing.domain.MemberPostRealEmoji;
+import com.oing.domain.MemberRealEmoji;
+import com.oing.dto.request.PostRealEmojiRequest;
+import com.oing.dto.response.ArrayResponse;
+import com.oing.dto.response.PostRealEmojiMemberResponse;
+import com.oing.dto.response.PostRealEmojiResponse;
+import com.oing.dto.response.PostRealEmojiSummaryResponse;
+import com.oing.exception.AuthorizationFailedException;
+import com.oing.exception.RealEmojiAlreadyExistsException;
+import com.oing.exception.RegisteredRealEmojiNotFoundException;
+import com.oing.service.MemberBridge;
+import com.oing.service.MemberPostRealEmojiService;
+import com.oing.service.MemberPostService;
+import com.oing.service.MemberRealEmojiService;
+import com.oing.util.AuthenticationHolder;
+import com.oing.util.IdentityGenerator;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@Transactional
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class MemberPostRealEmojiControllerTest {
+    @InjectMocks
+    private MemberPostRealEmojiController memberPostRealEmojiController;
+
+    @Mock
+    private AuthenticationHolder authenticationHolder;
+    @Mock
+    private IdentityGenerator identityGenerator;
+    @Mock
+    private MemberPostService memberPostService;
+    @Mock
+    private MemberPostRealEmojiService memberPostRealEmojiService;
+    @Mock
+    private MemberRealEmojiService memberRealEmojiService;
+    @Mock
+    private MemberBridge memberBridge;
+
+    @Test
+    void 게시물_리얼이모지_등록_테스트() {
+        //given
+        String memberId = "1";
+        String familyId = "1";
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
+        MemberPost post = new MemberPost("1", memberId, familyId, "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
+                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
+        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+        when(memberRealEmojiService.getMemberRealEmojiByIdAndFamilyId(realEmoji.getId(), familyId)).thenReturn(realEmoji);
+
+        MemberPostRealEmoji postRealEmoji = new MemberPostRealEmoji("1", realEmoji, post, memberId);
+        when(memberPostRealEmojiService.savePostRealEmoji(any(MemberPostRealEmoji.class))).thenReturn(postRealEmoji);
+        when(identityGenerator.generateIdentity()).thenReturn(postRealEmoji.getId());
+        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
+
+        //when
+        PostRealEmojiResponse response = memberPostRealEmojiController.createPostRealEmoji(post.getId(), familyId, request);
+
+        //then
+        assertEquals(post.getId(), response.postId());
+        assertEquals(request.realEmojiId(), response.realEmojiId());
+    }
+
+    @Test
+    void 권한없는_memberId로_게시물_리얼이모지_등록_예외_테스트() {
+        // given
+        String memberId = "1";
+        String familyId = "1";
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        MemberPost post = new MemberPost("1", memberId, familyId, "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
+                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
+        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(false);
+        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
+
+        // then
+        assertThrows(AuthorizationFailedException.class,
+                () -> memberPostRealEmojiController.createPostRealEmoji(post.getId(), familyId, request));
+    }
+
+    @Test
+    void 게시물_중복된_리얼이모지_등록_예외_테스트() {
+        //given
+        String memberId = "1";
+        String familyId = "1";
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
+        MemberPost post = new MemberPost("1", memberId, familyId, "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        MemberRealEmoji realEmoji = new MemberRealEmoji("1",  memberId, familyId, Emoji.EMOJI_1,
+                "https://oing.com/emoji.jpg", "emoji.jpg");
+        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+        when(memberRealEmojiService.getMemberRealEmojiByIdAndFamilyId(realEmoji.getId(), familyId)).thenReturn(realEmoji);
+
+        //when
+        when(memberPostRealEmojiService.isMemberPostRealEmojiExists(post, memberId, realEmoji)).thenReturn(true);
+        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
+
+        //then
+        assertThrows(RealEmojiAlreadyExistsException.class,
+                () -> memberPostRealEmojiController.createPostRealEmoji(post.getId(), familyId, request));
+    }
+
+    @Test
+    void 게시물_리얼이모지_삭제_테스트() {
+        //given
+        String memberId = "1";
+        String familyId = "1";
+        MemberPost post = new MemberPost("1", memberId, familyId, "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
+                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
+        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        memberPostRealEmojiController.deletePostRealEmoji(post.getId(), realEmoji.getId());
+
+        //then
+        //nothing. just check no exception
+    }
+
+    @Test
+    void 게시물_등록되지_않은_리얼이모지_삭제_예외_테스트() {
+        //given
+        String memberId = "1";
+        String familyId = "1";
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        MemberPost post = new MemberPost("1", memberId, familyId,"https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
+                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
+        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        when(memberPostRealEmojiService.getMemberPostRealEmojiByRealEmojiIdAndMemberIdAndPostId("1", memberId, post.getId()))
+                .thenThrow(RegisteredRealEmojiNotFoundException.class);
+
+        //then
+        assertThrows(RegisteredRealEmojiNotFoundException.class,
+                () -> memberPostRealEmojiController.deletePostRealEmoji(post.getId(), realEmoji.getId()));
+    }
+
+    @Test
+    void 게시물_리얼이모지_요약_조회_테스트() {
+        //given
+        String memberId = "1";
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        PostRealEmojiSummaryResponse summary = memberPostRealEmojiController.getPostRealEmojiSummary(post.getId());
+
+        //then
+        assertEquals(0, summary.results().size());
+    }
+
+    @Test
+    void 게시물_리얼이모지_목록_조회_테스트() {
+        //given
+        String memberId = "1";
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        ArrayResponse<PostRealEmojiResponse> response = memberPostRealEmojiController.getPostRealEmojis(post.getId());
+
+        //then
+        assertEquals(0, response.results().size());
+        assertEquals(List.of(), response.results());
+    }
+
+    @Test
+    void 게시물_리얼이모지_멤버_조회_테스트() {
+        //given
+        String memberId = "1";
+        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+                "안녕.오잉.");
+        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+
+        //when
+        PostRealEmojiMemberResponse response = memberPostRealEmojiController.getPostRealEmojiMembers(post.getId());
+
+        //then
+        assertEquals(0, response.emojiMemberIdsList().size());
+    }
+}

--- a/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostRealEmojiControllerTest.java
@@ -1,206 +1,206 @@
-package com.oing.controller;
-
-import com.oing.domain.Emoji;
-import com.oing.domain.MemberPost;
-import com.oing.domain.MemberPostRealEmoji;
-import com.oing.domain.MemberRealEmoji;
-import com.oing.dto.request.PostRealEmojiRequest;
-import com.oing.dto.response.ArrayResponse;
-import com.oing.dto.response.PostRealEmojiMemberResponse;
-import com.oing.dto.response.PostRealEmojiResponse;
-import com.oing.dto.response.PostRealEmojiSummaryResponse;
-import com.oing.exception.AuthorizationFailedException;
-import com.oing.exception.RealEmojiAlreadyExistsException;
-import com.oing.exception.RegisteredRealEmojiNotFoundException;
-import com.oing.service.MemberBridge;
-import com.oing.service.MemberPostRealEmojiService;
-import com.oing.service.MemberPostService;
-import com.oing.service.MemberRealEmojiService;
-import com.oing.util.AuthenticationHolder;
-import com.oing.util.IdentityGenerator;
-import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.context.ActiveProfiles;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
-@Transactional
-@ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
-public class MemberPostRealEmojiControllerTest {
-    @InjectMocks
-    private MemberPostRealEmojiController memberPostRealEmojiController;
-
-    @Mock
-    private AuthenticationHolder authenticationHolder;
-    @Mock
-    private IdentityGenerator identityGenerator;
-    @Mock
-    private MemberPostService memberPostService;
-    @Mock
-    private MemberPostRealEmojiService memberPostRealEmojiService;
-    @Mock
-    private MemberRealEmojiService memberRealEmojiService;
-    @Mock
-    private MemberBridge memberBridge;
-
-    @Test
-    void 게시물_리얼이모지_등록_테스트() {
-        //given
-        String memberId = "1";
-        when(authenticationHolder.getUserId()).thenReturn(memberId);
-        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
-        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-                "안녕.오잉.");
-        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
-                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-        when(memberRealEmojiService.getMemberRealEmojiById(realEmoji.getId())).thenReturn(realEmoji);
-
-        MemberPostRealEmoji postRealEmoji = new MemberPostRealEmoji("1", realEmoji, post, memberId);
-        when(memberPostRealEmojiService.savePostRealEmoji(any(MemberPostRealEmoji.class))).thenReturn(postRealEmoji);
-        when(identityGenerator.generateIdentity()).thenReturn(postRealEmoji.getId());
-        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
-
-        //when
-        PostRealEmojiResponse response = memberPostRealEmojiController.createPostRealEmoji(post.getId(), request);
-
-        //then
-        assertEquals(post.getId(), response.postId());
-        assertEquals(request.realEmojiId(), response.realEmojiId());
-    }
-
-    @Test
-    void 권한없는_memberId로_게시물_리얼이모지_등록_예외_테스트() {
-        // given
-        String memberId = "1";
-        when(authenticationHolder.getUserId()).thenReturn(memberId);
-        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-                "안녕.오잉.");
-        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
-                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-
-        //when
-        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(false);
-        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
-
-        // then
-        assertThrows(AuthorizationFailedException.class,
-                () -> memberPostRealEmojiController.createPostRealEmoji(post.getId(), request));
-    }
-
-    @Test
-    void 게시물_중복된_리얼이모지_등록_예외_테스트() {
-        //given
-        String memberId = "1";
-        when(authenticationHolder.getUserId()).thenReturn(memberId);
-        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
-        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-                "안녕.오잉.");
-        MemberRealEmoji realEmoji = new MemberRealEmoji("1",  memberId, Emoji.EMOJI_1,
-                "https://oing.com/emoji.jpg", "emoji.jpg");
-        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-        when(memberRealEmojiService.getMemberRealEmojiById(realEmoji.getId())).thenReturn(realEmoji);
-
-        //when
-        when(memberPostRealEmojiService.isMemberPostRealEmojiExists(post, memberId, realEmoji)).thenReturn(true);
-        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
-
-        //then
-        assertThrows(RealEmojiAlreadyExistsException.class,
-                () -> memberPostRealEmojiController.createPostRealEmoji(post.getId(), request));
-    }
-
-    @Test
-    void 게시물_리얼이모지_삭제_테스트() {
-        //given
-        String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-                "안녕.오잉.");
-        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
-                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-
-        //when
-        memberPostRealEmojiController.deletePostRealEmoji(post.getId(), realEmoji.getId());
-
-        //then
-        //nothing. just check no exception
-    }
-
-    @Test
-    void 게시물_등록되지_않은_리얼이모지_삭제_예외_테스트() {
-        //given
-        String memberId = "1";
-        when(authenticationHolder.getUserId()).thenReturn(memberId);
-        MemberPost post = new MemberPost("1", memberId, "1","https://oing.com/post.jpg", "post.jpg",
-                "안녕.오잉.");
-        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
-                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-
-        //when
-        when(memberPostRealEmojiService.getMemberPostRealEmojiByRealEmojiIdAndMemberIdAndPostId("1", memberId, post.getId()))
-                .thenThrow(RegisteredRealEmojiNotFoundException.class);
-
-        //then
-        assertThrows(RegisteredRealEmojiNotFoundException.class,
-                () -> memberPostRealEmojiController.deletePostRealEmoji(post.getId(), realEmoji.getId()));
-    }
-
-    @Test
-    void 게시물_리얼이모지_요약_조회_테스트() {
-        //given
-        String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-                "안녕.오잉.");
-        when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
-
-        //when
-        PostRealEmojiSummaryResponse summary = memberPostRealEmojiController.getPostRealEmojiSummary(post.getId());
-
-        //then
-        assertEquals(0, summary.results().size());
-    }
-
-    @Test
-    void 게시물_리얼이모지_목록_조회_테스트() {
-        //given
-        String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-                "안녕.오잉.");
-        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-
-        //when
-        ArrayResponse<PostRealEmojiResponse> response = memberPostRealEmojiController.getPostRealEmojis(post.getId());
-
-        //then
-        assertEquals(0, response.results().size());
-        assertEquals(List.of(), response.results());
-    }
-
-    @Test
-    void 게시물_리얼이모지_멤버_조회_테스트() {
-        //given
-        String memberId = "1";
-        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
-                "안녕.오잉.");
-        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
-
-        //when
-        PostRealEmojiMemberResponse response = memberPostRealEmojiController.getPostRealEmojiMembers(post.getId());
-
-        //then
-        assertEquals(0, response.emojiMemberIdsList().size());
-    }
-}
+//package com.oing.controller;
+//
+//import com.oing.domain.Emoji;
+//import com.oing.domain.MemberPost;
+//import com.oing.domain.MemberPostRealEmoji;
+//import com.oing.domain.MemberRealEmoji;
+//import com.oing.dto.request.PostRealEmojiRequest;
+//import com.oing.dto.response.ArrayResponse;
+//import com.oing.dto.response.PostRealEmojiMemberResponse;
+//import com.oing.dto.response.PostRealEmojiResponse;
+//import com.oing.dto.response.PostRealEmojiSummaryResponse;
+//import com.oing.exception.AuthorizationFailedException;
+//import com.oing.exception.RealEmojiAlreadyExistsException;
+//import com.oing.exception.RegisteredRealEmojiNotFoundException;
+//import com.oing.service.MemberBridge;
+//import com.oing.service.MemberPostRealEmojiService;
+//import com.oing.service.MemberPostService;
+//import com.oing.service.MemberRealEmojiService;
+//import com.oing.util.AuthenticationHolder;
+//import com.oing.util.IdentityGenerator;
+//import jakarta.transaction.Transactional;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.test.context.ActiveProfiles;
+//
+//import java.util.List;
+//
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.Mockito.when;
+//
+//@Transactional
+//@ActiveProfiles("test")
+//@ExtendWith(MockitoExtension.class)
+//public class MemberPostRealEmojiControllerTest {
+//    @InjectMocks
+//    private MemberPostRealEmojiController memberPostRealEmojiController;
+//
+//    @Mock
+//    private AuthenticationHolder authenticationHolder;
+//    @Mock
+//    private IdentityGenerator identityGenerator;
+//    @Mock
+//    private MemberPostService memberPostService;
+//    @Mock
+//    private MemberPostRealEmojiService memberPostRealEmojiService;
+//    @Mock
+//    private MemberRealEmojiService memberRealEmojiService;
+//    @Mock
+//    private MemberBridge memberBridge;
+//
+//    @Test
+//    void 게시물_리얼이모지_등록_테스트() {
+//        //given
+//        String memberId = "1";
+//        when(authenticationHolder.getUserId()).thenReturn(memberId);
+//        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
+//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+//                "안녕.오잉.");
+//        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
+//                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
+//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+//        when(memberRealEmojiService.getMemberRealEmojiById(realEmoji.getId())).thenReturn(realEmoji);
+//
+//        MemberPostRealEmoji postRealEmoji = new MemberPostRealEmoji("1", realEmoji, post, memberId);
+//        when(memberPostRealEmojiService.savePostRealEmoji(any(MemberPostRealEmoji.class))).thenReturn(postRealEmoji);
+//        when(identityGenerator.generateIdentity()).thenReturn(postRealEmoji.getId());
+//        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
+//
+//        //when
+//        PostRealEmojiResponse response = memberPostRealEmojiController.createPostRealEmoji(post.getId(), request);
+//
+//        //then
+//        assertEquals(post.getId(), response.postId());
+//        assertEquals(request.realEmojiId(), response.realEmojiId());
+//    }
+//
+//    @Test
+//    void 권한없는_memberId로_게시물_리얼이모지_등록_예외_테스트() {
+//        // given
+//        String memberId = "1";
+//        when(authenticationHolder.getUserId()).thenReturn(memberId);
+//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+//                "안녕.오잉.");
+//        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
+//                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
+//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+//
+//        //when
+//        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(false);
+//        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
+//
+//        // then
+//        assertThrows(AuthorizationFailedException.class,
+//                () -> memberPostRealEmojiController.createPostRealEmoji(post.getId(), request));
+//    }
+//
+//    @Test
+//    void 게시물_중복된_리얼이모지_등록_예외_테스트() {
+//        //given
+//        String memberId = "1";
+//        when(authenticationHolder.getUserId()).thenReturn(memberId);
+//        when(memberBridge.isInSameFamily(memberId, memberId)).thenReturn(true);
+//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+//                "안녕.오잉.");
+//        MemberRealEmoji realEmoji = new MemberRealEmoji("1",  memberId, Emoji.EMOJI_1,
+//                "https://oing.com/emoji.jpg", "emoji.jpg");
+//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+//        when(memberRealEmojiService.getMemberRealEmojiById(realEmoji.getId())).thenReturn(realEmoji);
+//
+//        //when
+//        when(memberPostRealEmojiService.isMemberPostRealEmojiExists(post, memberId, realEmoji)).thenReturn(true);
+//        PostRealEmojiRequest request = new PostRealEmojiRequest(realEmoji.getId());
+//
+//        //then
+//        assertThrows(RealEmojiAlreadyExistsException.class,
+//                () -> memberPostRealEmojiController.createPostRealEmoji(post.getId(), request));
+//    }
+//
+//    @Test
+//    void 게시물_리얼이모지_삭제_테스트() {
+//        //given
+//        String memberId = "1";
+//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+//                "안녕.오잉.");
+//        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
+//                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
+//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+//
+//        //when
+//        memberPostRealEmojiController.deletePostRealEmoji(post.getId(), realEmoji.getId());
+//
+//        //then
+//        //nothing. just check no exception
+//    }
+//
+//    @Test
+//    void 게시물_등록되지_않은_리얼이모지_삭제_예외_테스트() {
+//        //given
+//        String memberId = "1";
+//        when(authenticationHolder.getUserId()).thenReturn(memberId);
+//        MemberPost post = new MemberPost("1", memberId, "1","https://oing.com/post.jpg", "post.jpg",
+//                "안녕.오잉.");
+//        MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId,
+//                Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
+//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+//
+//        //when
+//        when(memberPostRealEmojiService.getMemberPostRealEmojiByRealEmojiIdAndMemberIdAndPostId("1", memberId, post.getId()))
+//                .thenThrow(RegisteredRealEmojiNotFoundException.class);
+//
+//        //then
+//        assertThrows(RegisteredRealEmojiNotFoundException.class,
+//                () -> memberPostRealEmojiController.deletePostRealEmoji(post.getId(), realEmoji.getId()));
+//    }
+//
+//    @Test
+//    void 게시물_리얼이모지_요약_조회_테스트() {
+//        //given
+//        String memberId = "1";
+//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+//                "안녕.오잉.");
+//        when(memberPostService.findMemberPostById(post.getId())).thenReturn(post);
+//
+//        //when
+//        PostRealEmojiSummaryResponse summary = memberPostRealEmojiController.getPostRealEmojiSummary(post.getId());
+//
+//        //then
+//        assertEquals(0, summary.results().size());
+//    }
+//
+//    @Test
+//    void 게시물_리얼이모지_목록_조회_테스트() {
+//        //given
+//        String memberId = "1";
+//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+//                "안녕.오잉.");
+//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+//
+//        //when
+//        ArrayResponse<PostRealEmojiResponse> response = memberPostRealEmojiController.getPostRealEmojis(post.getId());
+//
+//        //then
+//        assertEquals(0, response.results().size());
+//        assertEquals(List.of(), response.results());
+//    }
+//
+//    @Test
+//    void 게시물_리얼이모지_멤버_조회_테스트() {
+//        //given
+//        String memberId = "1";
+//        MemberPost post = new MemberPost("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+//                "안녕.오잉.");
+//        when(memberPostService.getMemberPostById(post.getId())).thenReturn(post);
+//
+//        //when
+//        PostRealEmojiMemberResponse response = memberPostRealEmojiController.getPostRealEmojiMembers(post.getId());
+//
+//        //then
+//        assertEquals(0, response.emojiMemberIdsList().size());
+//    }
+//}

--- a/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
@@ -170,4 +170,25 @@ public class MemberRealEmojiControllerTest {
         assertEquals(request1.imageUrl(), response.myRealEmojiList().get(0).imageUrl());
         assertEquals(request2.imageUrl(), response.myRealEmojiList().get(1).imageUrl());
     }
+
+    @Test
+    void 다른_가족에서_생성된_회원_리얼이모지_조회_테스트() {
+        // given
+        String memberId = "1";
+        String otherFamilyId = "1";
+        String familyId = "2";
+        String realEmojiImageUrl = "https://test.com/realEmoji1.jpg";
+        Emoji emoji = Emoji.EMOJI_1;
+        when(authenticationHolder.getUserId()).thenReturn(memberId);
+        CreateMyRealEmojiRequest request = new CreateMyRealEmojiRequest(emoji.getTypeKey(), realEmojiImageUrl);
+        when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("1", memberId, otherFamilyId, emoji,
+                realEmojiImageUrl, "realEmoji.jpg"));
+        memberRealEmojiController.createMemberRealEmoji(memberId, otherFamilyId, request);
+
+        // when
+        RealEmojisResponse response = memberRealEmojiController.getMemberRealEmojis(memberId, familyId);
+
+        // then
+        assertEquals(0, response.myRealEmojiList().size());
+    }
 }

--- a/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
@@ -65,15 +65,16 @@ public class MemberRealEmojiControllerTest {
     void 회원_리얼이모지_생성_테스트() {
         // given
         String memberId = "1";
+        String familyId = "1";
         String realEmojiImageUrl = "https://test.com/realEmoji.jpg";
         Emoji emoji = Emoji.EMOJI_1;
 
         // when
         when(authenticationHolder.getUserId()).thenReturn(memberId);
         CreateMyRealEmojiRequest request = new CreateMyRealEmojiRequest(emoji.getTypeKey(), realEmojiImageUrl);
-        when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("1", memberId, emoji,
+        when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("1", memberId, familyId, emoji,
                 realEmojiImageUrl, "realEmoji.jpg"));
-        RealEmojiResponse response = memberRealEmojiController.createMemberRealEmoji(memberId, request);
+        RealEmojiResponse response = memberRealEmojiController.createMemberRealEmoji(memberId, familyId, request);
 
         // then
         assertEquals(emoji.getTypeKey(), response.type());
@@ -84,6 +85,7 @@ public class MemberRealEmojiControllerTest {
     void 권한없는_memberId로_리얼이모지_생성_예외_테스트() {
         // given
         String memberId = "1";
+        String familyId = "1";
         String realEmojiImageUrl = "https://test.com/realEmoji.jpg";
         Emoji emoji = Emoji.EMOJI_1;
 
@@ -93,39 +95,41 @@ public class MemberRealEmojiControllerTest {
 
         // then
         assertThrows(AuthorizationFailedException.class,
-                () -> memberRealEmojiController.createMemberRealEmoji(memberId, request));
+                () -> memberRealEmojiController.createMemberRealEmoji(memberId, familyId, request));
     }
 
     @Test
     void 중복된_리얼이모지_생성_예외_테스트() {
         // given
         String memberId = "1";
+        String familyId = "1";
         String realEmojiImageUrl = "https://test.com/realEmoji.jpg";
         Emoji emoji = Emoji.EMOJI_1;
 
         // when
         when(authenticationHolder.getUserId()).thenReturn(memberId);
         CreateMyRealEmojiRequest request = new CreateMyRealEmojiRequest(emoji.getTypeKey(), realEmojiImageUrl);
-        when(memberRealEmojiService.findRealEmojiByEmojiTypeAndMemberId(emoji, memberId)).thenReturn(true);
+        when(memberRealEmojiService.findRealEmojiByEmojiTypeAndMemberIdAndFamilyId(emoji, memberId, familyId)).thenReturn(true);
 
         // then
         assertThrows(DuplicateRealEmojiException.class,
-                () -> memberRealEmojiController.createMemberRealEmoji(memberId, request));
+                () -> memberRealEmojiController.createMemberRealEmoji(memberId, familyId, request));
     }
 
     @Test
     void 회원_리얼이모지_수정_테스트() {
         // given
         String memberId = "1";
+        String familyId = "1";
         String realEmojiId = "1";
         String realEmojiImageUrl = "https://test.com/realEmoji.jpg";
 
         // when
         when(authenticationHolder.getUserId()).thenReturn(memberId);
         UpdateMyRealEmojiRequest request = new UpdateMyRealEmojiRequest(realEmojiImageUrl);
-        when(memberRealEmojiService.findRealEmojiById(realEmojiId)).thenReturn(new MemberRealEmoji("1", memberId,
-                Emoji.EMOJI_1, realEmojiImageUrl, "realEmoji.jpg"));
-        RealEmojiResponse response = memberRealEmojiController.changeMemberRealEmoji(memberId, realEmojiId, request);
+        when(memberRealEmojiService.getMemberRealEmojiByIdAndFamilyId(realEmojiId, familyId)).thenReturn(
+                new MemberRealEmoji("1", memberId, familyId, Emoji.EMOJI_1, realEmojiImageUrl, "realEmoji.jpg"));
+        RealEmojiResponse response = memberRealEmojiController.changeMemberRealEmoji(memberId, familyId, realEmojiId, request);
 
         // then
         assertEquals(request.imageUrl(), response.imageUrl());
@@ -135,6 +139,7 @@ public class MemberRealEmojiControllerTest {
     void 회원_리얼이모지_조회_테스트() {
         // given
         String memberId = "1";
+        String familyId = "1";
         String realEmojiImageUrl1 = "https://test.com/realEmoji1.jpg";
         String realEmojiImageUrl2 = "https://test.com/realEmoji2.jpg";
         Emoji emoji1 = Emoji.EMOJI_1;
@@ -142,19 +147,19 @@ public class MemberRealEmojiControllerTest {
         when(authenticationHolder.getUserId()).thenReturn(memberId);
         CreateMyRealEmojiRequest request1 = new CreateMyRealEmojiRequest(emoji1.getTypeKey(), realEmojiImageUrl1);
         CreateMyRealEmojiRequest request2 = new CreateMyRealEmojiRequest(emoji1.getTypeKey(), realEmojiImageUrl2);
-        when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("1", memberId, emoji1,
+        when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("1", memberId, familyId, emoji1,
                 realEmojiImageUrl1, "realEmoji1.jpg"));
-        memberRealEmojiController.createMemberRealEmoji(memberId, request1);
-        when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("2", memberId, emoji2,
+        memberRealEmojiController.createMemberRealEmoji(memberId, familyId, request1);
+        when(memberRealEmojiService.save(any())).thenReturn(new MemberRealEmoji("2", memberId, familyId, emoji2,
                 realEmojiImageUrl2, "realEmoji2.jpg"));
-        memberRealEmojiController.createMemberRealEmoji(memberId, request2);
+        memberRealEmojiController.createMemberRealEmoji(memberId, familyId, request2);
 
         // when
-        when(memberRealEmojiService.findRealEmojisByMemberId(memberId)).thenReturn(List.of(
-                new MemberRealEmoji("1", memberId, emoji1, realEmojiImageUrl1, "realEmoji1.jpg"),
-                new MemberRealEmoji("2", memberId, emoji2, realEmojiImageUrl2, "realEmoji2.jpg")
+        when(memberRealEmojiService.findRealEmojisByMemberIdAndFamilyId(memberId, familyId)).thenReturn(List.of(
+                new MemberRealEmoji("1", memberId, familyId, emoji1, realEmojiImageUrl1, "realEmoji1.jpg"),
+                new MemberRealEmoji("2", memberId, familyId, emoji2, realEmojiImageUrl2, "realEmoji2.jpg")
         ));
-        RealEmojisResponse response = memberRealEmojiController.getMemberRealEmojis(memberId);
+        RealEmojisResponse response = memberRealEmojiController.getMemberRealEmojis(memberId, familyId);
 
         // then
         assertEquals(2, response.myRealEmojiList().size());


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
회원이 그룹 탈퇴를 했을 때를 대비하여, 회원 리얼이모지 테이블에 familyId를 추가하고 로직을 수정했습니다.

## ➕ 추가/변경된 기능

---
- 회원리얼이모지 familyId 컬럼 추가
- 회원리얼이모지 로직 수정
  - 회원리얼이모지 생성/조회/수정 시, 회원의 familyId를 이용해 처리
- 수정된 로직에 따라 테스트코드 수정

## 🥺 리뷰어에게 하고싶은 말

---
로컬에서 API 호출하면서 회원의 가족이 바뀌어도 적절히 대응함을 확인했는데 리얼이모지 안에서 추가적으로 familyId를 고려해야 하는 기능이 있다면 알려주세요


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-193