### PR TITLE
[OING-270] feat: 회원 탈퇴 시, 프로필 이미지 키 삭제 기능 추가

### DIFF
--- a/member/src/main/java/com/oing/domain/Member.java
+++ b/member/src/main/java/com/oing/domain/Member.java
@@ -63,6 +63,7 @@ public class Member extends DeletableBaseAuditEntity {
         super.updateDeletedAt();
         this.name = "DeletedMember";
         this.profileImgUrl = null;
+        this.profileImgKey = null;
     }
 
     public void setFamilyId(String familyId) {

--- a/member/src/test/java/com/oing/controller/MemberControllerTest.java
+++ b/member/src/test/java/com/oing/controller/MemberControllerTest.java
@@ -193,7 +193,7 @@ public class MemberControllerTest {
     void 멤버_탈퇴_테스트() {
         // given
         Member member = new Member("1", "1", LocalDate.of(2000, 7, 8),
-                "testMember1", "http://test.com/test-profile.jpg", null,
+                "testMember1", "http://test.com/test-profile.jpg", "/test-profile.jpg",
                 LocalDateTime.now());
         when(memberService.findMemberById(any())).thenReturn(member);
 
@@ -203,6 +203,7 @@ public class MemberControllerTest {
         // then
         assertEquals("DeletedMember", member.getName());
         assertNull(member.getProfileImgUrl());
+        assertNull(member.getProfileImgKey());
     }
 
     @Test


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
회원 탈퇴 시, 프로필 이미지 키를 삭제 기능이 없어 추가했습니다.

## ➕ 추가/변경된 기능

---
- 회원 탈퇴 시, 프로필 이미지 키 삭제 기능 추가

## 🥺 리뷰어에게 하고싶은 말

---
확인해주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-270