### PR TITLE
[OING-199] chore: 자코코 테스트 커버리지 적용 범위 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,9 @@ subprojects {
             html.required.set(true)
             xml.required.set(true)
             csv.required.set(true)
-            html.destination file("$buildDir/reports/jacoco/index.html")
-            xml.destination file("$buildDir/reports/jacoco/index.xml")
-            csv.destination file("$buildDir/reports/jacoco/index.csv")
+            html.destination file(layout.buildDirectory.dir("reports/jacoco/index.html"))
+            xml.destination file(layout.buildDirectory.dir("reports/jacoco/index.xml"))
+            csv.destination file(layout.buildDirectory.dir("reports/jacoco/index.csv"))
         }
 
         def Qdomains = []
@@ -56,11 +56,16 @@ subprojects {
                     files(classDirectories.files.collect {
                         fileTree(dir: it, excludes: [
                                 // 측정 안하고 싶은 패턴
-                                "**/*Application*",
-                                "**/*Config*",
-                                "**/config/*",
+                                "**/domain/*",
                                 "**/dto/*",
-                                "**/*Dto*"
+                                "**/event/*",
+                                "**/exception/*",
+                                "**/util/*",
+                                "**/component/*",
+                                "**/config/*",
+                                "**/job/*",
+                                "**/service/*",
+                                "**/*Application*",
                                 // Querydsl 관련 제거
                         ] + Qdomains)
                     })
@@ -96,12 +101,16 @@ subprojects {
                 }
 
                 excludes = [
-                        "**.*Application*",
-                        "**.*Config*",
-                        "**.config.*",
+                        "**.domain.*",
                         "**.dto.*",
-                        "**.*Dto*",
-                        "**.*DTO*"
+                        "**.event.*",
+                        "**.exception.*",
+                        "**.util.*",
+                        "**.component.*",
+                        "**.config.*",
+                        "**.job.*",
+                        "**.service.*",
+                        "**.*Application*",
                 ] + Qdomains
             }
         }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
자코코 테스트 커버리지 적용 범위를 수정했습니다.

## ➕ 추가/변경된 기능

---
- 자코코 테스트 커버리지 적용 범위 수정
  - restapi, controller, repository 를 제외하고 현재 테스트가 적용되고 있는 디렉터리 제외

## 🥺 리뷰어에게 하고싶은 말

---
일단 임의로 이렇게 적용 범위를 수정했는데 추가/제외하고 싶은 적용 범위가 있다면 얘기해주세요. 오늘 회의때 잠깐 얘기 나눠도 좋을 거 같아요.



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-199