### PR TITLE
refactor: allFamilyMembersUploaded와 관련된 캘린더 정책 수정

### DIFF
--- a/gateway/src/main/java/com/oing/controller/WidgetController.java
+++ b/gateway/src/main/java/com/oing/controller/WidgetController.java
@@ -24,20 +24,16 @@ public class WidgetController implements WidgetApi {
     private final MemberService memberService;
     private final MemberPostService memberPostService;
 
-    private final TokenAuthenticationHolder tokenAuthenticationHolder;
     private final OptimizedImageUrlGenerator optimizedImageUrlGenerator;
 
     @Override
-    public ResponseEntity<SingleRecentPostWidgetResponse> getSingleRecentFamilyPostWidget(String date) {
-        String myId = tokenAuthenticationHolder.getUserId();
-        List<String> familyIds = memberService.findFamilyMembersIdByMemberId(myId);
-
+    public ResponseEntity<SingleRecentPostWidgetResponse> getSingleRecentFamilyPostWidget(String date, String familyId) {
         Optional<String> dateString = Optional.ofNullable(date);
         LocalDate startDate = dateString.map(LocalDate::parse).orElse(LocalDate.now());
         LocalDate endDate = startDate.plusDays(1);
 
 
-        List<MemberPost> latestPosts = memberPostService.findLatestPostOfEveryday(familyIds, startDate, endDate);
+        List<MemberPost> latestPosts = memberPostService.findLatestPostOfEveryday(startDate, endDate, familyId);
         if (latestPosts.isEmpty()) {
             return ResponseEntity.noContent().build();
         }

--- a/gateway/src/main/java/com/oing/dto/response/DayEventResponse.java
+++ b/gateway/src/main/java/com/oing/dto/response/DayEventResponse.java
@@ -1,0 +1,9 @@
+package com.oing.dto.response;
+
+import java.time.LocalDate;
+
+public record DayEventResponse(
+        LocalDate date,
+        Boolean allFamilyMembersUploaded
+) {
+}

--- a/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
@@ -34,14 +34,14 @@ public class MemberPostRepositoryCustomImpl implements MemberPostRepositoryCusto
     }
 
     @Override
-    public List<MemberPost> findLatestPostOfEveryday(List<String> memberIds, LocalDateTime startDate, LocalDateTime endDate) {
+    public List<MemberPost> findLatestPostOfEveryday(LocalDateTime startDate, LocalDateTime endDate, String familyId) {
         return queryFactory
                 .selectFrom(memberPost)
                 .where(memberPost.id.in(
                         JPAExpressions
                                 .select(memberPost.id.max())
                                 .from(memberPost)
-                                .where(memberPost.memberId.in(memberIds)
+                                .where(memberPost.familyId.eq(familyId)
                                         .and(memberPost.createdAt.between(startDate, endDate)))
                                 .groupBy(Expressions.dateOperation(LocalDate.class, Ops.DateTimeOps.DATE, memberPost.createdAt))
                 ))
@@ -52,11 +52,11 @@ public class MemberPostRepositoryCustomImpl implements MemberPostRepositoryCusto
 
 
     @Override
-    public List<MemberPostDailyCalendarDTO> findPostDailyCalendarDTOs(List<String> memberIds, LocalDateTime startDate, LocalDateTime endDate) {
+    public List<MemberPostDailyCalendarDTO> findPostDailyCalendarDTOs(LocalDateTime startDate, LocalDateTime endDate, String familyId) {
         return queryFactory
                 .select(Projections.constructor(MemberPostDailyCalendarDTO.class, memberPost.id.count()))
                 .from(memberPost)
-                .where(memberPost.memberId.in(memberIds)
+                .where(memberPost.familyId.eq(familyId)
                         .and(memberPost.createdAt.between(startDate, endDate)))
                 .groupBy(Expressions.dateOperation(LocalDate.class, Ops.DateTimeOps.DATE, memberPost.createdAt))
                 .fetch();

--- a/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
@@ -1,7 +1,6 @@
 package com.oing.repository;
 
 import com.oing.domain.MemberPost;
-import com.oing.domain.MemberPostDailyCalendarDTO;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.Projections;
@@ -46,19 +45,6 @@ public class MemberPostRepositoryCustomImpl implements MemberPostRepositoryCusto
                                 .groupBy(Expressions.dateOperation(LocalDate.class, Ops.DateTimeOps.DATE, memberPost.createdAt))
                 ))
                 .orderBy(memberPost.createdAt.asc())
-                .fetch();
-
-    }
-
-
-    @Override
-    public List<MemberPostDailyCalendarDTO> findPostDailyCalendarDTOs(LocalDateTime startDate, LocalDateTime endDate, String familyId) {
-        return queryFactory
-                .select(Projections.constructor(MemberPostDailyCalendarDTO.class, memberPost.id.count()))
-                .from(memberPost)
-                .where(memberPost.familyId.eq(familyId)
-                        .and(memberPost.createdAt.between(startDate, endDate)))
-                .groupBy(Expressions.dateOperation(LocalDate.class, Ops.DateTimeOps.DATE, memberPost.createdAt))
                 .fetch();
 
     }

--- a/gateway/src/main/java/com/oing/restapi/CalendarApi.java
+++ b/gateway/src/main/java/com/oing/restapi/CalendarApi.java
@@ -1,9 +1,6 @@
 package com.oing.restapi;
 
-import com.oing.dto.response.ArrayResponse;
-import com.oing.dto.response.BannerResponse;
-import com.oing.dto.response.CalendarResponse;
-import com.oing.dto.response.FamilyMonthlyStatisticsResponse;
+import com.oing.dto.response.*;
 import com.oing.util.security.FamilyId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,9 +23,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/calendar")
 public interface CalendarApi {
 
-    @Operation(summary = "월별 캘린더 조회", description = "월별 캘린더를 조회합니다.")
+    @Operation(summary = "월별 캘린더 조회", description = "월별로 캘린더를 조회합니다. 각 날짜의 대표 게시글 정보가 조회되며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.")
     @GetMapping(params = {"type=MONTHLY"})
     ArrayResponse<CalendarResponse> getMonthlyCalendar(
+            @RequestParam
+            @Parameter(description = "조회할 년월", example = "2021-12")
+            String yearMonth,
+
+            @Parameter(hidden = true)
+            @FamilyId
+            String familyId
+    );
+
+    @Operation(summary = "월별 이벤트 조회", description = "월별로 존재하는 이벤트들을 조회합니다. 모든 가족 구성원이 업로드한 여부 등이 이벤트에 속하며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.\n ⚠️ 월별 캘린더 조회 API와 반환되는 날짜가 다를 수 있습니다.")
+    @GetMapping(value = "/events", params = {"type=MONTHLY"})
+    ArrayResponse<DayEventResponse> getMonthlyEvents(
             @RequestParam
             @Parameter(description = "조회할 년월", example = "2021-12")
             String yearMonth,

--- a/gateway/src/main/java/com/oing/restapi/CalendarApi.java
+++ b/gateway/src/main/java/com/oing/restapi/CalendarApi.java
@@ -23,8 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/calendar")
 public interface CalendarApi {
 
-    @Operation(summary = "월별 캘린더 조회", description = "월별로 캘린더를 조회합니다. 각 날짜의 대표 게시글 정보가 조회되며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.")
-    @GetMapping(params = {"type=MONTHLY"})
+    @Operation(summary = "월별 썸네일 조회", description = "월별로 캘린더의 대표 게시물 썸네일을 조회합니다. 각 날짜의 대표 게시글 정보가 조회되며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.\n\n ⚠️ 더 이상 type=MONTHLY 를 사용하지 않습니다.")
+    @GetMapping("/thumbnails")
     ArrayResponse<CalendarResponse> getMonthlyCalendar(
             @RequestParam
             @Parameter(description = "조회할 년월", example = "2021-12")
@@ -35,7 +35,7 @@ public interface CalendarApi {
             String familyId
     );
 
-    @Operation(summary = "월별 이벤트 조회", description = "월별로 존재하는 이벤트들을 조회합니다. 모든 가족 구성원이 업로드한 여부 등이 이벤트에 속하며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.\n ⚠️ 월별 캘린더 조회 API와 반환되는 날짜가 다를 수 있습니다.")
+    @Operation(summary = "월별 이벤트 조회", description = "월별로 존재하는 캘린더의 이벤트들을 조회합니다. 모든 가족 구성원이 업로드한 여부 등이 이벤트에 속하며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.\n\n ⚠️ 월별 캘린더 조회 API와 반환되는 날짜가 다를 수 있습니다.\n\n ⚠️ 더 이상 type=MONTHLY 를 사용하지 않습니다.")
     @GetMapping(value = "/events", params = {"type=MONTHLY"})
     ArrayResponse<DayEventResponse> getMonthlyEvents(
             @RequestParam

--- a/gateway/src/main/java/com/oing/restapi/WidgetApi.java
+++ b/gateway/src/main/java/com/oing/restapi/WidgetApi.java
@@ -1,6 +1,7 @@
 package com.oing.restapi;
 
 import com.oing.dto.response.SingleRecentPostWidgetResponse;
+import com.oing.util.security.FamilyId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,6 +26,10 @@ public interface WidgetApi {
     ResponseEntity<SingleRecentPostWidgetResponse> getSingleRecentFamilyPostWidget(
             @RequestParam(required = false)
             @Parameter(description = "조회할 년월일 (default = today)", example = "2023-10-18")
-            String date
+            String date,
+
+            @Parameter(hidden = true)
+            @FamilyId
+            String familyId
     );
 }

--- a/gateway/src/main/resources/application-test.yaml
+++ b/gateway/src/main/resources/application-test.yaml
@@ -22,6 +22,7 @@ spring:
       port: 16379
       ssl:
         enabled: true
+
 app:
   external-urls:
     slack-webhook: https://www.naver.com # Must Be Replaced
@@ -48,6 +49,13 @@ app:
 logging:
   level:
     com.oing: DEBUG
+#    org:
+#      springframework:
+#        jdbc: debug
+#      hibernate:
+#        orm:
+#          jdbc:
+#            bind: trace
 
 cloud:
   ncp:

--- a/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
@@ -62,13 +62,12 @@ class CalendarControllerTest {
             LocalDateTime.now()
     );
 
-    private final List<String> familyIds = List.of(testMember1.getId(), testMember2.getId());
-
 
     @Test
     void 월별_캘린더_조회_테스트() {
         // Given
         String yearMonth = "2023-11";
+        String familyId = testMember1.getFamilyId();
 
         LocalDate startDate = LocalDate.of(2023, 11, 1);
         LocalDate endDate = startDate.plusMonths(1);
@@ -115,12 +114,11 @@ class CalendarControllerTest {
                 new MemberPostDailyCalendarDTO(2L),
                 new MemberPostDailyCalendarDTO(1L)
         );
-        when(memberService.findFamilyMembersIdsByFamilyId("testFamily")).thenReturn(familyIds);
-        when(memberPostService.findLatestPostOfEveryday(familyIds, startDate, endDate)).thenReturn(representativePosts);
-        when(memberPostService.findPostDailyCalendarDTOs(familyIds, startDate, endDate)).thenReturn(calendarDTOs);
+        when(memberPostService.findLatestPostOfEveryday(startDate, endDate, familyId)).thenReturn(representativePosts);
+        when(memberPostService.findPostDailyCalendarDTOs(startDate, endDate, familyId)).thenReturn(calendarDTOs);
 
         // When
-        ArrayResponse<CalendarResponse> weeklyCalendar = calendarController.getMonthlyCalendar(yearMonth, testMember1.getFamilyId());
+        ArrayResponse<CalendarResponse> weeklyCalendar = calendarController.getMonthlyCalendar(yearMonth, familyId);
 
         // Then
         assertThat(weeklyCalendar.results())

--- a/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
@@ -3,13 +3,11 @@ package com.oing.controller;
 import com.oing.component.TokenAuthenticationHolder;
 import com.oing.domain.Member;
 import com.oing.domain.MemberPost;
-import com.oing.domain.MemberPostDailyCalendarDTO;
 import com.oing.dto.response.ArrayResponse;
 import com.oing.dto.response.CalendarResponse;
 import com.oing.service.MemberPostService;
 import com.oing.service.MemberService;
 import com.oing.util.OptimizedImageUrlGenerator;
-import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -49,7 +47,7 @@ class CalendarControllerTest {
             "testMember1",
             "profile.com/1",
             "1",
-            LocalDateTime.now()
+            LocalDateTime.of(2023, 11, 1, 13, 0)
     );
 
     private final Member testMember2 = new Member(
@@ -59,7 +57,7 @@ class CalendarControllerTest {
             "testMember2",
             "profile.com/2",
             "2",
-            LocalDateTime.now()
+            LocalDateTime.of(2023, 11, 2, 13, 0)
     );
 
 
@@ -74,7 +72,7 @@ class CalendarControllerTest {
         MemberPost testPost1 = new MemberPost(
                 "1",
                 testMember1.getId(),
-                "1",
+                familyId,
                 "post.com/1",
                 "1",
                 "test1"
@@ -83,7 +81,7 @@ class CalendarControllerTest {
         MemberPost testPost2 = new MemberPost(
                 "2",
                 testMember2.getId(),
-                "1",
+                familyId,
                 "post.com/2",
                 "2",
                 "test2"
@@ -92,7 +90,7 @@ class CalendarControllerTest {
         MemberPost testPost3 = new MemberPost(
                 "3",
                 testMember1.getId(),
-                "1",
+                familyId,
                 "post.com/3",
                 "3",
                 "test3"
@@ -101,33 +99,21 @@ class CalendarControllerTest {
         MemberPost testPost4 = new MemberPost(
                 "4",
                 testMember2.getId(),
-                "1",
+                familyId,
                 "post.com/4",
                 "4",
                 "test4"
         );
         ReflectionTestUtils.setField(testPost4, "createdAt", LocalDateTime.of(2023, 11, 9, 13, 0));
         List<MemberPost> representativePosts = List.of(testPost1, testPost2, testPost3, testPost4);
-        List<MemberPostDailyCalendarDTO> calendarDTOs = List.of(
-                new MemberPostDailyCalendarDTO(2L),
-                new MemberPostDailyCalendarDTO(1L),
-                new MemberPostDailyCalendarDTO(2L),
-                new MemberPostDailyCalendarDTO(1L)
-        );
         when(memberPostService.findLatestPostOfEveryday(startDate, endDate, familyId)).thenReturn(representativePosts);
-        when(memberPostService.findPostDailyCalendarDTOs(startDate, endDate, familyId)).thenReturn(calendarDTOs);
 
         // When
         ArrayResponse<CalendarResponse> weeklyCalendar = calendarController.getMonthlyCalendar(yearMonth, familyId);
 
         // Then
         assertThat(weeklyCalendar.results())
-                .extracting(CalendarResponse::representativePostId, CalendarResponse::allFamilyMembersUploaded)
-                .containsExactly(
-                        Tuple.tuple("1", true),
-                        Tuple.tuple("2", false),
-                        Tuple.tuple("3", true),
-                        Tuple.tuple("4", false)
-                );
+                .extracting(CalendarResponse::representativePostId)
+                .containsExactly("1", "2", "3", "4");
     }
 }

--- a/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
@@ -69,23 +69,20 @@ class WidgetControllerTest {
             "testPost"
     );
 
-    private final List<String> familyIds = List.of(testMember1.getId(), testMember2.getId());
-
 
     @Test
     void 최근_게시글_싱글_위젯_정상_조회_테스트() {
         // given
         String date = "2024-10-18";
+        String familyId = testMember1.getFamilyId();
 
-        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
-        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
-        when(memberPostService.findLatestPostOfEveryday(familyIds, LocalDate.parse(date), LocalDate.parse(date).plusDays(1))).thenReturn(List.of(testPost1));
+        when(memberPostService.findLatestPostOfEveryday(LocalDate.parse(date), LocalDate.parse(date).plusDays(1), familyId)).thenReturn(List.of(testPost1));
         when(memberService.findMemberById(testPost1.getMemberId())).thenReturn(testMember1);
         when(optimizedImageUrlGenerator.getKBImageUrlGenerator(testMember1.getProfileImgUrl())).thenReturn(testMember1.getProfileImgUrl());
         when(optimizedImageUrlGenerator.getKBImageUrlGenerator(testPost1.getPostImgUrl())).thenReturn(testPost1.getPostImgUrl());
 
         // when
-        ResponseEntity<SingleRecentPostWidgetResponse> response = widgetController.getSingleRecentFamilyPostWidget(date);
+        ResponseEntity<SingleRecentPostWidgetResponse> response = widgetController.getSingleRecentFamilyPostWidget(date, familyId);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -108,16 +105,15 @@ class WidgetControllerTest {
     void 최근_게시글_싱글_위젯_null_파라미터_조회_테스트() {
         // given
         String date = null;
+        String familyId = testMember1.getFamilyId();
 
-        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
-        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
-        when(memberPostService.findLatestPostOfEveryday(familyIds, LocalDate.now(), LocalDate.now().plusDays(1))).thenReturn(List.of(testPost1));
+        when(memberPostService.findLatestPostOfEveryday(LocalDate.now(), LocalDate.now().plusDays(1), familyId)).thenReturn(List.of(testPost1));
         when(memberService.findMemberById(testPost1.getMemberId())).thenReturn(testMember1);
         when(optimizedImageUrlGenerator.getKBImageUrlGenerator(testMember1.getProfileImgUrl())).thenReturn(testMember1.getProfileImgUrl());
         when(optimizedImageUrlGenerator.getKBImageUrlGenerator(testPost1.getPostImgUrl())).thenReturn(testPost1.getPostImgUrl());
 
         // when
-        ResponseEntity<SingleRecentPostWidgetResponse> response = widgetController.getSingleRecentFamilyPostWidget(date);
+        ResponseEntity<SingleRecentPostWidgetResponse> response = widgetController.getSingleRecentFamilyPostWidget(date, familyId);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -140,13 +136,12 @@ class WidgetControllerTest {
     void 최근_게시글_싱글_위젯_빈_게시글_조회_테스트() {
         // given
         String date = "2024-10-18";
+        String familyId = testMember1.getFamilyId();
 
-        when(tokenAuthenticationHolder.getUserId()).thenReturn(testMember1.getId());
-        when(memberService.findFamilyMembersIdByMemberId(testMember1.getId())).thenReturn(familyIds);
-        when(memberPostService.findLatestPostOfEveryday(familyIds, LocalDate.parse(date), LocalDate.parse(date).plusDays(1))).thenReturn(List.of());
+        when(memberPostService.findLatestPostOfEveryday(LocalDate.parse(date), LocalDate.parse(date).plusDays(1), familyId)).thenReturn(List.of());
 
         // when
-        ResponseEntity<SingleRecentPostWidgetResponse> response = widgetController.getSingleRecentFamilyPostWidget(date);
+        ResponseEntity<SingleRecentPostWidgetResponse> response = widgetController.getSingleRecentFamilyPostWidget(date, familyId);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);

--- a/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
@@ -4,7 +4,6 @@ import com.oing.config.QuerydslConfig;
 import com.oing.domain.Family;
 import com.oing.domain.Member;
 import com.oing.domain.MemberPost;
-import com.oing.domain.MemberPostDailyCalendarDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,18 +99,6 @@ class MemberPostRepositoryCustomTest {
         assertThat(posts)
                 .extracting(MemberPost::getId)
                 .containsExactly("2", "4");
-    }
-
-    @Test
-    void 데일리_게시글_캘린더를_구성하기_위한_정보를_조회한다() {
-        // when
-        String familyId = testMember1.getFamilyId();
-        List<MemberPostDailyCalendarDTO> postDailyCalendarDTOs = memberPostRepositoryCustomImpl.findPostDailyCalendarDTOs(LocalDateTime.of(2023, 11, 1, 0, 0, 0), LocalDateTime.of(2023, 12, 1, 0, 0, 0), familyId);
-
-        // Then
-        assertThat(postDailyCalendarDTOs)
-                .extracting(MemberPostDailyCalendarDTO::dailyPostCount)
-                .containsExactly(2L, 1L);
     }
 
     @Test

--- a/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/MemberPostRepositoryCustomTest.java
@@ -69,8 +69,6 @@ class MemberPostRepositoryCustomTest {
             LocalDateTime.now()
     );
 
-    private final List<String> familyIds = List.of(testMember1.getId(), testMember2.getId());
-
 
     @BeforeEach
     void setup() {
@@ -95,7 +93,8 @@ class MemberPostRepositoryCustomTest {
     @Test
     void 각_날짜에서_가장_마지막으로_업로드된_게시글을_조회한다() {
         // When
-        List<MemberPost> posts = memberPostRepositoryCustomImpl.findLatestPostOfEveryday(familyIds, LocalDateTime.of(2023, 11, 1, 0, 0, 0), LocalDateTime.of(2023, 12, 1, 0, 0, 0));
+        String familyId = testMember1.getFamilyId();
+        List<MemberPost> posts = memberPostRepositoryCustomImpl.findLatestPostOfEveryday(LocalDateTime.of(2023, 11, 1, 0, 0, 0), LocalDateTime.of(2023, 12, 1, 0, 0, 0), familyId);
 
         // Then
         assertThat(posts)
@@ -106,7 +105,8 @@ class MemberPostRepositoryCustomTest {
     @Test
     void 데일리_게시글_캘린더를_구성하기_위한_정보를_조회한다() {
         // when
-        List<MemberPostDailyCalendarDTO> postDailyCalendarDTOs = memberPostRepositoryCustomImpl.findPostDailyCalendarDTOs(familyIds, LocalDateTime.of(2023, 11, 1, 0, 0, 0), LocalDateTime.of(2023, 12, 1, 0, 0, 0));
+        String familyId = testMember1.getFamilyId();
+        List<MemberPostDailyCalendarDTO> postDailyCalendarDTOs = memberPostRepositoryCustomImpl.findPostDailyCalendarDTOs(LocalDateTime.of(2023, 11, 1, 0, 0, 0), LocalDateTime.of(2023, 12, 1, 0, 0, 0), familyId);
 
         // Then
         assertThat(postDailyCalendarDTOs)

--- a/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
@@ -62,7 +62,6 @@ class WidgetApiTest {
     private String TEST_MEMBER2_TOKEN;
     private Member TEST_MEMBER3;
     private String TEST_MEMBER3_TOKEN;
-    private List<String> TEST_FAMILIES_IDS;
 
 
     @Value("${cloud.ncp.image-optimizer-cdn}")
@@ -119,8 +118,6 @@ class WidgetApiTest {
                 )
         );
         TEST_MEMBER3_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER3.getId()).accessToken();
-
-        TEST_FAMILIES_IDS = List.of(TEST_MEMBER1.getId(), TEST_MEMBER2.getId());
     }
 
 
@@ -130,7 +127,7 @@ class WidgetApiTest {
         MemberPost testPost1 = new MemberPost(
                 "testPost1",
                 TEST_MEMBER1.getId(),
-                "1",
+                TEST_MEMBER1.getFamilyId(),
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -138,7 +135,7 @@ class WidgetApiTest {
         MemberPost testPost2 = new MemberPost(
                 "testPost2",
                 TEST_MEMBER2.getId(),
-                "1",
+                TEST_MEMBER2.getFamilyId(),
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -146,7 +143,7 @@ class WidgetApiTest {
         MemberPost testPost3 = new MemberPost(
                 "testPost3",
                 TEST_MEMBER3.getId(),
-                "1",
+                TEST_MEMBER3.getFamilyId(),
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"
@@ -176,7 +173,7 @@ class WidgetApiTest {
         MemberPost testPost1 = new MemberPost(
                 "testPost1",
                 TEST_MEMBER1.getId(),
-                "1",
+                TEST_MEMBER1.getFamilyId(),
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -184,7 +181,7 @@ class WidgetApiTest {
         MemberPost testPost2 = new MemberPost(
                 "testPost2",
                 TEST_MEMBER2.getId(),
-                "1",
+                TEST_MEMBER2.getFamilyId(),
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -192,7 +189,7 @@ class WidgetApiTest {
         MemberPost testPost3 = new MemberPost(
                 "testPost3",
                 TEST_MEMBER3.getId(),
-                "1",
+                TEST_MEMBER3.getFamilyId(),
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"

--- a/member/src/main/java/com/oing/repository/MemberRepository.java
+++ b/member/src/main/java/com/oing/repository/MemberRepository.java
@@ -20,6 +20,8 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 
     Page<Member> findAllByFamilyIdAndDeletedAtIsNull(String familyId, PageRequest pageRequest);
 
+    List<Member> findAllByFamilyIdAndFamilyJoinAtBefore(String familyId, LocalDateTime dateTime);
+
     long countByFamilyIdAndFamilyJoinAtBefore(String familyId, LocalDateTime dateTime);
 
     List<Member> findAllByDeletedAtIsNull();

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -76,17 +76,15 @@ public class MemberService {
         return member;
     }
 
-    public List<String> findFamilyMembersIdByMemberId(String memberId) {
-        Member member = findMemberById(memberId);
-        List<Member> family = memberRepository.findAllByFamilyId(member.getFamilyId());
-
-        return family.stream()
+    public List<String> findFamilyMembersIdsByFamilyId(String familyId) {
+        return memberRepository.findAllByFamilyId(familyId)
+                .stream()
                 .map(Member::getId)
                 .toList();
     }
 
-    public List<String> findFamilyMembersIdsByFamilyId(String familyId) {
-        return memberRepository.findAllByFamilyId(familyId)
+    public List<String> findFamilyMembersIdsByFamilyJoinAtBefore(String familyId, LocalDate date) {
+        return memberRepository.findAllByFamilyIdAndFamilyJoinAtBefore(familyId, date.atStartOfDay())
                 .stream()
                 .map(Member::getId)
                 .toList();

--- a/post/src/main/java/com/oing/domain/MemberPostDailyCalendarDTO.java
+++ b/post/src/main/java/com/oing/domain/MemberPostDailyCalendarDTO.java
@@ -1,6 +1,0 @@
-package com.oing.domain;
-
-public record MemberPostDailyCalendarDTO(
-        Long dailyPostCount
-) {
-}

--- a/post/src/main/java/com/oing/dto/response/CalendarResponse.java
+++ b/post/src/main/java/com/oing/dto/response/CalendarResponse.java
@@ -22,9 +22,6 @@ public record CalendarResponse(
         String representativePostId,
 
         @Schema(description = "대표 썸네일 URL", example = "https://j1ansx15683.edge.naverncp.com/image/absc45j/image.jpg?type=f&w=96&h=96")
-        String representativeThumbnailUrl,
-
-        @Schema(description = "가족 모두 업로드했는지 여부", example = "true")
-        boolean allFamilyMembersUploaded
+        String representativeThumbnailUrl
 ) {
 }

--- a/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
@@ -1,7 +1,6 @@
 package com.oing.repository;
 
 import com.oing.domain.MemberPost;
-import com.oing.domain.MemberPostDailyCalendarDTO;
 import com.querydsl.core.QueryResults;
 
 import java.time.LocalDate;
@@ -12,8 +11,6 @@ public interface MemberPostRepositoryCustom {
     List<String> getMemberIdsPostedToday(LocalDate date);
 
     List<MemberPost> findLatestPostOfEveryday(LocalDateTime startDate, LocalDateTime endDate, String familyId);
-
-    List<MemberPostDailyCalendarDTO> findPostDailyCalendarDTOs(LocalDateTime startDate, LocalDateTime endDate, String familyId);
 
     QueryResults<MemberPost> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId, String familyId, boolean asc);
 

--- a/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/MemberPostRepositoryCustom.java
@@ -11,9 +11,9 @@ import java.util.List;
 public interface MemberPostRepositoryCustom {
     List<String> getMemberIdsPostedToday(LocalDate date);
 
-    List<MemberPost> findLatestPostOfEveryday(List<String> memberIds, LocalDateTime startDate, LocalDateTime endDate);
+    List<MemberPost> findLatestPostOfEveryday(LocalDateTime startDate, LocalDateTime endDate, String familyId);
 
-    List<MemberPostDailyCalendarDTO> findPostDailyCalendarDTOs(List<String> memberIds, LocalDateTime startDate, LocalDateTime endDate);
+    List<MemberPostDailyCalendarDTO> findPostDailyCalendarDTOs(LocalDateTime startDate, LocalDateTime endDate, String familyId);
 
     QueryResults<MemberPost> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId, String familyId, boolean asc);
 

--- a/post/src/main/java/com/oing/service/MemberPostService.java
+++ b/post/src/main/java/com/oing/service/MemberPostService.java
@@ -1,7 +1,6 @@
 package com.oing.service;
 
 import com.oing.domain.MemberPost;
-import com.oing.domain.MemberPostDailyCalendarDTO;
 import com.oing.domain.PaginationDTO;
 import com.oing.exception.PostNotFoundException;
 import com.oing.repository.MemberPostRepository;
@@ -41,18 +40,6 @@ public class MemberPostService {
         return memberPostRepository.findLatestPostOfEveryday(inclusiveStartDate.atStartOfDay(), exclusiveEndDate.atStartOfDay(), familyId);
     }
 
-
-    /**
-     * 캘린더를 구성하기 위해 !게시글을 제외하고! 필요한 정보를 조회한다.
-     *
-     * @param memberIds          조회 대상 멤버들의 ID
-     * @param inclusiveStartDate 조회 시작 날짜
-     * @param exclusiveEndDate   조회 종료 날짜
-     * @return 데일리 캘린더용 DTO
-     */
-    public List<MemberPostDailyCalendarDTO> findPostDailyCalendarDTOs(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, String familyId) {
-        return memberPostRepository.findPostDailyCalendarDTOs(inclusiveStartDate.atStartOfDay(), exclusiveEndDate.atStartOfDay(), familyId);
-    }
 
     public MemberPost findMemberPostById(String postId) {
         return memberPostRepository

--- a/post/src/main/java/com/oing/service/MemberPostService.java
+++ b/post/src/main/java/com/oing/service/MemberPostService.java
@@ -101,4 +101,8 @@ public class MemberPostService {
     public List<String> getMemberIdsPostedToday(LocalDate date) {
         return memberPostRepository.getMemberIdsPostedToday(date);
     }
+
+    public boolean existsByMemberIdAndFamilyIdAndCreatedAt(String memberId, String familyId, LocalDate postDate) {
+        return memberPostRepository.existsByMemberIdAndFamilyIdAndCreatedAt(memberId, familyId, postDate);
+    }
 }

--- a/post/src/main/java/com/oing/service/MemberPostService.java
+++ b/post/src/main/java/com/oing/service/MemberPostService.java
@@ -37,8 +37,8 @@ public class MemberPostService {
      * @param exclusiveEndDate   조회 종료 날짜
      * @return 데일리 대표 게시물들
      */
-    public List<MemberPost> findLatestPostOfEveryday(List<String> memberIds, LocalDate inclusiveStartDate, LocalDate exclusiveEndDate) {
-        return memberPostRepository.findLatestPostOfEveryday(memberIds, inclusiveStartDate.atStartOfDay(), exclusiveEndDate.atStartOfDay());
+    public List<MemberPost> findLatestPostOfEveryday(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, String familyId) {
+        return memberPostRepository.findLatestPostOfEveryday(inclusiveStartDate.atStartOfDay(), exclusiveEndDate.atStartOfDay(), familyId);
     }
 
 
@@ -50,8 +50,8 @@ public class MemberPostService {
      * @param exclusiveEndDate   조회 종료 날짜
      * @return 데일리 캘린더용 DTO
      */
-    public List<MemberPostDailyCalendarDTO> findPostDailyCalendarDTOs(List<String> memberIds, LocalDate inclusiveStartDate, LocalDate exclusiveEndDate) {
-        return memberPostRepository.findPostDailyCalendarDTOs(memberIds, inclusiveStartDate.atStartOfDay(), exclusiveEndDate.atStartOfDay());
+    public List<MemberPostDailyCalendarDTO> findPostDailyCalendarDTOs(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, String familyId) {
+        return memberPostRepository.findPostDailyCalendarDTOs(inclusiveStartDate.atStartOfDay(), exclusiveEndDate.atStartOfDay(), familyId);
     }
 
     public MemberPost findMemberPostById(String postId) {


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
모든 가족 구성원이 업로드했는지 여부의 계산에서 각 구성원이 가족을 가입한 날짜를 고려해달라는 요청이 베너 API에만 적용되어 있었는데, 캘린더 API에도 반영하였습니다. **하지만 그 과정에서 allFamilyMembersUploaded 계산 로직이 비대해져 기존의 캘린더 API를 2개로 분리했습니다. 프론트 분들이 반영해줘야 합니다.**

## ➕ 추가/변경된 기능

---
- **`/v1/calendar` API를 `/v1/calendar/thumbnails`와 `/v1/calendar/events`로 분리**
- 각 날짜에 가입해있던 구성원 전부가 업로드 했는지 철저히 계산하는 로직을 추가
- 테스트 코드 리펙토링

## 🥺 리뷰어에게 하고싶은 말

---
파이팅

