### PR TITLE
[OING-284] refactor: 가족 활동 점수 이벤트의 강결합 및 데드락 해결과 비동기용 테스트코드 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,7 @@ subprojects {
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.springframework.security:spring-security-test'
         testImplementation 'it.ozimov:embedded-redis:0.7.2'
+        testImplementation 'org.awaitility:awaitility:4.2.0'
     }
 }
 

--- a/common/src/main/java/com/oing/event/MemberPostCommentCreatedEvent.java
+++ b/common/src/main/java/com/oing/event/MemberPostCommentCreatedEvent.java
@@ -6,10 +6,12 @@ import org.springframework.context.ApplicationEvent;
 @Getter
 public class MemberPostCommentCreatedEvent extends ApplicationEvent {
 
+        private final String commentId;
         private final String memberId;
 
-        public MemberPostCommentCreatedEvent(Object source, String memberId) {
+        public MemberPostCommentCreatedEvent(Object source, String commentId, String memberId) {
             super(source);
+            this.commentId = commentId;
             this.memberId = memberId;
         }
 }

--- a/common/src/main/java/com/oing/event/MemberPostCommentDeletedEvent.java
+++ b/common/src/main/java/com/oing/event/MemberPostCommentDeletedEvent.java
@@ -6,10 +6,12 @@ import org.springframework.context.ApplicationEvent;
 @Getter
 public class MemberPostCommentDeletedEvent  extends ApplicationEvent {
 
+    private final String commentId;
     private final String memberId;
 
-    public MemberPostCommentDeletedEvent(Object source, String memberId) {
+    public MemberPostCommentDeletedEvent(Object source, String commentId, String memberId) {
         super(source);
+        this.commentId = commentId;
         this.memberId = memberId;
     }
 }

--- a/common/src/main/java/com/oing/event/MemberPostCreatedEvent.java
+++ b/common/src/main/java/com/oing/event/MemberPostCreatedEvent.java
@@ -6,10 +6,12 @@ import org.springframework.context.ApplicationEvent;
 @Getter
 public class MemberPostCreatedEvent extends ApplicationEvent {
 
+    private final String postId;
     private final String memberId;
 
-    public MemberPostCreatedEvent(Object source, String memberId) {
+    public MemberPostCreatedEvent(Object source, String postId, String memberId) {
         super(source);
+        this.postId = postId;
         this.memberId = memberId;
     }
 }

--- a/common/src/main/java/com/oing/event/MemberPostDeletedEvent.java
+++ b/common/src/main/java/com/oing/event/MemberPostDeletedEvent.java
@@ -6,10 +6,12 @@ import org.springframework.context.ApplicationEvent;
 @Getter
 public class MemberPostDeletedEvent extends ApplicationEvent {
 
+    private final String postId;
     private final String memberId;
 
-    public MemberPostDeletedEvent(Object source, String memberId) {
+    public MemberPostDeletedEvent(Object source, String postId, String memberId) {
         super(source);
+        this.postId = postId;
         this.memberId = memberId;
     }
 }

--- a/common/src/main/java/com/oing/event/MemberPostReactionCreatedEvent.java
+++ b/common/src/main/java/com/oing/event/MemberPostReactionCreatedEvent.java
@@ -6,10 +6,12 @@ import org.springframework.context.ApplicationEvent;
 @Getter
 public class MemberPostReactionCreatedEvent extends ApplicationEvent {
 
-        private final String memberId;
+    private final String reactionId;
+    private final String memberId;
 
-        public MemberPostReactionCreatedEvent(Object source, String memberId) {
-            super(source);
-            this.memberId = memberId;
-        }
+    public MemberPostReactionCreatedEvent(Object source, String reactionId, String memberId) {
+        super(source);
+        this.reactionId = reactionId;
+        this.memberId = memberId;
+    }
 }

--- a/common/src/main/java/com/oing/event/MemberPostReactionDeletedEvent.java
+++ b/common/src/main/java/com/oing/event/MemberPostReactionDeletedEvent.java
@@ -6,10 +6,12 @@ import org.springframework.context.ApplicationEvent;
 @Getter
 public class MemberPostReactionDeletedEvent extends ApplicationEvent {
 
+    private final String reactionId;
     private final String memberId;
 
-    public MemberPostReactionDeletedEvent(Object source, String memberId) {
+    public MemberPostReactionDeletedEvent(Object source, String reactionId, String memberId) {
         super(source);
+        this.reactionId = reactionId;
         this.memberId = memberId;
     }
 }

--- a/common/src/main/java/com/oing/event/MemberPostRealEmojiCreatedEvent.java
+++ b/common/src/main/java/com/oing/event/MemberPostRealEmojiCreatedEvent.java
@@ -6,10 +6,12 @@ import org.springframework.context.ApplicationEvent;
 @Getter
 public class MemberPostRealEmojiCreatedEvent extends ApplicationEvent {
 
-        private final String memberId;
+    private final String realEmojiId;
+    private final String memberId;
 
-        public MemberPostRealEmojiCreatedEvent(Object source, String memberId) {
-            super(source);
-            this.memberId = memberId;
-        }
+    public MemberPostRealEmojiCreatedEvent(Object source, String realEmojiId, String memberId) {
+        super(source);
+        this.realEmojiId = realEmojiId;
+        this.memberId = memberId;
+    }
 }

--- a/common/src/main/java/com/oing/event/MemberPostRealEmojiDeletedEvent.java
+++ b/common/src/main/java/com/oing/event/MemberPostRealEmojiDeletedEvent.java
@@ -6,10 +6,12 @@ import org.springframework.context.ApplicationEvent;
 @Getter
 public class MemberPostRealEmojiDeletedEvent extends ApplicationEvent {
 
+    private final String realEmojiId;
     private final String memberId;
 
-    public MemberPostRealEmojiDeletedEvent(Object source, String memberId) {
+    public MemberPostRealEmojiDeletedEvent(Object source, String realEmojiId, String memberId) {
         super(source);
+        this.realEmojiId = realEmojiId;
         this.memberId = memberId;
     }
 }

--- a/family/src/main/java/com/oing/event/FamilyScoreEventListener.java
+++ b/family/src/main/java/com/oing/event/FamilyScoreEventListener.java
@@ -4,6 +4,7 @@ import com.oing.service.FamilyService;
 import com.oing.service.MemberBridge;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ public class FamilyScoreEventListener {
     public final MemberBridge memberBridge;
     public final FamilyService familyService;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostCreatedEvent(MemberPostCreatedEvent memberPostCreatedEvent) {
@@ -29,6 +31,7 @@ public class FamilyScoreEventListener {
         log.info("New post score of family({}) added", familyId);
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostDeletedEvent(MemberPostDeletedEvent memberPostDeletedEvent) {
@@ -40,6 +43,7 @@ public class FamilyScoreEventListener {
         log.info("Deleted post score of family({}) subtracted", familyId);
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostCommentCreatedEvent(MemberPostCommentCreatedEvent memberPostCommentCreatedEvent) {
@@ -51,6 +55,7 @@ public class FamilyScoreEventListener {
         log.info("New comment score of family({}) added", familyId);
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostCommentDeletedEvent(MemberPostCommentDeletedEvent memberPostCommentDeletedEvent) {
@@ -62,6 +67,7 @@ public class FamilyScoreEventListener {
         log.info("Deleted comment score of family({}) subtracted", familyId);
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostReactionCreatedEvent(MemberPostReactionCreatedEvent memberPostReactionCreatedEvent) {
@@ -73,6 +79,7 @@ public class FamilyScoreEventListener {
         log.info("New reaction score of family({}) added", familyId);
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostReactionDeletedEvent(MemberPostReactionDeletedEvent memberPostReactionDeletedEvent) {
@@ -84,6 +91,7 @@ public class FamilyScoreEventListener {
         log.info("Deleted reaction score of family({}) subtracted", familyId);
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostRealEmojiCreatedEvent(MemberPostRealEmojiCreatedEvent memberPostRealEmojiCreatedEvent) {
@@ -95,6 +103,7 @@ public class FamilyScoreEventListener {
         log.info("New real emoji score of family({}) added", familyId);
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostRealEmojiDeletedEvent(MemberPostRealEmojiDeletedEvent memberPostRealEmojiDeletedEvent) {

--- a/family/src/main/java/com/oing/event/FamilyScoreEventListener.java
+++ b/family/src/main/java/com/oing/event/FamilyScoreEventListener.java
@@ -26,7 +26,7 @@ public class FamilyScoreEventListener {
         log.info("Event of new post uploaded by member({}) listened, adding family score", memberPostCreatedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostCreatedEvent.getMemberId());
-        familyService.getFamilyById(familyId).addNewPostScore();
+        familyService.getFamilyByIdWithLock(familyId).addNewPostScore();
 
         log.info("New post score of family({}) added", familyId);
     }
@@ -38,7 +38,7 @@ public class FamilyScoreEventListener {
         log.info("Event of post deleted by member({}) listened, subtracting family score", memberPostDeletedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostDeletedEvent.getMemberId());
-        familyService.getFamilyById(familyId).subtractNewPostScore();
+        familyService.getFamilyByIdWithLock(familyId).subtractNewPostScore();
 
         log.info("Deleted post score of family({}) subtracted", familyId);
     }
@@ -50,7 +50,7 @@ public class FamilyScoreEventListener {
         log.info("Event of new comment uploaded by member({}) listened, adding family score", memberPostCommentCreatedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostCommentCreatedEvent.getMemberId());
-        familyService.getFamilyById(familyId).addNewCommentScore();
+        familyService.getFamilyByIdWithLock(familyId).addNewCommentScore();
 
         log.info("New comment score of family({}) added", familyId);
     }
@@ -62,7 +62,7 @@ public class FamilyScoreEventListener {
         log.info("Event of comment deleted by member({}) listened, subtracting family score", memberPostCommentDeletedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostCommentDeletedEvent.getMemberId());
-        familyService.getFamilyById(familyId).subtractNewCommentScore();
+        familyService.getFamilyByIdWithLock(familyId).subtractNewCommentScore();
 
         log.info("Deleted comment score of family({}) subtracted", familyId);
     }
@@ -74,7 +74,7 @@ public class FamilyScoreEventListener {
         log.info("Event of new reaction uploaded by member({}) listened, adding family score", memberPostReactionCreatedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostReactionCreatedEvent.getMemberId());
-        familyService.getFamilyById(familyId).addNewReactionScore();
+        familyService.getFamilyByIdWithLock(familyId).addNewReactionScore();
 
         log.info("New reaction score of family({}) added", familyId);
     }
@@ -86,7 +86,7 @@ public class FamilyScoreEventListener {
         log.info("Event of new reaction uploaded by member({}) listened, adding family score", memberPostReactionDeletedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostReactionDeletedEvent.getMemberId());
-        familyService.getFamilyById(familyId).subtractNewReactionScore();
+        familyService.getFamilyByIdWithLock(familyId).subtractNewReactionScore();
 
         log.info("Deleted reaction score of family({}) subtracted", familyId);
     }
@@ -98,7 +98,7 @@ public class FamilyScoreEventListener {
         log.info("Event of new real emoji uploaded by member({}) listened, adding family score", memberPostRealEmojiCreatedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostRealEmojiCreatedEvent.getMemberId());
-        familyService.getFamilyById(familyId).addNewRealEmojiScore();
+        familyService.getFamilyByIdWithLock(familyId).addNewRealEmojiScore();
 
         log.info("New real emoji score of family({}) added", familyId);
     }
@@ -110,7 +110,7 @@ public class FamilyScoreEventListener {
         log.info("Event of real emoji deleted by member({}) listened, subtracting family score", memberPostRealEmojiDeletedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostRealEmojiDeletedEvent.getMemberId());
-        familyService.getFamilyById(familyId).subtractNewRealEmojiScore();
+        familyService.getFamilyByIdWithLock(familyId).subtractNewRealEmojiScore();
 
         log.info("Deleted real emoji score of family({}) subtracted", familyId);
     }

--- a/family/src/main/java/com/oing/event/FamilyScoreEventListener.java
+++ b/family/src/main/java/com/oing/event/FamilyScoreEventListener.java
@@ -23,96 +23,96 @@ public class FamilyScoreEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostCreatedEvent(MemberPostCreatedEvent memberPostCreatedEvent) {
-        log.info("Event of new post uploaded by member({}) listened, adding family score", memberPostCreatedEvent.getMemberId());
+        log.info("Event of uploading Post({}) by Member({}) listened, adding family score", memberPostCreatedEvent.getPostId(), memberPostCreatedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostCreatedEvent.getMemberId());
         familyService.getFamilyByIdWithLock(familyId).addNewPostScore();
 
-        log.info("New post score of family({}) added", familyId);
+        log.info("Uploading Post({}) score of Family({}) added", memberPostCreatedEvent.getPostId(), familyId);
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostDeletedEvent(MemberPostDeletedEvent memberPostDeletedEvent) {
-        log.info("Event of post deleted by member({}) listened, subtracting family score", memberPostDeletedEvent.getMemberId());
+        log.info("Event of deleting Post({}) by Member({}) listened, subtracting family score", memberPostDeletedEvent.getPostId(), memberPostDeletedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostDeletedEvent.getMemberId());
         familyService.getFamilyByIdWithLock(familyId).subtractNewPostScore();
 
-        log.info("Deleted post score of family({}) subtracted", familyId);
+        log.info("Deleting Post({}) score of Family({}) subtracted", memberPostDeletedEvent.getPostId(), familyId);
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostCommentCreatedEvent(MemberPostCommentCreatedEvent memberPostCommentCreatedEvent) {
-        log.info("Event of new comment uploaded by member({}) listened, adding family score", memberPostCommentCreatedEvent.getMemberId());
+        log.info("Event of uploading Comment({}) by Member({}) listened, adding family score", memberPostCommentCreatedEvent.getCommentId(), memberPostCommentCreatedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostCommentCreatedEvent.getMemberId());
         familyService.getFamilyByIdWithLock(familyId).addNewCommentScore();
 
-        log.info("New comment score of family({}) added", familyId);
+        log.info("Uploading Comment({}) score of Family({}) added", memberPostCommentCreatedEvent.getCommentId(), familyId);
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostCommentDeletedEvent(MemberPostCommentDeletedEvent memberPostCommentDeletedEvent) {
-        log.info("Event of comment deleted by member({}) listened, subtracting family score", memberPostCommentDeletedEvent.getMemberId());
+        log.info("Event of Comment({}) deleted by Member({}) listened, subtracting family score", memberPostCommentDeletedEvent.getCommentId(), memberPostCommentDeletedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostCommentDeletedEvent.getMemberId());
         familyService.getFamilyByIdWithLock(familyId).subtractNewCommentScore();
 
-        log.info("Deleted comment score of family({}) subtracted", familyId);
+        log.info("Deleting Comment({}) score of Family({}) subtracted", memberPostCommentDeletedEvent.getCommentId(), familyId);
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostReactionCreatedEvent(MemberPostReactionCreatedEvent memberPostReactionCreatedEvent) {
-        log.info("Event of new reaction uploaded by member({}) listened, adding family score", memberPostReactionCreatedEvent.getMemberId());
+        log.info("Event of uploading Reaction({}) by Member({}) listened, adding family score", memberPostReactionCreatedEvent.getReactionId(), memberPostReactionCreatedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostReactionCreatedEvent.getMemberId());
         familyService.getFamilyByIdWithLock(familyId).addNewReactionScore();
 
-        log.info("New reaction score of family({}) added", familyId);
+        log.info("Uploading Reaction({}) score of Family({}) added", memberPostReactionCreatedEvent.getReactionId(), familyId);
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostReactionDeletedEvent(MemberPostReactionDeletedEvent memberPostReactionDeletedEvent) {
-        log.info("Event of new reaction uploaded by member({}) listened, adding family score", memberPostReactionDeletedEvent.getMemberId());
+        log.info("Event of uploading Reaction({}) by Member({}) listened, adding family score", memberPostReactionDeletedEvent.getReactionId(), memberPostReactionDeletedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostReactionDeletedEvent.getMemberId());
         familyService.getFamilyByIdWithLock(familyId).subtractNewReactionScore();
 
-        log.info("Deleted reaction score of family({}) subtracted", familyId);
+        log.info("Deleting Reaction({}) score of Family({}) subtracted", memberPostReactionDeletedEvent.getReactionId(), familyId);
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostRealEmojiCreatedEvent(MemberPostRealEmojiCreatedEvent memberPostRealEmojiCreatedEvent) {
-        log.info("Event of new real emoji uploaded by member({}) listened, adding family score", memberPostRealEmojiCreatedEvent.getMemberId());
+        log.info("Event of new uploading Emoji({}) by Member({}) listened, adding family score", memberPostRealEmojiCreatedEvent.getRealEmojiId(), memberPostRealEmojiCreatedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostRealEmojiCreatedEvent.getMemberId());
         familyService.getFamilyByIdWithLock(familyId).addNewRealEmojiScore();
 
-        log.info("New real emoji score of family({}) added", familyId);
+        log.info("Uploading real Emoji({}) score of Family({}) added", memberPostRealEmojiCreatedEvent.getRealEmojiId(), familyId);
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onMemberPostRealEmojiDeletedEvent(MemberPostRealEmojiDeletedEvent memberPostRealEmojiDeletedEvent) {
-        log.info("Event of real emoji deleted by member({}) listened, subtracting family score", memberPostRealEmojiDeletedEvent.getMemberId());
+        log.info("Event of real Emoji({}) deleted by Member({}) listened, subtracting family score", memberPostRealEmojiDeletedEvent.getRealEmojiId(), memberPostRealEmojiDeletedEvent.getMemberId());
 
         String familyId = memberBridge.getFamilyIdByMemberId(memberPostRealEmojiDeletedEvent.getMemberId());
         familyService.getFamilyByIdWithLock(familyId).subtractNewRealEmojiScore();
 
-        log.info("Deleted real emoji score of family({}) subtracted", familyId);
+        log.info("Deleting real Emoji({}) score of Family({}) subtracted", memberPostRealEmojiDeletedEvent.getRealEmojiId(), familyId);
     }
 
 

--- a/family/src/main/java/com/oing/repository/FamilyRepositoryCustom.java
+++ b/family/src/main/java/com/oing/repository/FamilyRepositoryCustom.java
@@ -1,8 +1,14 @@
 package com.oing.repository;
 
+import com.oing.domain.Family;
+
+import java.util.Optional;
+
 public interface FamilyRepositoryCustom {
 
     int countByScoreDistinct();
 
     int countByScoreGreaterThanEqualScoreDistinct(int familyScore);
+
+    Optional<Family> findByIdWithLock(String familyId);
 }

--- a/family/src/main/java/com/oing/repository/FamilyRepositoryCustomImpl.java
+++ b/family/src/main/java/com/oing/repository/FamilyRepositoryCustomImpl.java
@@ -1,7 +1,14 @@
 package com.oing.repository;
 
+import com.oing.domain.Family;
+import com.oing.domain.QFamily;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 import static com.oing.domain.QFamily.family;
 
@@ -31,5 +38,14 @@ public class FamilyRepositoryCustomImpl implements FamilyRepositoryCustom {
                 .size();
     }
 
+    @Override
+    public Optional<Family> findByIdWithLock(String familyId) {
+        Family family = queryFactory
+                .selectFrom(QFamily.family)
+                .where(QFamily.family.id.eq(familyId))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchFirst();
 
+        return Optional.ofNullable(family);
+    }
 }

--- a/family/src/main/java/com/oing/service/FamilyService.java
+++ b/family/src/main/java/com/oing/service/FamilyService.java
@@ -52,6 +52,13 @@ public class FamilyService {
                 .orElseThrow(FamilyNotFoundException::new);
     }
 
+    @Transactional
+    public Family getFamilyByIdWithLock(String familyId) {
+        return familyRepository
+                .findByIdWithLock(familyId)
+                .orElseThrow(FamilyNotFoundException::new);
+    }
+
     public int getFamilyTopPercentage(String familyId, LocalDate calendarDate) {
         if (DateUtils.isCurrentMonth(calendarDate)) {
             return calculateLiveFamilyTopPercentage(familyId);

--- a/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
+++ b/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
@@ -96,7 +96,7 @@ class FamilyScoreEventListenerTest {
         ));
 
         // then
-        await().atMost(10, SECONDS).until(() -> {
+        await().atMost(5, SECONDS).until(() -> {
             Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
             return newScore.equals(NEW_POST_SCORE * 2);
         });
@@ -127,7 +127,7 @@ class FamilyScoreEventListenerTest {
         memberPostRepository.deleteById("2");
 
         // then
-        await().atMost(10, SECONDS).until(() -> {
+        await().atMost(5, SECONDS).until(() -> {
             Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
             return newScore.equals(0);
         });
@@ -162,7 +162,7 @@ class FamilyScoreEventListenerTest {
         ));
 
         // then
-        await().atMost(10, SECONDS).until(() -> {
+        await().atMost(5, SECONDS).until(() -> {
             Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
             return newScore.equals(originScore + NEW_COMMENT_SCORE * 2);
         });
@@ -199,7 +199,7 @@ class FamilyScoreEventListenerTest {
         memberPostCommentRepository.deleteById("2");
 
         // then
-        await().atMost(10, SECONDS).until(() -> {
+        await().atMost(5, SECONDS).until(() -> {
             Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
             return newScore.equals(originScore - (NEW_COMMENT_SCORE * 2));
         });
@@ -234,7 +234,7 @@ class FamilyScoreEventListenerTest {
         ));
 
         // then
-        await().atMost(10, SECONDS).until(() -> {
+        await().atMost(5, SECONDS).until(() -> {
             Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
             return newScore.equals(originScore + (NEW_REACTION_SCORE * 2));
         });
@@ -271,7 +271,7 @@ class FamilyScoreEventListenerTest {
         memberPostReactionRepository.deleteById("2");
 
         // then
-        await().atMost(10, SECONDS).until(() -> {
+        await().atMost(5, SECONDS).until(() -> {
             Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
             return newScore.equals(originScore - (NEW_REACTION_SCORE * 2));
         });
@@ -323,7 +323,7 @@ class FamilyScoreEventListenerTest {
         ));
 
         // then
-        await().atMost(10, SECONDS).until(() -> {
+        await().atMost(5, SECONDS).until(() -> {
             Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
             return newScore.equals(originScore + (NEW_REAL_EMOJI_SCORE * 2));
         });
@@ -378,7 +378,7 @@ class FamilyScoreEventListenerTest {
         memberPostRealEmojiRepository.deleteById("2");
 
         // then
-        await().atMost(10, SECONDS).until(() -> {
+        await().atMost(5, SECONDS).until(() -> {
             Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
             return newScore.equals(originScore - (NEW_REAL_EMOJI_SCORE * 2));
         });

--- a/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
+++ b/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
@@ -14,10 +14,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.oing.domain.Family.*;
-import static org.assertj.core.api.Assertions.assertThat;
+import static java.util.concurrent.TimeUnit.*;
+import static org.awaitility.Awaitility.await;
 
-@ActiveProfiles("test")
 @SpringBootTest
+@ActiveProfiles("test")
 @ExtendWith(DatabaseCleanerExtension.class)
 class FamilyScoreEventListenerTest {
 
@@ -75,7 +76,7 @@ class FamilyScoreEventListenerTest {
 
 
     @Test
-    void 새로운_글이_업로드되면_가족_점수를_더한다() throws InterruptedException {
+    void 새로운_글이_업로드되면_가족_점수를_더한다() {
         // given & when
         memberPostRepository.save(new MemberPost(
                 "1",
@@ -94,15 +95,15 @@ class FamilyScoreEventListenerTest {
                 "2"
         ));
 
-        Thread.sleep(1000);
-
         // then
-        int newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
-        assertThat(newScore).isEqualTo(NEW_POST_SCORE * 2);
+        await().atMost(10, SECONDS).until(() -> {
+            Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
+            return newScore.equals(NEW_POST_SCORE * 2);
+        });
     }
 
     @Test
-    void 글이_삭제되면_가족_점수를_뺀다() throws InterruptedException {
+    void 글이_삭제되면_가족_점수를_뺀다() {
         // given
         memberPostRepository.save(new MemberPost(
                 "1",
@@ -125,16 +126,15 @@ class FamilyScoreEventListenerTest {
         memberPostRepository.deleteById("1");
         memberPostRepository.deleteById("2");
 
-        Thread.sleep(1000);
-
         // then
-
-        int newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
-        assertThat(newScore).isEqualTo(0);
+        await().atMost(10, SECONDS).until(() -> {
+            Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
+            return newScore.equals(0);
+        });
     }
 
     @Test
-    void 새로운_댓글이_달리면_가족_점수를_더한다() throws InterruptedException {
+    void 새로운_댓글이_달리면_가족_점수를_더한다() {
         // given
         MemberPost post = memberPostRepository.save(new MemberPost(
                 "1",
@@ -161,16 +161,15 @@ class FamilyScoreEventListenerTest {
                 "1"
         ));
 
-        Thread.sleep(1000);
-
         // then
-
-        int newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
-        assertThat(newScore).isEqualTo(originScore + NEW_COMMENT_SCORE * 2);
+        await().atMost(10, SECONDS).until(() -> {
+            Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
+            return newScore.equals(originScore + NEW_COMMENT_SCORE * 2);
+        });
     }
 
     @Test
-    void 댓글이_지워지면_가족_점수를_뺀다() throws InterruptedException {
+    void 댓글이_지워지면_가족_점수를_뺀다() {
         // given
         MemberPost post = memberPostRepository.save(new MemberPost(
                 "1",
@@ -199,16 +198,15 @@ class FamilyScoreEventListenerTest {
         memberPostCommentRepository.deleteById("1");
         memberPostCommentRepository.deleteById("2");
 
-        Thread.sleep(1000);
-
         // then
-
-        int newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
-        assertThat(newScore).isEqualTo(originScore - (NEW_COMMENT_SCORE * 2));
+        await().atMost(10, SECONDS).until(() -> {
+            Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
+            return newScore.equals(originScore - (NEW_COMMENT_SCORE * 2));
+        });
     }
 
     @Test
-    void 새로운_리액션이_달리면_가족_점수를_더한다() throws InterruptedException {
+    void 새로운_리액션이_달리면_가족_점수를_더한다() {
         // given
         MemberPost post = memberPostRepository.save(new MemberPost(
                 "1",
@@ -235,15 +233,15 @@ class FamilyScoreEventListenerTest {
                 Emoji.EMOJI_3
         ));
 
-        Thread.sleep(1000);
-
         // then
-        int newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
-        assertThat(newScore).isEqualTo(originScore + (NEW_REACTION_SCORE * 2));
+        await().atMost(10, SECONDS).until(() -> {
+            Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
+            return newScore.equals(originScore + (NEW_REACTION_SCORE * 2));
+        });
     }
 
     @Test
-    void 리액션이_지워지면_가족_점수를_뺀다() throws InterruptedException {
+    void 리액션이_지워지면_가족_점수를_뺀다() {
         // given
         MemberPost post = memberPostRepository.save(new MemberPost(
                 "1",
@@ -272,16 +270,15 @@ class FamilyScoreEventListenerTest {
         memberPostReactionRepository.deleteById("1");
         memberPostReactionRepository.deleteById("2");
 
-        Thread.sleep(1000);
-
         // then
-
-        int newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
-        assertThat(newScore).isEqualTo(originScore - (NEW_REACTION_SCORE * 2));
+        await().atMost(10, SECONDS).until(() -> {
+            Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
+            return newScore.equals(originScore - (NEW_REACTION_SCORE * 2));
+        });
     }
 
     @Test
-    void 새로운_리얼이모지가_달리면_가족_점수를_더한다() throws InterruptedException {
+    void 새로운_리얼이모지가_달리면_가족_점수를_더한다() {
         // given
         MemberPost post = memberPostRepository.save(new MemberPost(
                 "1",
@@ -325,15 +322,15 @@ class FamilyScoreEventListenerTest {
                 testMember2.getId()
         ));
 
-        Thread.sleep(1000);
-
         // then
-        int newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
-        assertThat(newScore).isEqualTo(originScore + (NEW_REAL_EMOJI_SCORE * 2));
+        await().atMost(10, SECONDS).until(() -> {
+            Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
+            return newScore.equals(originScore + (NEW_REAL_EMOJI_SCORE * 2));
+        });
     }
 
     @Test
-    void 리얼이모지가_지워지면_가족_점수를_뺀다() throws InterruptedException {
+    void 리얼이모지가_지워지면_가족_점수를_뺀다() {
         // given
         MemberPost post = memberPostRepository.save(new MemberPost(
                 "1",
@@ -376,15 +373,14 @@ class FamilyScoreEventListenerTest {
 
         int originScore = NEW_POST_SCORE + NEW_REAL_EMOJI_SCORE * 2;
 
-
         // when
         memberPostRealEmojiRepository.deleteById("1");
         memberPostRealEmojiRepository.deleteById("2");
 
-        Thread.sleep(1000);
-
         // then
-        int newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
-        assertThat(newScore).isEqualTo(originScore - (NEW_REAL_EMOJI_SCORE * 2));
+        await().atMost(10, SECONDS).until(() -> {
+            Integer newScore = familyRepository.findById(testMember1.getFamilyId()).get().getScore();
+            return newScore.equals(originScore - (NEW_REAL_EMOJI_SCORE * 2));
+        });
     }
 }

--- a/post/src/main/java/com/oing/domain/MemberPostCommentEntityListener.java
+++ b/post/src/main/java/com/oing/domain/MemberPostCommentEntityListener.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Component;
 public class MemberPostCommentEntityListener {
 
     private ApplicationEventPublisher applicationEventPublisher;
-
     @Autowired
     public MemberPostCommentEntityListener(ApplicationEventPublisher applicationEventPublisher) {
         this.applicationEventPublisher = applicationEventPublisher;
@@ -24,11 +23,13 @@ public class MemberPostCommentEntityListener {
 
     @PostPersist
     public void onPostPersist(MemberPostComment memberPostComment) {
-        applicationEventPublisher.publishEvent(new MemberPostCommentCreatedEvent(memberPostComment, memberPostComment.getMemberId()));
+        log.info("Comment({}) persist listened, publishing MemberPostCommentCreatedEvent", memberPostComment.getId());
+        applicationEventPublisher.publishEvent(new MemberPostCommentCreatedEvent(memberPostComment, memberPostComment.getId(), memberPostComment.getMemberId()));
     }
 
     @PostRemove
     public void onPostRemove(MemberPostComment memberPostComment) {
-        applicationEventPublisher.publishEvent(new MemberPostCommentDeletedEvent(memberPostComment, memberPostComment.getMemberId()));
+        log.info("Comment({}) removal listened, publishing MemberPostCommentDeletedEvent", memberPostComment.getId());
+        applicationEventPublisher.publishEvent(new MemberPostCommentDeletedEvent(memberPostComment, memberPostComment.getId(), memberPostComment.getMemberId()));
     }
 }

--- a/post/src/main/java/com/oing/domain/MemberPostEntityListener.java
+++ b/post/src/main/java/com/oing/domain/MemberPostEntityListener.java
@@ -5,16 +5,17 @@ import com.oing.event.MemberPostDeletedEvent;
 import jakarta.persistence.PostPersist;
 import jakarta.persistence.PostRemove;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 @Component
 @NoArgsConstructor
+@Slf4j
 public class MemberPostEntityListener {
 
     private ApplicationEventPublisher applicationEventPublisher;
-
     @Autowired
     public MemberPostEntityListener(ApplicationEventPublisher applicationEventPublisher) {
         this.applicationEventPublisher = applicationEventPublisher;
@@ -22,11 +23,15 @@ public class MemberPostEntityListener {
 
     @PostPersist
     public void onPostPersist(MemberPost memberPost) {
-        applicationEventPublisher.publishEvent(new MemberPostCreatedEvent(memberPost, memberPost.getMemberId()));
+        log.info("Post({}) persist listened, publishing MemberPostCreatedEvent", memberPost.getId());
+
+        applicationEventPublisher.publishEvent(new MemberPostCreatedEvent(memberPost, memberPost.getId(), memberPost.getMemberId()));
     }
 
     @PostRemove
     public void onPostRemove(MemberPost memberPost) {
-        applicationEventPublisher.publishEvent(new MemberPostDeletedEvent(memberPost, memberPost.getMemberId()));
+        log.info("Post({}) removal listened, publishing MemberPostDeletedEvent", memberPost.getId());
+
+        applicationEventPublisher.publishEvent(new MemberPostDeletedEvent(memberPost, memberPost.getId(), memberPost.getMemberId()));
     }
 }

--- a/post/src/main/java/com/oing/domain/MemberPostReactionEntityListener.java
+++ b/post/src/main/java/com/oing/domain/MemberPostReactionEntityListener.java
@@ -5,16 +5,17 @@ import com.oing.event.MemberPostReactionDeletedEvent;
 import jakarta.persistence.PostPersist;
 import jakarta.persistence.PostRemove;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 @Component
 @NoArgsConstructor
+@Slf4j
 public class MemberPostReactionEntityListener {
 
     private ApplicationEventPublisher applicationEventPublisher;
-
     @Autowired
     public MemberPostReactionEntityListener(ApplicationEventPublisher applicationEventPublisher) {
         this.applicationEventPublisher = applicationEventPublisher;
@@ -22,11 +23,13 @@ public class MemberPostReactionEntityListener {
 
    @PostPersist
     public void onPostPersist(MemberPostReaction memberPostReaction) {
-        applicationEventPublisher.publishEvent(new MemberPostReactionCreatedEvent(memberPostReaction, memberPostReaction.getMemberId()));
+       log.info("Reaction({}) persist listened, publishing MemberPostReactionCreatedEvent", memberPostReaction.getId());
+        applicationEventPublisher.publishEvent(new MemberPostReactionCreatedEvent(memberPostReaction, memberPostReaction.getId(), memberPostReaction.getMemberId()));
     }
 
     @PostRemove
     public void onPostRemove(MemberPostReaction memberPostReaction) {
-        applicationEventPublisher.publishEvent(new MemberPostReactionDeletedEvent(memberPostReaction, memberPostReaction.getMemberId()));
+        log.info("Reaction({}) removal listened, publishing MemberPostReactionDeletedEvent", memberPostReaction.getId());
+        applicationEventPublisher.publishEvent(new MemberPostReactionDeletedEvent(memberPostReaction, memberPostReaction.getId(), memberPostReaction.getMemberId()));
     }
 }

--- a/post/src/main/java/com/oing/domain/MemberPostRealEmojiEntityListener.java
+++ b/post/src/main/java/com/oing/domain/MemberPostRealEmojiEntityListener.java
@@ -1,22 +1,21 @@
 package com.oing.domain;
 
-import com.oing.event.MemberPostCreatedEvent;
-import com.oing.event.MemberPostDeletedEvent;
 import com.oing.event.MemberPostRealEmojiCreatedEvent;
 import com.oing.event.MemberPostRealEmojiDeletedEvent;
 import jakarta.persistence.PostPersist;
 import jakarta.persistence.PostRemove;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 @Component
 @NoArgsConstructor
+@Slf4j
 public class MemberPostRealEmojiEntityListener {
 
     private ApplicationEventPublisher applicationEventPublisher;
-
     @Autowired
     public MemberPostRealEmojiEntityListener(ApplicationEventPublisher applicationEventPublisher) {
         this.applicationEventPublisher = applicationEventPublisher;
@@ -24,11 +23,13 @@ public class MemberPostRealEmojiEntityListener {
 
     @PostPersist
     public void onPostPersist(MemberPostRealEmoji memberPostRealEmoji) {
-        applicationEventPublisher.publishEvent(new MemberPostRealEmojiCreatedEvent(memberPostRealEmoji, memberPostRealEmoji.getPost().getMemberId()));
+        log.info("RealEmoji({}) persist listened, publishing MemberPostRealEmojiCreatedEvent", memberPostRealEmoji.getId());
+        applicationEventPublisher.publishEvent(new MemberPostRealEmojiCreatedEvent(memberPostRealEmoji, memberPostRealEmoji.getId(), memberPostRealEmoji.getPost().getMemberId()));
     }
 
     @PostRemove
     public void onPostRemove(MemberPostRealEmoji memberPostRealEmoji) {
-        applicationEventPublisher.publishEvent(new MemberPostRealEmojiDeletedEvent(memberPostRealEmoji, memberPostRealEmoji.getPost().getMemberId()));
+        log.info("RealEmoji({}) removal listened, publishing MemberPostRealEmojiDeletedEvent", memberPostRealEmoji.getId());
+        applicationEventPublisher.publishEvent(new MemberPostRealEmojiDeletedEvent(memberPostRealEmoji, memberPostRealEmoji.getId(), memberPostRealEmoji.getPost().getMemberId()));
     }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
#200 에서 점수가 정상적으로 산정되지 않던 크리티컬 이슈는 해결되었지만, 여전히 게시글 작성과 댓글 작성 등 메인 비즈니스 로직과 트랜잭션이 분리되어 있지 않았습니다. 이러한 강결합 구조를 해결하였습니다. 또한 Thread.sleep으로 스마트하지 못하게 이벤트를 테스트하고 있는 구조를 외부 라이브러리로 해결했습니다

## ➕ 추가/변경된 기능

---
- 가족 점수 산정용 이벤트를 비동기로 전환
- 비동기로 인해 데드락이 발생하는 것을 해결하기 위해, getFamilyByFamilyId 메소드에 비관적 락 도입
- Awaitility 라이브러리를 통해 이벤트 검증을 위한 통합 테스트를 더 깔끔하게 구현
- 이벤트와 관련된 전체 로직에 더 자세한 로깅을 추가

## 🥺 리뷰어에게 하고싶은 말

---
이런저런 이슈로 해결하는데 오래 걸려서 수정사항이 좀 많네용..



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-284