### PR TITLE
[OING-277] fix: test용 RedisConfig 추가

### DIFF
--- a/gateway/src/main/java/com/oing/config/RedisConfig.java
+++ b/gateway/src/main/java/com/oing/config/RedisConfig.java
@@ -14,7 +14,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.util.Collections;
 
-@Profile({"local", "dev", "prod"})
+@Profile("!test")
 @Configuration
 public class RedisConfig {
 

--- a/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
@@ -9,6 +9,7 @@ import com.oing.dto.response.DeepLinkResponse;
 import com.oing.dto.response.FamilyResponse;
 import com.oing.service.*;
 import com.oing.support.EmbeddedRedisConfig;
+import com.oing.support.RedisTestConfig;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @SpringBootTest
-@Import(EmbeddedRedisConfig.class)
+@Import({EmbeddedRedisConfig.class, RedisTestConfig.class})
 @ActiveProfiles("test")
 @Transactional
 @AutoConfigureMockMvc

--- a/gateway/src/test/java/com/oing/restapi/MemberPostApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MemberPostApiTest.java
@@ -9,6 +9,7 @@ import com.oing.repository.MemberPostRepository;
 import com.oing.repository.MemberRepository;
 import com.oing.service.TokenGenerator;
 import com.oing.support.EmbeddedRedisConfig;
+import com.oing.support.RedisTestConfig;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
-@Import(EmbeddedRedisConfig.class)
+@Import({EmbeddedRedisConfig.class, RedisTestConfig.class})
 @Transactional
 @ActiveProfiles("test")
 @AutoConfigureMockMvc

--- a/gateway/src/test/java/com/oing/support/EmbeddedRedisConfig.java
+++ b/gateway/src/test/java/com/oing/support/EmbeddedRedisConfig.java
@@ -7,8 +7,8 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Profile;
 import redis.embedded.RedisServer;
 
-@TestConfiguration
 @Profile("test")
+@TestConfiguration
 public class EmbeddedRedisConfig {
 
     @Value("${spring.data.redis.port}")

--- a/gateway/src/test/java/com/oing/support/RedisTestConfig.java
+++ b/gateway/src/test/java/com/oing/support/RedisTestConfig.java
@@ -1,22 +1,19 @@
-package com.oing.config;
+package com.oing.support;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import java.util.Collections;
-
-@Profile({"local", "dev", "prod"})
+@Profile("test")
 @Configuration
-public class RedisConfig {
+public class RedisTestConfig {
 
     @Value("${spring.data.redis.host}")
     private String redisHost;
@@ -26,8 +23,7 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        LettuceClientConfiguration configuration = LettuceClientConfiguration.builder().useSsl().build();
-        return new LettuceConnectionFactory(new RedisClusterConfiguration(Collections.singleton(redisHost + ":" + redisPort)), configuration);
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
     }
 
     @Bean

--- a/gateway/src/test/java/com/oing/support/RedisTestConfig.java
+++ b/gateway/src/test/java/com/oing/support/RedisTestConfig.java
@@ -1,8 +1,8 @@
 package com.oing.support;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
@@ -12,7 +12,7 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Profile("test")
-@Configuration
+@TestConfiguration
 public class RedisTestConfig {
 
     @Value("${spring.data.redis.host}")


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
서버 이전을 하면서 레디스가 serverless(cluster mode)로 바뀌어 레디스 설정 파일에서는 클러스터 모드인데 임베디드 레디스는 단일 구성 설정이라 제대로 동작되지 않았습니다. 
클러스터 모드이지만 port를 하나만 쓰는 단일 구성형태라 임베디드 레디스는 그대로 두고 임베디드 레디스를 위한 테스트용 RedisConfig 파일을 생성했습니다.

## ➕ 추가/변경된 기능

---
- test용 RedisConfig 추가

## 🥺 리뷰어에게 하고싶은 말

---
임베디드 레디스가 실행되어 캘린더쪽 테스트코드가 돌아가는지 확인해주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-277