### PR TITLE
[OING-250] feat: post 모듈 로깅 추가

### DIFF
--- a/post/src/main/java/com/oing/restapi/MemberPostApi.java
+++ b/post/src/main/java/com/oing/restapi/MemberPostApi.java
@@ -33,7 +33,11 @@ public interface MemberPostApi {
     PreSignedUrlResponse requestPresignedUrl(
             @Valid
             @RequestBody
-            PreSignedUrlRequest request
+            PreSignedUrlRequest request,
+
+            @Parameter(hidden = true)
+            @LoginMemberId
+            String loginMemberId
     );
 
     @Operation(summary = "게시물 조회", description = "게시물 목록을 조회합니다. 조회 기준은 생성 순서입니다.")

--- a/post/src/test/java/com/oing/controller/MemberPostControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberPostControllerTest.java
@@ -37,9 +37,9 @@ public class MemberPostControllerTest {
 
         // when
         PreSignedUrlRequest request = new PreSignedUrlRequest(newFeedImage);
-        PreSignedUrlResponse dummyResponse = new PreSignedUrlResponse("https://test.com/presigend-request-url");
+        PreSignedUrlResponse dummyResponse = new PreSignedUrlResponse("https://test.com/presigend-request-url.jpg");
         when(preSignedUrlGenerator.getFeedPreSignedUrl(any())).thenReturn(dummyResponse);
-        PreSignedUrlResponse response = memberPostController.requestPresignedUrl(request);
+        PreSignedUrlResponse response = memberPostController.requestPresignedUrl(request, "1");
 
         // then
         assertNotNull(response.url());

--- a/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
@@ -13,7 +13,6 @@ import com.oing.exception.DuplicateRealEmojiException;
 import com.oing.service.MemberRealEmojiService;
 import com.oing.util.IdentityGenerator;
 import com.oing.util.PreSignedUrlGenerator;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -27,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@Transactional
+//@Transactional
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 public class MemberRealEmojiControllerTest {
@@ -49,7 +48,7 @@ public class MemberRealEmojiControllerTest {
 
         // when
         PreSignedUrlRequest request = new PreSignedUrlRequest(realEmojiImage);
-        PreSignedUrlResponse dummyResponse = new PreSignedUrlResponse("https://test.com/presigend-request-url");
+        PreSignedUrlResponse dummyResponse = new PreSignedUrlResponse("https://test.com/presigend-request-url.jpg");
         when(preSignedUrlGenerator.getRealEmojiPreSignedUrl(any())).thenReturn(dummyResponse);
         PreSignedUrlResponse response = memberRealEmojiController.requestPresignedUrl(memberId, memberId, request);
 

--- a/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/MemberRealEmojiControllerTest.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-//@Transactional
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 public class MemberRealEmojiControllerTest {


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
post 모듈 기능에 대해 로깅을 추가했습니다.

## ➕ 추가/변경된 기능

---
- 포스트 컨트롤러 로깅 추가
- 회원 리얼이모지 컨트롤러 로깅 추가
- 포스트 리얼이모지 컨트롤러 로깅 추가
- 포스트 코멘트 컨트롤러 로깅 추가
- 포스트 리액션 컨트롤러 로깅 추가

## 🥺 리뷰어에게 하고싶은 말

---
오타가 있거나 보완할 부분이 있다면 알려주세요~
그리고 리얼이모지/리액션을 등록/삭제 할 때 해당 회원이 이미 등록/삭제했는지 확인하는 검증 로직이 있는데 이 부분은 프론트에서 사용자가 이모지 한번 더 눌렀을 때 등록/삭제 어느 operation을 취해야할지 확인하는 용도로도 쓰인다고 생각해서 로깅을 안했는데 이 방법이 맞을까요? (이거까지 로깅하면 많은 로그가 쌓일 거 같아 로깅에서 제외했습니다)


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-250