### PR TITLE
[OING-288] fix: 테스트 중 FamilyScoreEventListnerTest가 실패하는 문제 해결

### DIFF
--- a/gateway/src/test/java/com/oing/event/DatabaseCleaner.java
+++ b/gateway/src/test/java/com/oing/event/DatabaseCleaner.java
@@ -35,6 +35,9 @@ public class DatabaseCleaner {
     private void truncateAllTables() {
         entityManager.createNativeQuery(String.format("SET FOREIGN_KEY_CHECKS %d", 0)).executeUpdate();
         for (String tableName : tableNames) {
+            // Don't truncate flyway tables
+            if(tableName.startsWith("flyway")) continue;
+
             entityManager.createNativeQuery(String.format("TRUNCATE TABLE %s", tableName)).executeUpdate();
         }
         entityManager.createNativeQuery(String.format("SET FOREIGN_KEY_CHECKS %d", 1)).executeUpdate();


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
테스트 실행 중 FamilyScoreEventListnerTest가 실패하는 문제를 파악하고 해결했습니다.

## ➕ 추가/변경된 기능

---
- FamilyScoreEventListnerTest의 DatabaseCleaner 익스텐션이 flyway db는 truncate하지 않도록 예외 추가

## 🥺 리뷰어에게 하고싶은 말

---
큰 변경점없이 픽스한거니 빠르게 부탁드려요!



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-288