### PR TITLE
[OING-208] feat: Sentry 도입 및 예외와 스케줄링 Job 추적 추가

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,8 @@ on:
         required: true
       DOCKER_PASSWORD:
         required: true
+      SENTRY_AUTH_TOKEN:
+        required: true
 
 env:
   IMAGE_TAG: ${{ inputs.image-tag || 'latest' }}
@@ -49,6 +51,7 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           echo "IMAGE_TAG=$IMAGE_TAG, ACTIVE_PROFILE=$ACTIVE_PROFILE, IMAGE_NAME=$IMAGE_NAME" &&
           chmod +x ./gradlew &&

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -59,6 +59,7 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   call-deploy-workflow:
     if: github.event_name == 'push'

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -59,6 +59,7 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   call-deploy-workflow:
     if: github.event_name == 'push'

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'jacoco-report-aggregation'
+    id "io.sentry.jvm.gradle" version "3.12.0"
 }
 
 repositories {
@@ -19,6 +20,7 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'jacoco'
     apply plugin: 'jacoco-report-aggregation'
+    apply plugin: 'io.sentry.jvm.gradle'
 
     configurations {
         compileOnly {
@@ -114,6 +116,14 @@ subprojects {
                 ] + Qdomains
             }
         }
+    }
+
+    sentry {
+        includeSourceContext = true
+
+        org = "sentry"
+        projectName = "bibbi-prod"
+        authToken = System.getenv("SENTRY_AUTH_TOKEN")
     }
 
     dependencies {

--- a/family/src/main/java/com/oing/job/FamilyStatisticJob.java
+++ b/family/src/main/java/com/oing/job/FamilyStatisticJob.java
@@ -1,6 +1,8 @@
 package com.oing.job;
 
 import com.oing.service.FamilyScoreBridge;
+import io.sentry.Sentry;
+import io.sentry.SentryLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -23,7 +25,9 @@ public class FamilyStatisticJob {
         LocalDate historyDate = LocalDate.now().minusMonths(1);
         int historyYear = historyDate.getYear();
         int historyMonth = historyDate.getMonthValue();
+
         log.info("[MonthlyFamilyTopPercentageHistoryRecordingSchedule: {}-{}] scheduled and locked for 30s", historyYear, historyMonth);
+        Sentry.captureMessage("⏰ [MonthlyFamilyTopPercentageHistoryRecordingSchedule: {"+historyYear+"}-{"+historyMonth+"}] scheduled and locked for 30s", SentryLevel.INFO);
 
         familyScoreBridge.updateAllFamilyTopPercentageHistories(historyYear, historyMonth);
     }

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -115,3 +115,9 @@ management:
     web:
       exposure:
         include: health,info,prometheus
+
+sentry:
+  dsn: ${SENTRY_DSN:}
+  # Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.
+  # We recommend adjusting this value in production.
+  traces-sample-rate: 0.5


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
라이브 서버에서 추적되지 않고있는 401, 400 UNKNOWN exception error를 추적하기 위해, 서버의 예외와 메시지를 추적 및 관리해주는 Sentry를 도입했습니다. 다만 NCP monitor 서버에 구축하였으나, 구동을 위해 굉장한 사양을 요구하는 것으로 보입니다. (NCP monitor 서버 Scale-up 함: 2 vCPU 8GB Ram -> 4 vCPU 16GB RAM) 도입이후 유지비 대비 유용성을 계속 검토해야할 것으로 보입니다.

Sentry에 필요한 라이브러리 도커를 구동중인 모습
![스크린샷 2024-02-26 16 36 56](https://github.com/depromeet/14th-team5-BE/assets/49567744/05e74c41-a085-4c99-a873-4ba416c2eb0a)

## ➕ 추가/변경된 기능

---
- Sentry 구축 및 스프링 부트와 연결
- `SpringWebExceptionHandler`에서 모든 예외 추적 추가
- `FamilyStatisticJob`와 `DailyNotificationJob`의 스케줄링 잡에 메시지 추적 추가

## 🥺 리뷰어에게 하고싶은 말

---
원래 정책은 개발서버가 아닌 라이브 서버에만 Sentry가 적용되어야 하지만. Sentry에 멀티 모듈 프로젝트 적용 가이드도 없고 첫 도입이라 우선 개발 서버에 Sentry를 적용하여 테스트해볼 예정입니다. **정상작동이 확인되면 빠르게 라이브 서버에 적용하여 데이터를 수집하고 싶으므로, 금일 27(화) 중으로 개발서버에서 테스트 및 버전 릴리즈와 Sentry 적용을 했으면 합니다.**



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-208