### PR TITLE
[OING-206] feat: 가족 이력 데이터 테이블 및 코드를 클린하게 리팩토링하고 ShedLock 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,8 @@ subprojects {
         implementation 'com.google.api-client:google-api-client:1.32.1'
         implementation 'org.springframework.boot:spring-boot-starter-data-redis'
         implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3'
+        implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
+        implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0'
         runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
         runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
         implementation("com.nimbusds:nimbus-jose-jwt:9.37")

--- a/common/src/main/java/com/oing/service/FamilyScoreBridge.java
+++ b/common/src/main/java/com/oing/service/FamilyScoreBridge.java
@@ -1,9 +1,8 @@
 package com.oing.service;
 
-import java.time.LocalDate;
 
 public interface FamilyScoreBridge {
-    void updateAllFamilyTopPercentageHistories(LocalDate historyDate);
+    void updateAllFamilyTopPercentageHistories(int year, int month);
 
     int calculateFamilyTopPercentage(int rank, int familiesCount);
 }

--- a/common/src/main/java/com/oing/util/DateUtils.java
+++ b/common/src/main/java/com/oing/util/DateUtils.java
@@ -1,0 +1,14 @@
+package com.oing.util;
+
+import java.time.LocalDate;
+
+public class DateUtils {
+
+    public static boolean isCurrentMonth(LocalDate date) {
+        return isSameMonth(date, LocalDate.now());
+    }
+
+    public static boolean isSameMonth(LocalDate date1, LocalDate date2) {
+        return date1.getYear() == date2.getYear() && date1.getMonth() == date2.getMonth();
+    }
+}

--- a/family/src/main/java/com/oing/domain/CreateNewFamilyTopPercentageHistoryDTO.java
+++ b/family/src/main/java/com/oing/domain/CreateNewFamilyTopPercentageHistoryDTO.java
@@ -1,10 +1,9 @@
 package com.oing.domain;
 
-import java.time.LocalDate;
-
 public record CreateNewFamilyTopPercentageHistoryDTO(
         String familyId,
-        LocalDate date,
+        Integer year,
+        Integer month,
         Family family,
         Integer topPercentage
 ) {

--- a/family/src/main/java/com/oing/domain/FamilyTopPercentageHistory.java
+++ b/family/src/main/java/com/oing/domain/FamilyTopPercentageHistory.java
@@ -25,9 +25,9 @@ public class FamilyTopPercentageHistory {
     @Column(nullable = false)
     private Integer topPercentage;
 
-    public FamilyTopPercentageHistory(CreateNewFamilyTopPercentageHistoryDTO createNewFamilyTopPercentageHistoryDTO) {
-        this.familyTopPercentageHistoryId = new FamilyTopPercentageHistoryId(createNewFamilyTopPercentageHistoryDTO.familyId(), createNewFamilyTopPercentageHistoryDTO.date().withDayOfMonth(1));
-        this.family = createNewFamilyTopPercentageHistoryDTO.family();
-        this.topPercentage = createNewFamilyTopPercentageHistoryDTO.topPercentage();
+    public FamilyTopPercentageHistory(CreateNewFamilyTopPercentageHistoryDTO dto) {
+        this.familyTopPercentageHistoryId = new FamilyTopPercentageHistoryId(dto.familyId(), dto.year(), dto.month());
+        this.family = dto.family();
+        this.topPercentage = dto.topPercentage();
     }
 }

--- a/family/src/main/java/com/oing/domain/FamilyTopPercentageHistoryId.java
+++ b/family/src/main/java/com/oing/domain/FamilyTopPercentageHistoryId.java
@@ -18,8 +18,5 @@ public class FamilyTopPercentageHistoryId implements Serializable {
     private String familyId;
 
     @Column(nullable = false)
-    private Integer year;
-
-    @Column(nullable = false)
-    private Integer month;
+    private LocalDate date;
 }

--- a/family/src/main/java/com/oing/domain/FamilyTopPercentageHistoryId.java
+++ b/family/src/main/java/com/oing/domain/FamilyTopPercentageHistoryId.java
@@ -17,6 +17,9 @@ public class FamilyTopPercentageHistoryId implements Serializable {
     @Column(name = "family_id", columnDefinition = "CHAR(26)", nullable = false)
     private String familyId;
 
-    @Column(nullable = false)
-    private LocalDate date;
+    @Column(name = "history_year", nullable = false)
+    private Integer year;
+
+    @Column(name = "history_month", nullable = false)
+    private Integer month;
 }

--- a/family/src/main/java/com/oing/domain/FamilyTopPercentageHistoryId.java
+++ b/family/src/main/java/com/oing/domain/FamilyTopPercentageHistoryId.java
@@ -18,5 +18,8 @@ public class FamilyTopPercentageHistoryId implements Serializable {
     private String familyId;
 
     @Column(nullable = false)
-    private LocalDate date;
+    private Integer year;
+
+    @Column(nullable = false)
+    private Integer month;
 }

--- a/family/src/main/java/com/oing/job/FamilyStatisticJob.java
+++ b/family/src/main/java/com/oing/job/FamilyStatisticJob.java
@@ -2,12 +2,14 @@ package com.oing.job;
 
 import com.oing.service.FamilyScoreBridge;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FamilyStatisticJob {
@@ -15,10 +17,14 @@ public class FamilyStatisticJob {
     private final FamilyScoreBridge familyScoreBridge;
 
     @Scheduled(cron = "0 0 1 1 * *") // 매월 1일 01시
-    @SchedulerLock(name = "MonthlyFamilyTopPercentageHistoryRecordingScheduling", lockAtMostFor = "PT30S", lockAtLeastFor = "PT30S")
+    @SchedulerLock(name = "MonthlyFamilyTopPercentageHistoryRecordingSchedule", lockAtMostFor = "PT30S", lockAtLeastFor = "PT30S")
     public void recordAllFamilyTopPercentageHistoriesMonthly() {
         // 방금 막 지나간 지난 달의 데이터를 기록한다.
         LocalDate historyDate = LocalDate.now().minusMonths(1);
-        familyScoreBridge.updateAllFamilyTopPercentageHistories(historyDate.getYear(), historyDate.getMonthValue());
+        int historyYear = historyDate.getYear();
+        int historyMonth = historyDate.getMonthValue();
+        log.info("[MonthlyFamilyTopPercentageHistoryRecordingSchedule: {}-{}] scheduled and locked for 30s", historyYear, historyMonth);
+
+        familyScoreBridge.updateAllFamilyTopPercentageHistories(historyYear, historyMonth);
     }
 }

--- a/family/src/main/java/com/oing/job/FamilyStatisticJob.java
+++ b/family/src/main/java/com/oing/job/FamilyStatisticJob.java
@@ -15,7 +15,8 @@ public class FamilyStatisticJob {
 
     @Scheduled(cron = "0 0 1 1 * *") // 매월 1일 01시
     public void recordAllFamilyTopPercentageHistoriesMonthly() {
+        // 방금 막 지나간 지난 달의 데이터를 기록한다.
         LocalDate historyDate = LocalDate.now().minusMonths(1);
-        familyScoreBridge.updateAllFamilyTopPercentageHistories(historyDate);
+        familyScoreBridge.updateAllFamilyTopPercentageHistories(historyDate.getYear(), historyDate.getMonthValue());
     }
 }

--- a/family/src/main/java/com/oing/job/FamilyStatisticJob.java
+++ b/family/src/main/java/com/oing/job/FamilyStatisticJob.java
@@ -2,18 +2,20 @@ package com.oing.job;
 
 import com.oing.service.FamilyScoreBridge;
 import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class FamilyStatisticJob {
 
     private final FamilyScoreBridge familyScoreBridge;
 
     @Scheduled(cron = "0 0 1 1 * *") // 매월 1일 01시
+    @SchedulerLock(name = "MonthlyFamilyTopPercentageHistoryRecordingScheduling", lockAtMostFor = "PT30S", lockAtLeastFor = "PT30S")
     public void recordAllFamilyTopPercentageHistoriesMonthly() {
         // 방금 막 지나간 지난 달의 데이터를 기록한다.
         LocalDate historyDate = LocalDate.now().minusMonths(1);

--- a/family/src/main/java/com/oing/service/FamilyService.java
+++ b/family/src/main/java/com/oing/service/FamilyService.java
@@ -3,6 +3,7 @@ package com.oing.service;
 import com.oing.domain.Family;
 import com.oing.exception.FamilyNotFoundException;
 import com.oing.repository.FamilyRepository;
+import com.oing.util.DateUtils;
 import com.oing.util.IdentityGenerator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -52,13 +53,10 @@ public class FamilyService {
     }
 
     public int getFamilyTopPercentage(String familyId, LocalDate calendarDate) {
-        // 이번 달의 캘린더를 조회 시, 실시간으로 topPercentage를 계산
-        if (calendarDate.getYear() == LocalDate.now().getYear() && calendarDate.getMonth() == LocalDate.now().getMonth()) {
+        if (DateUtils.isCurrentMonth(calendarDate)) {
             return calculateLiveFamilyTopPercentage(familyId);
-
-        // 과거의 캘린더를 조회 시, 해당 날짜의 topPercentage를 조회
         } else {
-            return getFamilyTopPercentageHistory(familyId, calendarDate);
+            return familyTopPercentageHistoryService.getTopPercentage(familyId, calendarDate.getYear(), calendarDate.getMonthValue());
         }
     }
 
@@ -69,9 +67,5 @@ public class FamilyService {
 
         // score 를 통한 순위를 통해 전체 가족들 중 상위 백분율 계산 (1%에 가까울수록 고순위)
         return familyScoreBridge.calculateFamilyTopPercentage(rank, familiesCount);
-    }
-
-    private int getFamilyTopPercentageHistory(String familyId, LocalDate calendarDate) {
-        return familyTopPercentageHistoryService.getTopPercentageByFamilyIdAndDate(familyId, calendarDate);
     }
 }

--- a/family/src/main/java/com/oing/service/FamilyTopPercentageHistoryService.java
+++ b/family/src/main/java/com/oing/service/FamilyTopPercentageHistoryService.java
@@ -1,13 +1,11 @@
 package com.oing.service;
 
-import com.oing.domain.CreateNewFamilyTopPercentageHistoryDTO;
 import com.oing.domain.FamilyTopPercentageHistory;
 import com.oing.domain.FamilyTopPercentageHistoryId;
 import com.oing.repository.FamilyTopPercentageHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 @Service
@@ -17,14 +15,11 @@ public class FamilyTopPercentageHistoryService {
     private final FamilyTopPercentageHistoryRepository familyTopPercentageHistoryRepository;
 
 
-    public int getTopPercentageByFamilyIdAndDate(String familyId, LocalDate historyDate) {
-        LocalDate firstDayOfMonth = historyDate.withDayOfMonth(1);
-        FamilyTopPercentageHistoryId familyTopPercentageHistoryId = new FamilyTopPercentageHistoryId(familyId, firstDayOfMonth);
-
+    public int getTopPercentage(String familyId, int year, int month) {
+        FamilyTopPercentageHistoryId familyTopPercentageHistoryId = new FamilyTopPercentageHistoryId(familyId, year, month);
 
         Optional<FamilyTopPercentageHistory> familyTopPercentageHistory = familyTopPercentageHistoryRepository.findByFamilyTopPercentageHistoryId(familyTopPercentageHistoryId);
-        // 이력이 없다면, 최저값인 100 반환
-        if (familyTopPercentageHistory.isEmpty()) {
+        if (familyTopPercentageHistory.isEmpty()) { // 이력이 없다면, 최저값인 100 반환
             return 100;
         }
 

--- a/gateway/src/main/java/com/oing/ServerApplication.java
+++ b/gateway/src/main/java/com/oing/ServerApplication.java
@@ -9,7 +9,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @EnableAsync
-@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class ServerApplication {

--- a/gateway/src/main/java/com/oing/config/ScheduleConfig.java
+++ b/gateway/src/main/java/com/oing/config/ScheduleConfig.java
@@ -1,0 +1,38 @@
+package com.oing.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
+public class ScheduleConfig implements SchedulingConfigurer {
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        scheduler.setThreadNamePrefix("bibbi-scheduled-task-pool-");
+        scheduler.initialize();
+        taskRegistrar.setTaskScheduler(scheduler);
+    }
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new org.springframework.jdbc.core.JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        );
+    }
+}

--- a/gateway/src/main/java/com/oing/service/FamilyScoreBridgeImpl.java
+++ b/gateway/src/main/java/com/oing/service/FamilyScoreBridgeImpl.java
@@ -25,7 +25,7 @@ public class FamilyScoreBridgeImpl implements FamilyScoreBridge {
 
     @Override
     @Transactional
-    public void updateAllFamilyTopPercentageHistories(LocalDate historyDate) {
+    public void updateAllFamilyTopPercentageHistories(int year, int month) {
         List<Family> families = familyRepository.findAll();
         int familiesCount = familyRepository.countByScoreDistinct();
 
@@ -35,7 +35,8 @@ public class FamilyScoreBridgeImpl implements FamilyScoreBridge {
 
             CreateNewFamilyTopPercentageHistoryDTO dto = new CreateNewFamilyTopPercentageHistoryDTO(
                     family.getId(),
-                    historyDate,
+                    year,
+                    month,
                     family,
                     topPercentage
             );

--- a/gateway/src/main/resources/db/migration/V202402252319__alter_FamolyTopPercentageHistory_tbl.sql
+++ b/gateway/src/main/resources/db/migration/V202402252319__alter_FamolyTopPercentageHistory_tbl.sql
@@ -2,9 +2,9 @@ ALTER TABLE family_top_percentage_history
 DROP COLUMN date;
 
 ALTER TABLE family_top_percentage_history
-ADD COLUMN year INT NOT NULL DEFAULT 2024;
+ADD COLUMN history_year INT NOT NULL DEFAULT 2024;
 
 ALTER TABLE family_top_percentage_history
-ADD COLUMN month INT NOT NULL DEFAULT 1;
+ADD COLUMN history_month INT NOT NULL DEFAULT 1;
 
 

--- a/gateway/src/main/resources/db/migration/V202402252319__alter_FamolyTopPercentageHistory_tbl.sql
+++ b/gateway/src/main/resources/db/migration/V202402252319__alter_FamolyTopPercentageHistory_tbl.sql
@@ -1,0 +1,10 @@
+ALTER TABLE family_top_percentage_history
+DROP COLUMN date;
+
+ALTER TABLE family_top_percentage_history
+ADD COLUMN year INT NOT NULL DEFAULT 2024;
+
+ALTER TABLE family_top_percentage_history
+ADD COLUMN month INT NOT NULL DEFAULT 1;
+
+

--- a/gateway/src/main/resources/db/migration/V202402260000__add_ShedLock_tbl.sql
+++ b/gateway/src/main/resources/db/migration/V202402260000__add_ShedLock_tbl.sql
@@ -1,0 +1,9 @@
+CREATE TABLE shedlock
+(
+    name       VARCHAR(64)  NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    locked_by  VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+) DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci COMMENT 'ShedLock 테이블';


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
감사히도 피드백주신 #158 를 드디어 도입하게 되었습니다. ShedLock을 통해 락을 추가하였고, 인스턴스 간의 중복이 발생하지 않도록 스케줄의 최소 lock 소유 시간을 30초로 잡았습니다. (어차피 한달에 한 번 실행하므로)

수정하는 김에 관련 코드와 테이블을 클린하게 변경했습니다.

## ➕ 추가/변경된 기능

---
- FamilyTopPercentageHistory 테이블 구조 변경
- 테이블의 기존 데이터이 정상적으로 작동하도록 default 값을 추가하여 flyway 작성
- ShedLock 도입
- recordAllFamilyTopPercentageHistoriesMonthly 스케줄에 락 추가 (최소, 최대 30초 Locked)
- 로깅 추가

## 🥺 리뷰어에게 하고싶은 말

---
ShedLock 공식 가이드를 따라 flyway도 추가하였지만, 간혹 ShedLock 테이블이 정상적으로 연결되지 않는 경우도 있다고 들었습니다. dev 환경에서 제대로 실행되는지 확인할 필요가 있습니다.



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-206