### PR TITLE
[OING-217] chore: local환경을 위한 EmbeddedRedis 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,7 @@ subprojects {
         implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3'
         implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
         implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0'
+        implementation 'it.ozimov:embedded-redis:0.7.2'
         runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
         runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
         implementation("com.nimbusds:nimbus-jose-jwt:9.37")
@@ -143,7 +144,6 @@ subprojects {
         annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.springframework.security:spring-security-test'
-        testImplementation 'it.ozimov:embedded-redis:0.7.2'
     }
 }
 

--- a/gateway/src/main/java/com/oing/config/EmbeddedRedisConfig.java
+++ b/gateway/src/main/java/com/oing/config/EmbeddedRedisConfig.java
@@ -1,0 +1,36 @@
+package com.oing.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+@Configuration
+@Profile("local")
+public class EmbeddedRedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void startRedis() {
+        try {
+            redisServer = RedisServer.builder()
+                    .port(port)
+                    .setting("maxmemory 256M")
+                    .build();
+            redisServer.start();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        redisServer.stop();
+    }
+}

--- a/gateway/src/main/resources/template-application-local.yaml
+++ b/gateway/src/main/resources/template-application-local.yaml
@@ -12,11 +12,14 @@ spring:
           enabled: true
         show_sql: true
         format_sql: true
+  data:
+    redis:
+      host: ${REDIS_HOST} # Must Be Replaced
+      port: ${REDIS_PORT} # Must Be Replaced
+
 app:
-<<<<<<< HEAD
-=======
   oauth:
-    google-client-id: ${GOOGLE_CLIENT_ID}
+    google-client-id: ${GOOGLE_CLIENT_ID} # Must Be Replaced
   web:
     versionFilterEnabled: false
   external-urls:
@@ -25,11 +28,12 @@ app:
     secret-key: ${TOKEN_SECRET_KEY} # Must Be Replaced
 
 cloud:
+  firebase: ${FIREBASE_SECRET} # Must Be Replaced
   ncp:
-    region: ${OBJECT_STORAGE_REGION}
-    end-point: ${OBJECT_STORAGE_END_POINT}
-    access-key: ${OBJECT_STORAGE_ACCESS_KEY}
-    secret-key: ${OBJECT_STORAGE_SECRET_KEY}
-    image-optimizer-cdn: ${IMAGE_OPTIMIZER_CDN_URL}
+    region: ${OBJECT_STORAGE_REGION} # Must Be Replaced
+    end-point: ${OBJECT_STORAGE_END_POINT} # Must Be Replaced
+    access-key: ${OBJECT_STORAGE_ACCESS_KEY} # Must Be Replaced
+    secret-key: ${OBJECT_STORAGE_SECRET_KEY} # Must Be Replaced
     storage:
-      bucket: ${OBJECT_STORAGE_BUCKET_NAME}
+      bucket: ${OBJECT_STORAGE_BUCKET_NAME} # Must Be Replaced
+    image-optimizer-cdn: ${IMAGE_OPTIMIZER_CDN_URL} # Must Be Replaced

--- a/gateway/src/test/java/com/oing/config/support/S3PreSignedUrlProviderTest.java
+++ b/gateway/src/test/java/com/oing/config/support/S3PreSignedUrlProviderTest.java
@@ -3,13 +3,14 @@ package com.oing.config.support;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.oing.dto.response.PreSignedUrlResponse;
-import com.oing.support.InfraTest;
 import com.oing.util.IdentityGenerator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URL;
 
@@ -19,7 +20,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class S3PreSignedUrlProviderTest extends InfraTest {
+@ExtendWith(MockitoExtension.class)
+class S3PreSignedUrlProviderTest {
 
     private S3PreSignedUrlProvider provider;
 

--- a/gateway/src/test/java/com/oing/support/InfraTest.java
+++ b/gateway/src/test/java/com/oing/support/InfraTest.java
@@ -1,8 +1,0 @@
-package com.oing.support;
-
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-@ExtendWith(MockitoExtension.class)
-public class InfraTest {
-}


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
기존에는 로컬에서 Redis가 실행중이어야 서버 실행이 되었는데 Redis가 실행중이지 않을 때도 서버 실행이 가능하도록 변경했습니다.

## ➕ 추가/변경된 기능

---
- local용 EmbeddedRedisConfig 추가
- local 환경 설정 파일 템플릿 수정
- 사용하지 않는 InfraTest 삭제
## 🥺 리뷰어에게 하고싶은 말

---
<img width="647" alt="스크린샷 2024-02-26 오후 8 58 52" src="https://github.com/depromeet/14th-team5-BE/assets/69844138/96b69e2e-8113-432f-845f-a4a501dba19a">
local 환경 설정 파일을 생성하고 profile을 local로 바꾸면 레디스가 꺼져있어도 캘린더 기능이 정상동작합니다. 안된다면 알려주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-217