### PR TITLE
[OING-224] hotfix: 가족 통계 전체 추억 수 불일치 이슈

### DIFF
--- a/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/MemberPostRepositoryCustomImpl.java
@@ -69,8 +69,7 @@ public class MemberPostRepositoryCustomImpl implements MemberPostRepositoryCusto
         return queryFactory
                 .select(memberPost.count())
                 .from(memberPost)
-                .leftJoin(member).on(memberPost.memberId.eq(member.id))
-                .where(member.familyId.eq(familyId),
+                .where(memberPost.familyId.eq(familyId),
                         memberPost.createdAt.year().eq(year),
                         memberPost.createdAt.month().eq(month))
                 .fetchFirst();


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
캘린더 화면에서 가족 전체 추억 수가 불일치하는 이슈

## ➕ 추가/변경된 기능

---
memberPost의 familyId를 통해 쿼리하도록 변경

## 🥺 리뷰어에게 하고싶은 말

---
감사합니다

