### PR TITLE
[OING-252] refactor: 잘못된 Sentry 로깅 설정 수정 및 Jwt Token 예외 핸들링 일부 리펙토링

### DIFF
--- a/common/src/main/java/com/oing/exception/ErrorCode.java
+++ b/common/src/main/java/com/oing/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     AUTHENTICATION_FAILED("AU0001", "Authentication failed"),
     AUTHORIZATION_FAILED("AU0002", "No Permission"),
     REFRESH_TOKEN_INVALID("AU0003", "Refresh Token is invalid"),
+    TOKEN_EXPIRED("AU0004", "Token is expired"),
     /**
      * Member Related Errors
      */

--- a/common/src/main/java/com/oing/exception/ErrorCode.java
+++ b/common/src/main/java/com/oing/exception/ErrorCode.java
@@ -22,9 +22,10 @@ public enum ErrorCode {
      * Auth Related Errors
      */
     AUTHENTICATION_FAILED("AU0001", "Authentication failed"),
-    AUTHORIZATION_FAILED("AU0002", "No Permission"),
-    REFRESH_TOKEN_INVALID("AU0003", "Refresh Token is invalid"),
-    TOKEN_EXPIRED("AU0004", "Token is expired"),
+    TOKEN_AUTHENTICATION_FAILED("AU0002", "Token Authentication failed"),
+    AUTHORIZATION_FAILED("AU0003", "No Permission"),
+    REFRESH_TOKEN_INVALID("AU0004", "Refresh Token is invalid"),
+    TOKEN_EXPIRED("AU0005", "Token is expired"),
     /**
      * Member Related Errors
      */

--- a/gateway/src/main/java/com/oing/config/SpringWebExceptionHandler.java
+++ b/gateway/src/main/java/com/oing/config/SpringWebExceptionHandler.java
@@ -103,7 +103,7 @@ public class SpringWebExceptionHandler {
 
         return ResponseEntity
                 .status(UNAUTHORIZED)
-                .body(ErrorResponse.of(ErrorCode.AUTHENTICATION_FAILED));
+                .body(ErrorResponse.of(ErrorCode.TOKEN_AUTHENTICATION_FAILED));
     }
 
     @ExceptionHandler(IOException.class)

--- a/gateway/src/main/java/com/oing/config/SpringWebExceptionHandler.java
+++ b/gateway/src/main/java/com/oing/config/SpringWebExceptionHandler.java
@@ -7,6 +7,7 @@ import com.oing.dto.response.ErrorResponse;
 import com.oing.exception.TokenNotValidException;
 import com.oing.exception.DomainException;
 import com.oing.exception.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +28,7 @@ import java.io.StringWriter;
 import java.security.InvalidParameterException;
 import java.util.Enumeration;
 
-import static io.sentry.SentryLevel.ERROR;
-import static io.sentry.SentryLevel.WARNING;
+import static io.sentry.SentryLevel.*;
 import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
@@ -84,10 +84,21 @@ public class SpringWebExceptionHandler {
                 .body(ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED));
     }
 
-    @ExceptionHandler(TokenNotValidException.class)
-    ResponseEntity<ErrorResponse> handleAuthenticationFailedException(HttpServletRequest request, TokenNotValidException exception) {
+    @ExceptionHandler(ExpiredJwtException.class)
+    ResponseEntity<ErrorResponse> handleExpiredJwtException(HttpServletRequest request, ExpiredJwtException exception) {
 
-        log.warn("[AuthenticationFailedException]", exception);
+        log.info("[ExpiredJwtException]", exception);
+        sentryGateway.captureException(exception, INFO, request, UNAUTHORIZED);
+
+        return ResponseEntity
+                .status(UNAUTHORIZED)
+                .body(ErrorResponse.of(ErrorCode.TOKEN_EXPIRED));
+    }
+
+    @ExceptionHandler(TokenNotValidException.class)
+    ResponseEntity<ErrorResponse> handleTokenNotValidException(HttpServletRequest request, TokenNotValidException exception) {
+
+        log.warn("[TokenNotValidException]", exception);
         sentryGateway.captureException(exception, WARNING, request, UNAUTHORIZED);
 
         return ResponseEntity

--- a/gateway/src/main/java/com/oing/config/filter/JwtAuthenticationEntryPoint.java
+++ b/gateway/src/main/java/com/oing/config/filter/JwtAuthenticationEntryPoint.java
@@ -37,6 +37,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setCharacterEncoding("UTF-8");
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.AUTHENTICATION_FAILED)));
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.TOKEN_AUTHENTICATION_FAILED)));
     }
 }

--- a/gateway/src/main/resources/application-dev.yaml
+++ b/gateway/src/main/resources/application-dev.yaml
@@ -45,7 +45,7 @@ sentry:
   environment: development
   logging:
     enabled: true
-    minimum-event-level: warn
-    minimum-breadcrumb-level: warn
+    minimum-event-level: WARN
+    minimum-breadcrumb-level: DEBUG
   dsn: ${SENTRY_DEV_DSN:}
   traces-sample-rate: 1.0

--- a/gateway/src/main/resources/application-prod.yaml
+++ b/gateway/src/main/resources/application-prod.yaml
@@ -54,8 +54,8 @@ sentry:
   environment: production
   logging:
     enabled: true
-    minimum-event-level: warn
-    minimum-breadcrumb-level: warn
+    minimum-event-level: WARN
+    minimum-breadcrumb-level: DEBUG
   dsn: ${SENTRY_PROD_DSN:}
   # Set traces-sample-rate to 1.0 to capture 100% of transactions for performance monitoring.
   # We recommend adjusting this value in production.

--- a/member/src/main/java/com/oing/exception/TokenExpiredException.java
+++ b/member/src/main/java/com/oing/exception/TokenExpiredException.java
@@ -7,4 +7,7 @@ package com.oing.exception;
  * Time: 6:24 PM
  */
 public class TokenExpiredException extends TokenNotValidException {
+    public TokenExpiredException() {
+        super(ErrorCode.TOKEN_EXPIRED);
+    }
 }

--- a/member/src/main/java/com/oing/exception/TokenNotValidException.java
+++ b/member/src/main/java/com/oing/exception/TokenNotValidException.java
@@ -8,7 +8,7 @@ package com.oing.exception;
  */
 public class TokenNotValidException extends DomainException {
     public TokenNotValidException() {
-        super(ErrorCode.AUTHENTICATION_FAILED);
+        super(ErrorCode.TOKEN_AUTHENTICATION_FAILED);
     }
 
     public TokenNotValidException(ErrorCode errorCode) {

--- a/member/src/main/java/com/oing/exception/TokenNotValidException.java
+++ b/member/src/main/java/com/oing/exception/TokenNotValidException.java
@@ -10,4 +10,8 @@ public class TokenNotValidException extends DomainException {
     public TokenNotValidException() {
         super(ErrorCode.AUTHENTICATION_FAILED);
     }
+
+    public TokenNotValidException(ErrorCode errorCode) {
+        super(errorCode);
+    }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
센트리 체크 중에 일부 잘못된 설정으로 인해 스택 트레이스가 안될 여지가 있어서 급하게 고쳤고, 이와 함께 향상시킬 부분이 보여서 진행했습니다.

## ➕ 추가/변경된 기능

---
- minimum-breadcrumb-level를 DEBUG로 변경
- InvalidTokenExcpetion 핸들링에서 공통적으로 핸들링 하던 ExpiredJwtTokenException을 분리
- Authentication failed 에러 코드를 공통적으로 사용하고 있던 것을 Token Authentication Failed와 Token Expired로 세분화

## 🥺 리뷰어에게 하고싶은 말

---
minimum-breadcrumb-level 는 스택 트레이스에 관련된 세팅이므로, 캡쳐하는 예외 레밸과는 다릅니다.


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-252