### PR TITLE
[OING-291] fix: 캘린더 API의 가족구성원 계산 로직이 삭제한 유저도 포함하는 결함을 수정

### DIFF
--- a/member/src/main/java/com/oing/repository/MemberRepository.java
+++ b/member/src/main/java/com/oing/repository/MemberRepository.java
@@ -19,7 +19,7 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 
     Page<Member> findAllByFamilyIdAndDeletedAtIsNull(String familyId, PageRequest pageRequest);
 
-    List<Member> findAllByFamilyIdAndFamilyJoinAtBefore(String familyId, LocalDateTime dateTime);
+    List<Member> findAllByFamilyIdAndFamilyJoinAtBeforeAndDeletedAtIsNull(String familyId, LocalDateTime dateTime);
 
     long countByFamilyIdAndFamilyJoinAtBefore(String familyId, LocalDateTime dateTime);
 

--- a/member/src/main/java/com/oing/repository/MemberRepository.java
+++ b/member/src/main/java/com/oing/repository/MemberRepository.java
@@ -21,8 +21,6 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 
     List<Member> findAllByFamilyIdAndFamilyJoinAtBeforeAndDeletedAtIsNull(String familyId, LocalDateTime dateTime);
 
-    long countByFamilyIdAndFamilyJoinAtBefore(String familyId, LocalDateTime dateTime);
-
     List<Member> findAllByDeletedAtIsNull();
 
     boolean existsByIdAndDeletedAtNotNull(String memberId);

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -104,10 +104,6 @@ public class MemberService {
         return new PageImpl<>(familyMemberProfiles, memberPage.getPageable(), memberPage.getTotalElements());
     }
 
-    public long countFamilyMembersByFamilyIdBefore(String familyId, LocalDate date) {
-        return memberRepository.countByFamilyIdAndFamilyJoinAtBefore(familyId, date.atStartOfDay());
-    }
-
     private List<FamilyMemberProfileResponse> createFamilyMemberProfiles(List<Member> members) {
         return members.stream()
                 .map(FamilyMemberProfileResponse::of)

--- a/member/src/main/java/com/oing/service/MemberService.java
+++ b/member/src/main/java/com/oing/service/MemberService.java
@@ -85,7 +85,8 @@ public class MemberService {
     }
 
     public List<String> findFamilyMembersIdsByFamilyJoinAtBefore(String familyId, LocalDate date) {
-        return memberRepository.findAllByFamilyIdAndFamilyJoinAtBefore(familyId, date.atStartOfDay())
+        return memberRepository
+                .findAllByFamilyIdAndFamilyJoinAtBeforeAndDeletedAtIsNull(familyId, date.atStartOfDay())
                 .stream()
                 .map(Member::getId)
                 .toList();


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
캘린더 API에서 모든 가족 업로드 여부의 계산 로직에서 삭제한 유저도 구성원에 포함하고 있는 결함을 발견하여, 수정하는 PR입니다.

## ➕ 추가/변경된 기능

---
- 가족구성원 조회에서 삭제된 유저는 제외하도록 쿼리 수정
- 사용안되고 있는 방치된 메소드 삭제

## 🥺 리뷰어에게 하고싶은 말

---
간단하게 픽스한 사안이라 빠르게 부탁쓰


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-291