### PR TITLE
fix: UTC로 설정된 월간 가족 이력 데이터 기록 스케줄러를 KST로 변경

### DIFF
--- a/family/src/main/java/com/oing/job/FamilyStatisticJob.java
+++ b/family/src/main/java/com/oing/job/FamilyStatisticJob.java
@@ -18,7 +18,7 @@ public class FamilyStatisticJob {
 
     private final FamilyScoreBridge familyScoreBridge;
 
-    @Scheduled(cron = "0 0 1 1 * *") // 매월 1일 01시
+    @Scheduled(cron = "0 0 1 1 * *", zone = "Asia/Seoul") // 매월 1일 01시
     @SchedulerLock(name = "MonthlyFamilyTopPercentageHistoryRecordingSchedule", lockAtMostFor = "PT30S", lockAtLeastFor = "PT30S")
     public void recordAllFamilyTopPercentageHistoriesMonthly() {
         // 방금 막 지나간 지난 달의 데이터를 기록한다.


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
월간 가족 이력 데이터 기록 스케줄러를 UTC 기준으로 설정되어 있었습니다.

## ➕ 추가/변경된 기능

---
- UTC로 설정된 월간 가족 이력 데이터 기록 스케줄러를 KST로 변경

## 🥺 리뷰어에게 하고싶은 말

---
ㅎ;

