### PR TITLE
[OING-302] feature: 미션 포스트 작성/조회 모킹 API 추가

### DIFF
--- a/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.oing.repository;
 
 import com.oing.domain.Post;
+import com.oing.domain.Type;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -52,12 +53,13 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public QueryResults<Post> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId, String familyId, boolean asc) {
+    public QueryResults<Post> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId,
+                                          String familyId, boolean asc, Type type) {
         return queryFactory
                 .select(post)
                 .from(post)
                 .leftJoin(member).on(post.memberId.eq(member.id))
-                .where(post.familyId.eq(familyId), eqDate(date), eqMemberId(memberId))
+                .where(post.familyId.eq(familyId), eqDate(date), eqMemberId(memberId), post.type.eq(type))
                 .orderBy(asc ? post.id.asc() : post.id.desc())
                 .offset((long) (page - 1) * size)
                 .limit(size)

--- a/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
@@ -1,7 +1,7 @@
 package com.oing.repository;
 
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -54,7 +54,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
 
     @Override
     public QueryResults<Post> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId,
-                                          String familyId, boolean asc, Type type) {
+                                          String familyId, boolean asc, PostType type) {
         return queryFactory
                 .select(post)
                 .from(post)

--- a/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
@@ -2,6 +2,7 @@ package com.oing.controller;
 
 import com.oing.domain.Member;
 import com.oing.domain.Post;
+import com.oing.domain.Type;
 import com.oing.dto.response.ArrayResponse;
 import com.oing.dto.response.CalendarResponse;
 import com.oing.service.MemberService;
@@ -70,6 +71,7 @@ class CalendarControllerTest {
                 "1",
                 testMember1.getId(),
                 familyId,
+                Type.FEED,
                 "post.com/1",
                 "1",
                 "test1"
@@ -79,6 +81,7 @@ class CalendarControllerTest {
                 "2",
                 testMember2.getId(),
                 familyId,
+                Type.FEED,
                 "post.com/2",
                 "2",
                 "test2"
@@ -88,6 +91,7 @@ class CalendarControllerTest {
                 "3",
                 testMember1.getId(),
                 familyId,
+                Type.FEED,
                 "post.com/3",
                 "3",
                 "test3"
@@ -97,6 +101,7 @@ class CalendarControllerTest {
                 "4",
                 testMember2.getId(),
                 familyId,
+                Type.FEED,
                 "post.com/4",
                 "4",
                 "test4"

--- a/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
@@ -2,7 +2,7 @@ package com.oing.controller;
 
 import com.oing.domain.Member;
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.oing.dto.response.ArrayResponse;
 import com.oing.dto.response.CalendarResponse;
 import com.oing.service.MemberService;
@@ -71,7 +71,7 @@ class CalendarControllerTest {
                 "1",
                 testMember1.getId(),
                 familyId,
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "post.com/1",
                 "1",
                 "test1"
@@ -81,7 +81,7 @@ class CalendarControllerTest {
                 "2",
                 testMember2.getId(),
                 familyId,
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "post.com/2",
                 "2",
                 "test2"
@@ -91,7 +91,7 @@ class CalendarControllerTest {
                 "3",
                 testMember1.getId(),
                 familyId,
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "post.com/3",
                 "3",
                 "test3"
@@ -101,7 +101,7 @@ class CalendarControllerTest {
                 "4",
                 testMember2.getId(),
                 familyId,
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "post.com/4",
                 "4",
                 "test4"

--- a/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
@@ -71,7 +71,7 @@ class CalendarControllerTest {
                 "1",
                 testMember1.getId(),
                 familyId,
-                Type.FEED,
+                Type.SURVIVAL,
                 "post.com/1",
                 "1",
                 "test1"
@@ -81,7 +81,7 @@ class CalendarControllerTest {
                 "2",
                 testMember2.getId(),
                 familyId,
-                Type.FEED,
+                Type.SURVIVAL,
                 "post.com/2",
                 "2",
                 "test2"
@@ -91,7 +91,7 @@ class CalendarControllerTest {
                 "3",
                 testMember1.getId(),
                 familyId,
-                Type.FEED,
+                Type.SURVIVAL,
                 "post.com/3",
                 "3",
                 "test3"
@@ -101,7 +101,7 @@ class CalendarControllerTest {
                 "4",
                 testMember2.getId(),
                 familyId,
-                Type.FEED,
+                Type.SURVIVAL,
                 "post.com/4",
                 "4",
                 "test4"

--- a/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
@@ -62,7 +62,7 @@ class WidgetControllerTest {
             "testPost1",
             testMember1.getId(),
             "1",
-            Type.FEED,
+            Type.SURVIVAL,
             "post.com/1",
             "1",
             "testPost"

--- a/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
@@ -2,7 +2,7 @@ package com.oing.controller;
 
 import com.oing.domain.Member;
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.oing.dto.response.SingleRecentPostWidgetResponse;
 import com.oing.service.MemberService;
 import com.oing.service.PostService;
@@ -62,7 +62,7 @@ class WidgetControllerTest {
             "testPost1",
             testMember1.getId(),
             "1",
-            Type.SURVIVAL,
+            PostType.SURVIVAL,
             "post.com/1",
             "1",
             "testPost"

--- a/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/WidgetControllerTest.java
@@ -2,6 +2,7 @@ package com.oing.controller;
 
 import com.oing.domain.Member;
 import com.oing.domain.Post;
+import com.oing.domain.Type;
 import com.oing.dto.response.SingleRecentPostWidgetResponse;
 import com.oing.service.MemberService;
 import com.oing.service.PostService;
@@ -61,6 +62,7 @@ class WidgetControllerTest {
             "testPost1",
             testMember1.getId(),
             "1",
+            Type.FEED,
             "post.com/1",
             "1",
             "testPost"

--- a/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
+++ b/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
@@ -82,6 +82,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -90,6 +91,7 @@ class FamilyScoreEventListenerTest {
                 "2",
                 testMember2.getId(),
                 testMember2.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/2",
                 "images/2",
                 "2"
@@ -109,6 +111,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -117,6 +120,7 @@ class FamilyScoreEventListenerTest {
                 "2",
                 testMember2.getId(),
                 testMember2.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/2",
                 "images/2",
                 "2"
@@ -140,6 +144,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -175,6 +180,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -212,6 +218,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -247,6 +254,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -284,6 +292,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -336,6 +345,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
+                Type.FEED,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"

--- a/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
+++ b/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
@@ -82,7 +82,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -91,7 +91,7 @@ class FamilyScoreEventListenerTest {
                 "2",
                 testMember2.getId(),
                 testMember2.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/2",
                 "images/2",
                 "2"
@@ -111,7 +111,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -120,7 +120,7 @@ class FamilyScoreEventListenerTest {
                 "2",
                 testMember2.getId(),
                 testMember2.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/2",
                 "images/2",
                 "2"
@@ -144,7 +144,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -180,7 +180,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -218,7 +218,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -254,7 +254,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -292,7 +292,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -345,7 +345,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"

--- a/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
+++ b/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
@@ -82,7 +82,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -91,7 +91,7 @@ class FamilyScoreEventListenerTest {
                 "2",
                 testMember2.getId(),
                 testMember2.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/2",
                 "images/2",
                 "2"
@@ -111,7 +111,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -120,7 +120,7 @@ class FamilyScoreEventListenerTest {
                 "2",
                 testMember2.getId(),
                 testMember2.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/2",
                 "images/2",
                 "2"
@@ -144,7 +144,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -180,7 +180,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -218,7 +218,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -254,7 +254,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -292,7 +292,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"
@@ -345,7 +345,7 @@ class FamilyScoreEventListenerTest {
                 "1",
                 testMember1.getId(),
                 testMember1.getFamilyId(),
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/images/1",
                 "images/1",
                 "1"

--- a/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
@@ -80,13 +80,13 @@ class PostRepositoryCustomTest {
 
         // Posts
         jdbcTemplate.execute("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('1', '" + testMember1.getId() + "', '" + testMember1.getFamilyId() + "', 1, 'FEED', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
+                "values ('1', '" + testMember1.getId() + "', '" + testMember1.getFamilyId() + "', 1, 'SURVIVAL', 'https://storage.com/images/1', 0, 0, '2023-11-01 14:00:00', '2023-11-01 14:00:00', 'post1111', '1');");
         jdbcTemplate.execute("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('2', '" + testMember2.getId() + "', '" + testMember2.getFamilyId() + "', 1, 'FEED', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
+                "values ('2', '" + testMember2.getId() + "', '" + testMember2.getFamilyId() + "', 1, 'SURVIVAL', 'https://storage.com/images/2', 0, 0, '2023-11-01 15:00:00', '2023-11-01 15:00:00', 'post2222', '2');");
         jdbcTemplate.execute("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('3', '" + testMember3.getId() + "', '" + testMember3.getFamilyId() + "', 1, 'FEED', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
+                "values ('3', '" + testMember3.getId() + "', '" + testMember3.getFamilyId() + "', 1, 'SURVIVAL', 'https://storage.com/images/3', 0, 0, '2023-11-01 17:00:00', '2023-11-01 17:00:00', 'post3333', '3');");
         jdbcTemplate.execute("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) " +
-                "values ('4', '" + testMember1.getId() + "', '" + testMember1.getFamilyId() + "', 1, 'FEED', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
+                "values ('4', '" + testMember1.getId() + "', '" + testMember1.getFamilyId() + "', 1, 'SURVIVAL', 'https://storage.com/images/4', 0, 0, '2023-11-02 14:00:00', '2023-11-02 14:00:00', 'post4444', '4');");
     }
 
 

--- a/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
@@ -4,7 +4,6 @@ import com.oing.config.QuerydslConfig;
 import com.oing.domain.Family;
 import com.oing.domain.Member;
 import com.oing.domain.Post;
-import com.oing.domain.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
@@ -134,14 +134,14 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "3", TEST_MEMBER3_ID, "something_other", 1, "FEED", "https://storage.com/images/3", 0, 0, "2023-11-02 17:00:00", "2023-11-02 17:00:00", "post3333", "3");
+                "3", TEST_MEMBER3_ID, "something_other", 1, "SURVIVAL", "https://storage.com/images/3", 0, 0, "2023-11-02 17:00:00", "2023-11-02 17:00:00", "post3333", "3");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "4", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/4", 0, 0, "2023-11-03 14:00:00", "2023-11-03 14:00:00", "post4444", "4");
+                "4", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/4", 0, 0, "2023-11-03 14:00:00", "2023-11-03 14:00:00", "post4444", "4");
 
 
         // When & Then
@@ -170,15 +170,15 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "0", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/0", 0, 0, "2023-11-01 14:00:00", "2023-11-01 14:00:00", "post0000", "0");
+                "0", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/0", 0, 0, "2023-11-01 14:00:00", "2023-11-01 14:00:00", "post0000", "0");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "3", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/3", 0, 0, "2023-11-03 13:00:00", "2023-11-03 13:00:00", "post3333", "3");
+                "3", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/3", 0, 0, "2023-11-03 13:00:00", "2023-11-03 13:00:00", "post3333", "3");
 
 
         // When & Then
@@ -210,9 +210,9 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
 
         // Member2 가족 탈퇴
         mockMvc.perform(post("/v1/me/quit-family")
@@ -256,24 +256,24 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/1", 0, 0, "2023-11-01 14:00:00", "2023-11-01 14:00:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/1", 0, 0, "2023-11-01 14:00:00", "2023-11-01 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/2", 0, 0, "2023-11-01 15:00:00", "2023-11-01 15:00:00", "post2222", "2");
+                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/2", 0, 0, "2023-11-01 15:00:00", "2023-11-01 15:00:00", "post2222", "2");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "3", TEST_MEMBER3_ID, "something_other", 1, "FEED", "https://storage.com/images/3", 0, 0, "2023-11-01 17:00:00", "2023-11-01 17:00:00", "post3333", "3");
+                "3", TEST_MEMBER3_ID, "something_other", 1, "SURVIVAL", "https://storage.com/images/3", 0, 0, "2023-11-01 17:00:00", "2023-11-01 17:00:00", "post3333", "3");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "4", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/4", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post4444", "4");
+                "4", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/4", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post4444", "4");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "5", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/5", 0, 0, "2023-11-29 14:00:00", "2023-11-29 14:00:00", "post5555", "5");
+                "5", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/5", 0, 0, "2023-11-29 14:00:00", "2023-11-29 14:00:00", "post5555", "5");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "6", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/6", 0, 0, "2023-11-29 15:00:00", "2023-11-29 15:00:00", "post6666", "6");
+                "6", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/6", 0, 0, "2023-11-29 15:00:00", "2023-11-29 15:00:00", "post6666", "6");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "7", TEST_MEMBER3_ID, "something_other", 1, "FEED", "https://storage.com/images/7", 0, 0, "2023-11-29 17:00:00", "2023-11-29 17:00:00", "post7777", "7");
+                "7", TEST_MEMBER3_ID, "something_other", 1, "SURVIVAL", "https://storage.com/images/7", 0, 0, "2023-11-29 17:00:00", "2023-11-29 17:00:00", "post7777", "7");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "8", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "FEED", "https://storage.com/images/8", 0, 0, "2023-11-30 14:00:00", "2023-11-30 14:00:00", "post8888", "8");
+                "8", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/8", 0, 0, "2023-11-30 14:00:00", "2023-11-30 14:00:00", "post8888", "8");
 
 
         // When & Then

--- a/gateway/src/test/java/com/oing/restapi/CommentApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CommentApiTest.java
@@ -75,7 +75,7 @@ public class CommentApiTest {
                         TEST_POST_ID,
                         TEST_MEMBER_ID,
                         TEST_FAMILY_ID,
-                        Type.FEED,
+                        Type.SURVIVAL,
                         "img",
                         "img",
                         "content"

--- a/gateway/src/test/java/com/oing/restapi/CommentApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CommentApiTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oing.domain.Comment;
 import com.oing.domain.Member;
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.oing.dto.request.CreatePostCommentRequest;
 import com.oing.dto.request.UpdatePostCommentRequest;
 import com.oing.repository.CommentRepository;
@@ -75,7 +75,7 @@ public class CommentApiTest {
                         TEST_POST_ID,
                         TEST_MEMBER_ID,
                         TEST_FAMILY_ID,
-                        Type.SURVIVAL,
+                        PostType.SURVIVAL,
                         "img",
                         "img",
                         "content"

--- a/gateway/src/test/java/com/oing/restapi/CommentApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CommentApiTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oing.domain.Comment;
 import com.oing.domain.Member;
 import com.oing.domain.Post;
+import com.oing.domain.Type;
 import com.oing.dto.request.CreatePostCommentRequest;
 import com.oing.dto.request.UpdatePostCommentRequest;
 import com.oing.repository.CommentRepository;
@@ -74,6 +75,7 @@ public class CommentApiTest {
                         TEST_POST_ID,
                         TEST_MEMBER_ID,
                         TEST_FAMILY_ID,
+                        Type.FEED,
                         "img",
                         "img",
                         "content"

--- a/gateway/src/test/java/com/oing/restapi/PostApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/PostApiTest.java
@@ -3,7 +3,7 @@ package com.oing.restapi;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oing.domain.Member;
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.repository.PostRepository;
@@ -125,7 +125,7 @@ class PostApiTest {
     @Test
     void 그룹에서_탈퇴한_회원_게시물_조회_테스트() throws Exception {
         //given
-        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER1_ID, TEST_FAMILY_ID, Type.SURVIVAL, "img", "img",
+        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER1_ID, TEST_FAMILY_ID, PostType.SURVIVAL, "img", "img",
                 "content"));
         mockMvc.perform(
                 post("/v1/me/quit-family")

--- a/gateway/src/test/java/com/oing/restapi/PostApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/PostApiTest.java
@@ -3,6 +3,7 @@ package com.oing.restapi;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oing.domain.Member;
 import com.oing.domain.Post;
+import com.oing.domain.Type;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.repository.PostRepository;
@@ -124,7 +125,7 @@ class PostApiTest {
     @Test
     void 그룹에서_탈퇴한_회원_게시물_조회_테스트() throws Exception {
         //given
-        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER1_ID, TEST_FAMILY_ID, "img", "img",
+        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER1_ID, TEST_FAMILY_ID, Type.FEED, "img", "img",
                 "content"));
         mockMvc.perform(
                 post("/v1/me/quit-family")

--- a/gateway/src/test/java/com/oing/restapi/PostApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/PostApiTest.java
@@ -125,7 +125,7 @@ class PostApiTest {
     @Test
     void 그룹에서_탈퇴한_회원_게시물_조회_테스트() throws Exception {
         //given
-        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER1_ID, TEST_FAMILY_ID, Type.FEED, "img", "img",
+        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER1_ID, TEST_FAMILY_ID, Type.SURVIVAL, "img", "img",
                 "content"));
         mockMvc.perform(
                 post("/v1/me/quit-family")

--- a/gateway/src/test/java/com/oing/restapi/ReactionApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/ReactionApiTest.java
@@ -1,10 +1,7 @@
 package com.oing.restapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.oing.domain.Emoji;
-import com.oing.domain.Member;
-import com.oing.domain.Post;
-import com.oing.domain.Reaction;
+import com.oing.domain.*;
 import com.oing.dto.request.PostReactionRequest;
 import com.oing.repository.ReactionRepository;
 import com.oing.repository.PostRepository;
@@ -72,6 +69,7 @@ public class ReactionApiTest {
                         TEST_POST_ID,
                         TEST_MEMBER_ID,
                         TEST_FAMILY_ID,
+                        Type.FEED,
                         "img",
                         "img",
                         "content"

--- a/gateway/src/test/java/com/oing/restapi/ReactionApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/ReactionApiTest.java
@@ -69,7 +69,7 @@ public class ReactionApiTest {
                         TEST_POST_ID,
                         TEST_MEMBER_ID,
                         TEST_FAMILY_ID,
-                        Type.FEED,
+                        Type.SURVIVAL,
                         "img",
                         "img",
                         "content"

--- a/gateway/src/test/java/com/oing/restapi/ReactionApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/ReactionApiTest.java
@@ -69,7 +69,7 @@ public class ReactionApiTest {
                         TEST_POST_ID,
                         TEST_MEMBER_ID,
                         TEST_FAMILY_ID,
-                        Type.SURVIVAL,
+                        PostType.SURVIVAL,
                         "img",
                         "img",
                         "content"

--- a/gateway/src/test/java/com/oing/restapi/RealEmojiApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/RealEmojiApiTest.java
@@ -61,7 +61,7 @@ public class RealEmojiApiTest {
                 LocalDateTime.now()));
         TEST_MEMBER_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER_ID).accessToken();
 
-        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, "img", "img",
+        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, Type.FEED, "img", "img",
                 "content"));
 
         memberRealEmojiRepository.save(new MemberRealEmoji(TEST_MEMBER_REAL_EMOJI_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, Emoji.EMOJI_1,

--- a/gateway/src/test/java/com/oing/restapi/RealEmojiApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/RealEmojiApiTest.java
@@ -61,7 +61,7 @@ public class RealEmojiApiTest {
                 LocalDateTime.now()));
         TEST_MEMBER_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER_ID).accessToken();
 
-        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, Type.FEED, "img", "img",
+        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, Type.SURVIVAL, "img", "img",
                 "content"));
 
         memberRealEmojiRepository.save(new MemberRealEmoji(TEST_MEMBER_REAL_EMOJI_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, Emoji.EMOJI_1,

--- a/gateway/src/test/java/com/oing/restapi/RealEmojiApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/RealEmojiApiTest.java
@@ -61,7 +61,7 @@ public class RealEmojiApiTest {
                 LocalDateTime.now()));
         TEST_MEMBER_TOKEN = tokenGenerator.generateTokenPair(TEST_MEMBER_ID).accessToken();
 
-        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, Type.SURVIVAL, "img", "img",
+        postRepository.save(new Post(TEST_POST_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, PostType.SURVIVAL, "img", "img",
                 "content"));
 
         memberRealEmojiRepository.save(new MemberRealEmoji(TEST_MEMBER_REAL_EMOJI_ID, TEST_MEMBER_ID, TEST_FAMILY_ID, Emoji.EMOJI_1,

--- a/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
@@ -127,7 +127,7 @@ class WidgetApiTest {
                 "testPost1",
                 TEST_MEMBER1.getId(),
                 TEST_FAMILY_ID,
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -136,7 +136,7 @@ class WidgetApiTest {
                 "testPost2",
                 TEST_MEMBER2.getId(),
                 TEST_FAMILY_ID,
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -145,7 +145,7 @@ class WidgetApiTest {
                 "testPost3",
                 TEST_MEMBER3.getId(),
                 "something_other",
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"
@@ -165,9 +165,9 @@ class WidgetApiTest {
                 "testPos3",
                 ZonedDateTime.now()
         );
-        postService.createMemberPost(request1, Type.SURVIVAL, TEST_MEMBER1.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request2, Type.SURVIVAL, TEST_MEMBER2.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request3, Type.SURVIVAL, TEST_MEMBER3.getId(), "something_other");
+        postService.createMemberPost(request1, PostType.SURVIVAL, TEST_MEMBER1.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request2, PostType.SURVIVAL, TEST_MEMBER2.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request3, PostType.SURVIVAL, TEST_MEMBER3.getId(), "something_other");
 
 
         // when & then
@@ -191,7 +191,7 @@ class WidgetApiTest {
                 "testPost1",
                 TEST_MEMBER1.getId(),
                 TEST_FAMILY_ID,
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -200,7 +200,7 @@ class WidgetApiTest {
                 "testPost2",
                 TEST_MEMBER2.getId(),
                 TEST_FAMILY_ID,
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -209,7 +209,7 @@ class WidgetApiTest {
                 "testPost3",
                 TEST_MEMBER3.getId(),
                 "something_other",
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"
@@ -229,9 +229,9 @@ class WidgetApiTest {
                 "testPos3",
                 ZonedDateTime.now()
         );
-        postService.createMemberPost(request1, Type.SURVIVAL, TEST_MEMBER1.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request2, Type.SURVIVAL, TEST_MEMBER2.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request3, Type.SURVIVAL, TEST_MEMBER3.getId(), "something_other");
+        postService.createMemberPost(request1, PostType.SURVIVAL, TEST_MEMBER1.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request2, PostType.SURVIVAL, TEST_MEMBER2.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request3, PostType.SURVIVAL, TEST_MEMBER3.getId(), "something_other");
 
 
         // when & then

--- a/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
@@ -127,7 +127,7 @@ class WidgetApiTest {
                 "testPost1",
                 TEST_MEMBER1.getId(),
                 TEST_FAMILY_ID,
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -136,7 +136,7 @@ class WidgetApiTest {
                 "testPost2",
                 TEST_MEMBER2.getId(),
                 TEST_FAMILY_ID,
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -145,7 +145,7 @@ class WidgetApiTest {
                 "testPost3",
                 TEST_MEMBER3.getId(),
                 "something_other",
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"
@@ -165,9 +165,9 @@ class WidgetApiTest {
                 "testPos3",
                 ZonedDateTime.now()
         );
-        postService.createMemberPost(request1, "feed", TEST_MEMBER1.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request2, "feed", TEST_MEMBER2.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request3, "feed", TEST_MEMBER3.getId(), "something_other");
+        postService.createMemberPost(request1, Type.SURVIVAL, TEST_MEMBER1.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request2, Type.SURVIVAL, TEST_MEMBER2.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request3, Type.SURVIVAL, TEST_MEMBER3.getId(), "something_other");
 
 
         // when & then
@@ -191,7 +191,7 @@ class WidgetApiTest {
                 "testPost1",
                 TEST_MEMBER1.getId(),
                 TEST_FAMILY_ID,
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -200,7 +200,7 @@ class WidgetApiTest {
                 "testPost2",
                 TEST_MEMBER2.getId(),
                 TEST_FAMILY_ID,
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -209,7 +209,7 @@ class WidgetApiTest {
                 "testPost3",
                 TEST_MEMBER3.getId(),
                 "something_other",
-                Type.FEED,
+                Type.SURVIVAL,
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"
@@ -229,9 +229,9 @@ class WidgetApiTest {
                 "testPos3",
                 ZonedDateTime.now()
         );
-        postService.createMemberPost(request1, "feed", TEST_MEMBER1.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request2, "feed", TEST_MEMBER2.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request3, "feed", TEST_MEMBER3.getId(), "something_other");
+        postService.createMemberPost(request1, Type.SURVIVAL, TEST_MEMBER1.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request2, Type.SURVIVAL, TEST_MEMBER2.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request3, Type.SURVIVAL, TEST_MEMBER3.getId(), "something_other");
 
 
         // when & then

--- a/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/WidgetApiTest.java
@@ -2,10 +2,7 @@ package com.oing.restapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oing.config.support.OptimizedImageUrlProvider;
-import com.oing.domain.CreateNewUserDTO;
-import com.oing.domain.Member;
-import com.oing.domain.Post;
-import com.oing.domain.SocialLoginProvider;
+import com.oing.domain.*;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.JoinFamilyRequest;
 import com.oing.dto.response.DeepLinkResponse;
@@ -130,6 +127,7 @@ class WidgetApiTest {
                 "testPost1",
                 TEST_MEMBER1.getId(),
                 TEST_FAMILY_ID,
+                Type.FEED,
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -138,6 +136,7 @@ class WidgetApiTest {
                 "testPost2",
                 TEST_MEMBER2.getId(),
                 TEST_FAMILY_ID,
+                Type.FEED,
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -146,6 +145,7 @@ class WidgetApiTest {
                 "testPost3",
                 TEST_MEMBER3.getId(),
                 "something_other",
+                Type.FEED,
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"
@@ -165,9 +165,9 @@ class WidgetApiTest {
                 "testPos3",
                 ZonedDateTime.now()
         );
-        postService.createMemberPost(request1, TEST_MEMBER1.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request2, TEST_MEMBER2.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request3, TEST_MEMBER3.getId(), "something_other");
+        postService.createMemberPost(request1, "feed", TEST_MEMBER1.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request2, "feed", TEST_MEMBER2.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request3, "feed", TEST_MEMBER3.getId(), "something_other");
 
 
         // when & then
@@ -191,6 +191,7 @@ class WidgetApiTest {
                 "testPost1",
                 TEST_MEMBER1.getId(),
                 TEST_FAMILY_ID,
+                Type.FEED,
                 "https://storage.com/bucket/images/1",
                 "1",
                 "testPos1"
@@ -199,6 +200,7 @@ class WidgetApiTest {
                 "testPost2",
                 TEST_MEMBER2.getId(),
                 TEST_FAMILY_ID,
+                Type.FEED,
                 "https://storage.com/bucket/images/2",
                 "2",
                 "testPos2"
@@ -207,6 +209,7 @@ class WidgetApiTest {
                 "testPost3",
                 TEST_MEMBER3.getId(),
                 "something_other",
+                Type.FEED,
                 "https://storage.com/bucket/images/3",
                 "3",
                 "testPos3"
@@ -226,9 +229,9 @@ class WidgetApiTest {
                 "testPos3",
                 ZonedDateTime.now()
         );
-        postService.createMemberPost(request1, TEST_MEMBER1.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request2, TEST_MEMBER2.getId(), TEST_FAMILY_ID);
-        postService.createMemberPost(request3, TEST_MEMBER3.getId(), "something_other");
+        postService.createMemberPost(request1, "feed", TEST_MEMBER1.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request2, "feed", TEST_MEMBER2.getId(), TEST_FAMILY_ID);
+        postService.createMemberPost(request3, "feed", TEST_MEMBER3.getId(), "something_other");
 
 
         // when & then

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -3,6 +3,7 @@ package com.oing.controller;
 
 import com.oing.domain.PaginationDTO;
 import com.oing.domain.Post;
+import com.oing.domain.Type;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.response.PaginationResponse;
@@ -40,7 +41,7 @@ public class PostController implements PostApi {
 
     @Override
     public PaginationResponse<PostResponse> fetchDailyFeeds(Integer page, Integer size, LocalDate date, String memberId,
-                                                            String sort, String type, String loginMemberId) {
+                                                            String sort, Type type, String loginMemberId) {
         String familyId = memberBridge.getFamilyIdByMemberId(loginMemberId);
         // TODO: type이 mission이라면 사용자 검증 로직 추가
         PaginationDTO<Post> fetchResult = postService.searchMemberPost(
@@ -54,8 +55,8 @@ public class PostController implements PostApi {
     }
 
     @Override
-    public PostResponse createPost(CreatePostRequest request, String type, String loginFamilyId, String loginMemberId) {
-        if (type.equals("feed")) {
+    public PostResponse createPost(CreatePostRequest request, Type type, String loginFamilyId, String loginMemberId) {
+        if (type.equals(Type.SURVIVAL)) {
             log.info("Member {} is trying to create post", loginMemberId);
 
             Post savedPost = postService.createMemberPost(request, type, loginMemberId, loginFamilyId);

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 /**
  * no5ing-server
@@ -39,10 +40,11 @@ public class PostController implements PostApi {
 
     @Override
     public PaginationResponse<PostResponse> fetchDailyFeeds(Integer page, Integer size, LocalDate date, String memberId,
-                                                            String sort, String loginMemberId) {
+                                                            String sort, String type, String loginMemberId) {
         String familyId = memberBridge.getFamilyIdByMemberId(loginMemberId);
         PaginationDTO<Post> fetchResult = postService.searchMemberPost(
-                page, size, date, memberId, loginMemberId, familyId, sort == null || sort.equalsIgnoreCase("ASC")
+                page, size, date, memberId, loginMemberId, familyId,
+                sort == null || sort.equalsIgnoreCase("ASC"), type
         );
 
         return PaginationResponse
@@ -51,13 +53,19 @@ public class PostController implements PostApi {
     }
 
     @Override
-    public PostResponse createPost(CreatePostRequest request, String loginFamilyId, String loginMemberId) {
-        log.info("Member {} is trying to create post", loginMemberId);
+    public PostResponse createPost(CreatePostRequest request, String type, String loginFamilyId, String loginMemberId) {
+        if (type.equals("feed")) {
+            log.info("Member {} is trying to create post", loginMemberId);
 
-        Post savedPost = postService.createMemberPost(request, loginMemberId, loginFamilyId);
-        log.info("Member {} has created post {}", loginMemberId, savedPost.getId());
+            Post savedPost = postService.createMemberPost(request, type, loginMemberId, loginFamilyId);
+            log.info("Member {} has created post {}", loginMemberId, savedPost.getId());
+            return PostResponse.from(savedPost);
+        } else {
+            // 미션 API 응답 모킹을 위해 if-else 문으로 분기 처리했습니다 (추후 삭제 예정)
+            return new PostResponse("01HGW2N7EHJVJ4CJ999RRS2E97", "01HGWOODDDFFF4CJ999RRS2E111",
+                    "MISSION", "01HGW2N7EHJVJ4CJ999RRS2E97", 3, 2, "https://asset.no5ing.kr/post/01HGW2N7EHJVJ4CJ999RRS2E97", "맛있는 밥!", ZonedDateTime.now());
+        }
 
-        return PostResponse.from(savedPost);
     }
 
     @Override

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -42,6 +42,7 @@ public class PostController implements PostApi {
     public PaginationResponse<PostResponse> fetchDailyFeeds(Integer page, Integer size, LocalDate date, String memberId,
                                                             String sort, String type, String loginMemberId) {
         String familyId = memberBridge.getFamilyIdByMemberId(loginMemberId);
+        // TODO: type이 mission이라면 사용자 검증 로직 추가
         PaginationDTO<Post> fetchResult = postService.searchMemberPost(
                 page, size, date, memberId, loginMemberId, familyId,
                 sort == null || sort.equalsIgnoreCase("ASC"), type

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -3,7 +3,7 @@ package com.oing.controller;
 
 import com.oing.domain.PaginationDTO;
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.response.PaginationResponse;
@@ -41,7 +41,7 @@ public class PostController implements PostApi {
 
     @Override
     public PaginationResponse<PostResponse> fetchDailyFeeds(Integer page, Integer size, LocalDate date, String memberId,
-                                                            String sort, Type type, String loginMemberId) {
+                                                            String sort, PostType type, String loginMemberId) {
         String familyId = memberBridge.getFamilyIdByMemberId(loginMemberId);
         // TODO: type이 mission이라면 사용자 검증 로직 추가
         PaginationDTO<Post> fetchResult = postService.searchMemberPost(
@@ -55,8 +55,8 @@ public class PostController implements PostApi {
     }
 
     @Override
-    public PostResponse createPost(CreatePostRequest request, Type type, String loginFamilyId, String loginMemberId) {
-        if (type.equals(Type.SURVIVAL)) {
+    public PostResponse createPost(CreatePostRequest request, PostType type, String loginFamilyId, String loginMemberId) {
+        if (type.equals(PostType.SURVIVAL)) {
             log.info("Member {} is trying to create post", loginMemberId);
 
             Post savedPost = postService.createMemberPost(request, type, loginMemberId, loginFamilyId);

--- a/post/src/main/java/com/oing/domain/Post.java
+++ b/post/src/main/java/com/oing/domain/Post.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.security.InvalidParameterException;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +33,7 @@ public class Post extends BaseAuditEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
-    private Type type;
+    private PostType type;
 
     @Column(name = "post_img_url", nullable = false)
     private String postImgUrl;
@@ -63,7 +62,7 @@ public class Post extends BaseAuditEntity {
     @OneToMany(mappedBy = "post")
     private List<RealEmoji> realEmojis = new ArrayList<>();
 
-    public Post(String id, String memberId, String familyId, Type type, String postImgUrl, String postImgKey, String content) {
+    public Post(String id, String memberId, String familyId, PostType type, String postImgUrl, String postImgKey, String content) {
         validateContent(content);
         this.id = id;
         this.memberId = memberId;

--- a/post/src/main/java/com/oing/domain/Post.java
+++ b/post/src/main/java/com/oing/domain/Post.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.security.InvalidParameterException;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -62,13 +63,12 @@ public class Post extends BaseAuditEntity {
     @OneToMany(mappedBy = "post")
     private List<RealEmoji> realEmojis = new ArrayList<>();
 
-    public Post(String id, String memberId, String familyId, String postImgUrl, String postImgKey, String content) {
+    public Post(String id, String memberId, String familyId, Type type, String postImgUrl, String postImgKey, String content) {
         validateContent(content);
         this.id = id;
         this.memberId = memberId;
         this.familyId = familyId;
-        // TODO: 미션용 API 모킹 시, 변경 필요
-        this.type = Type.FEED;
+        this.type = type;
         this.postImgUrl = postImgUrl;
         this.postImgKey = postImgKey;
         this.content = content;

--- a/post/src/main/java/com/oing/domain/PostType.java
+++ b/post/src/main/java/com/oing/domain/PostType.java
@@ -7,14 +7,14 @@ import java.security.InvalidParameterException;
 
 @RequiredArgsConstructor
 @Getter
-public enum Type {
+public enum PostType {
 
     SURVIVAL("survival"),
     MISSION("mission");
 
     private final String typeKey;
 
-    public static Type fromString(String typeKey) {
+    public static PostType fromString(String typeKey) {
         return switch (typeKey.toUpperCase()) {
             case "SURVIVAL" -> SURVIVAL;
             case "MISSION" -> MISSION;

--- a/post/src/main/java/com/oing/domain/Type.java
+++ b/post/src/main/java/com/oing/domain/Type.java
@@ -9,14 +9,14 @@ import java.security.InvalidParameterException;
 @Getter
 public enum Type {
 
-    FEED("feed"),
+    SURVIVAL("survival"),
     MISSION("mission");
 
     private final String typeKey;
 
     public static Type fromString(String typeKey) {
         return switch (typeKey.toUpperCase()) {
-            case "FEED" -> FEED;
+            case "SURVIVAL" -> SURVIVAL;
             case "MISSION" -> MISSION;
             default -> throw new InvalidParameterException();
         };

--- a/post/src/main/java/com/oing/dto/response/PostResponse.java
+++ b/post/src/main/java/com/oing/dto/response/PostResponse.java
@@ -20,6 +20,12 @@ public record PostResponse(
         @Schema(description = "피드 게시물 작성자 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
         String authorId,
 
+        @Schema(description = "게시물 타입", example = "MISSION")
+        String type,
+
+        @Schema(description = "미션 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String missionId,
+
         @Schema(description = "피드 게시물 댓글 수", example = "3")
         Integer commentCount,
 
@@ -39,6 +45,8 @@ public record PostResponse(
         return new PostResponse(
                 post.getId(),
                 post.getMemberId(),
+                post.getType().getTypeKey(),
+                post.getMissionId(),
                 post.getCommentCnt(),
                 post.getReactionCnt() + post.getRealEmojiCnt(),
                 post.getPostImgUrl(),

--- a/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.oing.repository;
 
 import com.oing.domain.Post;
+import com.oing.domain.Type;
 import com.querydsl.core.QueryResults;
 
 import java.time.LocalDate;
@@ -12,7 +13,8 @@ public interface PostRepositoryCustom {
 
     List<Post> findLatestPostOfEveryday(LocalDateTime startDate, LocalDateTime endDate, String familyId);
 
-    QueryResults<Post> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId, String familyId, boolean asc);
+    QueryResults<Post> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId,
+                                   String familyId, boolean asc, Type type);
 
     long countMonthlyPostByFamilyId(int year, int month, String familyId);
 

--- a/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
@@ -1,7 +1,7 @@
 package com.oing.repository;
 
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.querydsl.core.QueryResults;
 
 import java.time.LocalDate;
@@ -14,7 +14,7 @@ public interface PostRepositoryCustom {
     List<Post> findLatestPostOfEveryday(LocalDateTime startDate, LocalDateTime endDate, String familyId);
 
     QueryResults<Post> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId,
-                                   String familyId, boolean asc, Type type);
+                                   String familyId, boolean asc, PostType type);
 
     long countMonthlyPostByFamilyId(int year, int month, String familyId);
 

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -1,6 +1,6 @@
 package com.oing.restapi;
 
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.response.PaginationResponse;
@@ -69,7 +69,7 @@ public interface PostApi {
 
             @RequestParam(required = false, defaultValue = "SURVIVAL")
             @Parameter(description = "게시물 타입", example = "SURVIVAL")
-            Type type,
+            PostType type,
 
             @Parameter(hidden = true)
             @LoginMemberId
@@ -85,7 +85,7 @@ public interface PostApi {
 
             @RequestParam(required = false, defaultValue = "SURVIVAL")
             @Parameter(description = "게시물 타입", example = "SURVIVAL")
-            Type type,
+            PostType type,
 
             @Parameter(hidden = true)
             @LoginFamilyId

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -66,6 +66,10 @@ public interface PostApi {
             @Parameter(description = "정렬 방식", example = "DESC | ASC")
             String sort,
 
+            @RequestParam(required = false, defaultValue = "feed")
+            @Parameter(description = "게시물 타입", example = "feed")
+            String type,
+
             @Parameter(hidden = true)
             @LoginMemberId
             String loginMemberId
@@ -77,6 +81,10 @@ public interface PostApi {
             @Valid
             @RequestBody
             CreatePostRequest request,
+
+            @RequestParam(required = false, defaultValue = "feed")
+            @Parameter(description = "게시물 타입", example = "feed")
+            String type,
 
             @Parameter(hidden = true)
             @LoginFamilyId

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -1,5 +1,6 @@
 package com.oing.restapi;
 
+import com.oing.domain.Type;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.response.PaginationResponse;
@@ -66,9 +67,9 @@ public interface PostApi {
             @Parameter(description = "정렬 방식", example = "DESC | ASC")
             String sort,
 
-            @RequestParam(required = false, defaultValue = "feed")
-            @Parameter(description = "게시물 타입", example = "feed")
-            String type,
+            @RequestParam(required = false, defaultValue = "SURVIVAL")
+            @Parameter(description = "게시물 타입", example = "SURVIVAL")
+            Type type,
 
             @Parameter(hidden = true)
             @LoginMemberId
@@ -82,9 +83,9 @@ public interface PostApi {
             @RequestBody
             CreatePostRequest request,
 
-            @RequestParam(required = false, defaultValue = "feed")
-            @Parameter(description = "게시물 타입", example = "feed")
-            String type,
+            @RequestParam(required = false, defaultValue = "SURVIVAL")
+            @Parameter(description = "게시물 타입", example = "SURVIVAL")
+            Type type,
 
             @Parameter(hidden = true)
             @LoginFamilyId

--- a/post/src/main/java/com/oing/service/PostService.java
+++ b/post/src/main/java/com/oing/service/PostService.java
@@ -45,22 +45,22 @@ public class PostService {
     }
 
     @Transactional
-    public Post createMemberPost(CreatePostRequest request, String type, String loginMemberId, String loginFamilyId) {
-        if (type.equals("feed")) {
-            return createFeedPost(request, loginMemberId, loginFamilyId);
-        } else if (type.equals("mission")) {
+    public Post createMemberPost(CreatePostRequest request, Type type, String loginMemberId, String loginFamilyId) {
+        if (type.equals(Type.SURVIVAL)) {
+            return createSurvivalPost(request, loginMemberId, loginFamilyId);
+        } else if (type.equals(Type.MISSION)) {
             return createMissionPost(request, loginMemberId, loginFamilyId);
         } else {
             throw new InvalidParameterException();
         }
     }
 
-    public Post createFeedPost(CreatePostRequest request, String loginMemberId, String loginFamilyId) {
+    public Post createSurvivalPost(CreatePostRequest request, String loginMemberId, String loginFamilyId) {
         ZonedDateTime uploadTime = request.uploadTime();
         validateUserHasNotCreatedPostToday(loginMemberId, loginFamilyId, uploadTime);
         validateUploadTime(loginMemberId, uploadTime);
 
-        Post post = new Post(identityGenerator.generateIdentity(), loginMemberId, loginFamilyId, Type.FEED,
+        Post post = new Post(identityGenerator.generateIdentity(), loginMemberId, loginFamilyId, Type.SURVIVAL,
                 request.imageUrl(), preSignedUrlGenerator.extractImageKey(request.imageUrl()), request.content());
         return postRepository.save(post);
     }
@@ -104,10 +104,9 @@ public class PostService {
     }
 
     public PaginationDTO<Post> searchMemberPost(int page, int size, LocalDate date, String memberId, String requesterMemberId,
-                                                String familyId, boolean asc, String type) {
-        Type postType = Type.fromString(type);
-        if (postType.equals(Type.FEED)) {
-            QueryResults<Post> results = postRepository.searchPosts(page, size, date, memberId, requesterMemberId, familyId, asc, postType);
+                                                String familyId, boolean asc, Type type) {
+        if (type.equals(Type.SURVIVAL)) {
+            QueryResults<Post> results = postRepository.searchPosts(page, size, date, memberId, requesterMemberId, familyId, asc, type);
             int totalPage = (int) Math.ceil((double) results.getTotal() / size);
             return new PaginationDTO<>(
                     totalPage,
@@ -115,7 +114,7 @@ public class PostService {
             );
         } else {
             // TODO: mission type으로 응답을 모킹하기가 힘들어 구현 전까지는 feed type으로 응답합니다
-            QueryResults<Post> results = postRepository.searchPosts(page, size, date, memberId, requesterMemberId, familyId, asc, Type.FEED);
+            QueryResults<Post> results = postRepository.searchPosts(page, size, date, memberId, requesterMemberId, familyId, asc, Type.SURVIVAL);
             int totalPage = (int) Math.ceil((double) results.getTotal() / size);
             return new PaginationDTO<>(
                     totalPage,

--- a/post/src/main/java/com/oing/service/PostService.java
+++ b/post/src/main/java/com/oing/service/PostService.java
@@ -46,13 +46,10 @@ public class PostService {
 
     @Transactional
     public Post createMemberPost(CreatePostRequest request, PostType type, String loginMemberId, String loginFamilyId) {
-        if (type.equals(PostType.SURVIVAL)) {
-            return createSurvivalPost(request, loginMemberId, loginFamilyId);
-        } else if (type.equals(PostType.MISSION)) {
-            return createMissionPost(request, loginMemberId, loginFamilyId);
-        } else {
-            throw new InvalidParameterException();
-        }
+        return switch (type) {
+            case SURVIVAL -> createSurvivalPost(request, loginMemberId, loginFamilyId);
+            case MISSION -> createMissionPost(request, loginMemberId, loginFamilyId);
+        };
     }
 
     public Post createSurvivalPost(CreatePostRequest request, String loginMemberId, String loginFamilyId) {

--- a/post/src/main/java/com/oing/service/PostService.java
+++ b/post/src/main/java/com/oing/service/PostService.java
@@ -2,7 +2,7 @@ package com.oing.service;
 
 import com.oing.domain.PaginationDTO;
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.response.PreSignedUrlResponse;
 import com.oing.exception.DuplicatePostUploadException;
@@ -45,10 +45,10 @@ public class PostService {
     }
 
     @Transactional
-    public Post createMemberPost(CreatePostRequest request, Type type, String loginMemberId, String loginFamilyId) {
-        if (type.equals(Type.SURVIVAL)) {
+    public Post createMemberPost(CreatePostRequest request, PostType type, String loginMemberId, String loginFamilyId) {
+        if (type.equals(PostType.SURVIVAL)) {
             return createSurvivalPost(request, loginMemberId, loginFamilyId);
-        } else if (type.equals(Type.MISSION)) {
+        } else if (type.equals(PostType.MISSION)) {
             return createMissionPost(request, loginMemberId, loginFamilyId);
         } else {
             throw new InvalidParameterException();
@@ -60,7 +60,7 @@ public class PostService {
         validateUserHasNotCreatedPostToday(loginMemberId, loginFamilyId, uploadTime);
         validateUploadTime(loginMemberId, uploadTime);
 
-        Post post = new Post(identityGenerator.generateIdentity(), loginMemberId, loginFamilyId, Type.SURVIVAL,
+        Post post = new Post(identityGenerator.generateIdentity(), loginMemberId, loginFamilyId, PostType.SURVIVAL,
                 request.imageUrl(), preSignedUrlGenerator.extractImageKey(request.imageUrl()), request.content());
         return postRepository.save(post);
     }
@@ -69,7 +69,7 @@ public class PostService {
         ZonedDateTime uploadTime = request.uploadTime();
         validateUploadTime(loginMemberId, uploadTime);
         // TODO: 미션 게시물 업로드 가능한 사용자인지 검증하는 로직 필요
-        Post post = new Post(identityGenerator.generateIdentity(), loginMemberId, loginFamilyId, Type.MISSION,
+        Post post = new Post(identityGenerator.generateIdentity(), loginMemberId, loginFamilyId, PostType.MISSION,
                 request.imageUrl(), preSignedUrlGenerator.extractImageKey(request.imageUrl()), request.content());
 
         return null;
@@ -104,8 +104,8 @@ public class PostService {
     }
 
     public PaginationDTO<Post> searchMemberPost(int page, int size, LocalDate date, String memberId, String requesterMemberId,
-                                                String familyId, boolean asc, Type type) {
-        if (type.equals(Type.SURVIVAL)) {
+                                                String familyId, boolean asc, PostType type) {
+        if (type.equals(PostType.SURVIVAL)) {
             QueryResults<Post> results = postRepository.searchPosts(page, size, date, memberId, requesterMemberId, familyId, asc, type);
             int totalPage = (int) Math.ceil((double) results.getTotal() / size);
             return new PaginationDTO<>(
@@ -114,7 +114,7 @@ public class PostService {
             );
         } else {
             // TODO: mission type으로 응답을 모킹하기가 힘들어 구현 전까지는 feed type으로 응답합니다
-            QueryResults<Post> results = postRepository.searchPosts(page, size, date, memberId, requesterMemberId, familyId, asc, Type.SURVIVAL);
+            QueryResults<Post> results = postRepository.searchPosts(page, size, date, memberId, requesterMemberId, familyId, asc, PostType.SURVIVAL);
             int totalPage = (int) Math.ceil((double) results.getTotal() / size);
             return new PaginationDTO<>(
                     totalPage,

--- a/post/src/test/java/com/oing/controller/PostCommentControllerTest.java
+++ b/post/src/test/java/com/oing/controller/PostCommentControllerTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.oing.domain.Comment;
 import com.oing.domain.PaginationDTO;
 import com.oing.domain.Post;
+import com.oing.domain.Type;
 import com.oing.dto.request.CreatePostCommentRequest;
 import com.oing.dto.request.UpdatePostCommentRequest;
 import com.oing.dto.response.PaginationResponse;
@@ -39,7 +40,7 @@ public class PostCommentControllerTest {
     @Test
     void 게시물_댓글_생성_테스트() {
         //given
-        Post post = new Post("1", "1", "1", "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         CreatePostCommentRequest request = new CreatePostCommentRequest(comment.getContent());
         when(postService.getMemberPostById("1")).thenReturn(post);
@@ -60,7 +61,7 @@ public class PostCommentControllerTest {
     @Test
     void 게시물_댓글_삭제_테스트() {
         //given
-        Post post = spy(new Post("1", "1", "1", "1", "1", "1"));
+        Post post = spy(new Post("1", "1", "1", Type.FEED, "1", "1", "1"));
         Comment comment = spy(new Comment("1", post, "1", "1"));
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -78,7 +79,7 @@ public class PostCommentControllerTest {
     @Test
     void 게시물_댓글_수정_테스트() {
         //given
-        Post post = new Post("1", "1", "1", "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         UpdatePostCommentRequest updateRequest = new UpdatePostCommentRequest(comment.getContent());
         when(commentService.updateMemberPostComment(post.getId(), comment.getId(), updateRequest.content(), "1"))
@@ -103,6 +104,7 @@ public class PostCommentControllerTest {
                 "1",
                 "1",
                 "1",
+                Type.FEED,
                 "1",
                 "1",
                 "1"

--- a/post/src/test/java/com/oing/controller/PostCommentControllerTest.java
+++ b/post/src/test/java/com/oing/controller/PostCommentControllerTest.java
@@ -40,7 +40,7 @@ public class PostCommentControllerTest {
     @Test
     void 게시물_댓글_생성_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         CreatePostCommentRequest request = new CreatePostCommentRequest(comment.getContent());
         when(postService.getMemberPostById("1")).thenReturn(post);
@@ -61,7 +61,7 @@ public class PostCommentControllerTest {
     @Test
     void 게시물_댓글_삭제_테스트() {
         //given
-        Post post = spy(new Post("1", "1", "1", Type.FEED, "1", "1", "1"));
+        Post post = spy(new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1"));
         Comment comment = spy(new Comment("1", post, "1", "1"));
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -79,7 +79,7 @@ public class PostCommentControllerTest {
     @Test
     void 게시물_댓글_수정_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         UpdatePostCommentRequest updateRequest = new UpdatePostCommentRequest(comment.getContent());
         when(commentService.updateMemberPostComment(post.getId(), comment.getId(), updateRequest.content(), "1"))
@@ -104,7 +104,7 @@ public class PostCommentControllerTest {
                 "1",
                 "1",
                 "1",
-                Type.FEED,
+                Type.SURVIVAL,
                 "1",
                 "1",
                 "1"

--- a/post/src/test/java/com/oing/controller/PostCommentControllerTest.java
+++ b/post/src/test/java/com/oing/controller/PostCommentControllerTest.java
@@ -4,7 +4,7 @@ import com.google.common.collect.Lists;
 import com.oing.domain.Comment;
 import com.oing.domain.PaginationDTO;
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.oing.dto.request.CreatePostCommentRequest;
 import com.oing.dto.request.UpdatePostCommentRequest;
 import com.oing.dto.response.PaginationResponse;
@@ -40,7 +40,7 @@ public class PostCommentControllerTest {
     @Test
     void 게시물_댓글_생성_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", "1", "1", PostType.SURVIVAL, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         CreatePostCommentRequest request = new CreatePostCommentRequest(comment.getContent());
         when(postService.getMemberPostById("1")).thenReturn(post);
@@ -61,7 +61,7 @@ public class PostCommentControllerTest {
     @Test
     void 게시물_댓글_삭제_테스트() {
         //given
-        Post post = spy(new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1"));
+        Post post = spy(new Post("1", "1", "1", PostType.SURVIVAL, "1", "1", "1"));
         Comment comment = spy(new Comment("1", post, "1", "1"));
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -79,7 +79,7 @@ public class PostCommentControllerTest {
     @Test
     void 게시물_댓글_수정_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", "1", "1", PostType.SURVIVAL, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         UpdatePostCommentRequest updateRequest = new UpdatePostCommentRequest(comment.getContent());
         when(commentService.updateMemberPostComment(post.getId(), comment.getId(), updateRequest.content(), "1"))
@@ -104,7 +104,7 @@ public class PostCommentControllerTest {
                 "1",
                 "1",
                 "1",
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "1",
                 "1",
                 "1"

--- a/post/src/test/java/com/oing/controller/ReactionControllerTest.java
+++ b/post/src/test/java/com/oing/controller/ReactionControllerTest.java
@@ -3,6 +3,7 @@ package com.oing.controller;
 import com.oing.domain.Emoji;
 import com.oing.domain.Post;
 import com.oing.domain.Reaction;
+import com.oing.domain.Type;
 import com.oing.dto.request.PostReactionRequest;
 import com.oing.dto.response.PostReactionMemberResponse;
 import com.oing.service.MemberBridge;
@@ -37,7 +38,7 @@ public class ReactionControllerTest {
     void 게시물_리액션_생성_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
         Reaction reaction = new Reaction("1", post, memberId, Emoji.EMOJI_1);
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -54,7 +55,7 @@ public class ReactionControllerTest {
     void 게시물_리액션_삭제_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
         //when
@@ -69,7 +70,7 @@ public class ReactionControllerTest {
     void 리액션_남긴_멤버_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
         List<Reaction> mockReactions = Arrays.asList(
                 new Reaction("1", post, memberId, Emoji.EMOJI_1),
                 new Reaction("2", post, memberId, Emoji.EMOJI_2)

--- a/post/src/test/java/com/oing/controller/ReactionControllerTest.java
+++ b/post/src/test/java/com/oing/controller/ReactionControllerTest.java
@@ -2,8 +2,8 @@ package com.oing.controller;
 
 import com.oing.domain.Emoji;
 import com.oing.domain.Post;
+import com.oing.domain.PostType;
 import com.oing.domain.Reaction;
-import com.oing.domain.Type;
 import com.oing.dto.request.PostReactionRequest;
 import com.oing.dto.response.PostReactionMemberResponse;
 import com.oing.service.MemberBridge;
@@ -38,7 +38,7 @@ public class ReactionControllerTest {
     void 게시물_리액션_생성_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "1", "1", "1");
         Reaction reaction = new Reaction("1", post, memberId, Emoji.EMOJI_1);
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -55,7 +55,7 @@ public class ReactionControllerTest {
     void 게시물_리액션_삭제_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "1", "1", "1");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
         //when
@@ -70,7 +70,7 @@ public class ReactionControllerTest {
     void 리액션_남긴_멤버_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "1", "1", "1");
         List<Reaction> mockReactions = Arrays.asList(
                 new Reaction("1", post, memberId, Emoji.EMOJI_1),
                 new Reaction("2", post, memberId, Emoji.EMOJI_2)

--- a/post/src/test/java/com/oing/controller/ReactionControllerTest.java
+++ b/post/src/test/java/com/oing/controller/ReactionControllerTest.java
@@ -38,7 +38,7 @@ public class ReactionControllerTest {
     void 게시물_리액션_생성_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
         Reaction reaction = new Reaction("1", post, memberId, Emoji.EMOJI_1);
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -55,7 +55,7 @@ public class ReactionControllerTest {
     void 게시물_리액션_삭제_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
         //when
@@ -70,7 +70,7 @@ public class ReactionControllerTest {
     void 리액션_남긴_멤버_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
         List<Reaction> mockReactions = Arrays.asList(
                 new Reaction("1", post, memberId, Emoji.EMOJI_1),
                 new Reaction("2", post, memberId, Emoji.EMOJI_2)

--- a/post/src/test/java/com/oing/controller/RealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/RealEmojiControllerTest.java
@@ -43,7 +43,7 @@ public class RealEmojiControllerTest {
         String familyId = "1";
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -64,7 +64,7 @@ public class RealEmojiControllerTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -81,7 +81,7 @@ public class RealEmojiControllerTest {
     void 게시물_리얼이모지_요약_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);
@@ -97,7 +97,7 @@ public class RealEmojiControllerTest {
     void 게시물_리얼이모지_목록_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);
@@ -114,7 +114,7 @@ public class RealEmojiControllerTest {
     void 게시물_리얼이모지_멤버_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);

--- a/post/src/test/java/com/oing/controller/RealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/RealEmojiControllerTest.java
@@ -43,7 +43,7 @@ public class RealEmojiControllerTest {
         String familyId = "1";
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -64,7 +64,7 @@ public class RealEmojiControllerTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -81,7 +81,7 @@ public class RealEmojiControllerTest {
     void 게시물_리얼이모지_요약_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);
@@ -97,7 +97,7 @@ public class RealEmojiControllerTest {
     void 게시물_리얼이모지_목록_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);
@@ -114,7 +114,7 @@ public class RealEmojiControllerTest {
     void 게시물_리얼이모지_멤버_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);

--- a/post/src/test/java/com/oing/controller/RealEmojiControllerTest.java
+++ b/post/src/test/java/com/oing/controller/RealEmojiControllerTest.java
@@ -1,9 +1,6 @@
 package com.oing.controller;
 
-import com.oing.domain.Emoji;
-import com.oing.domain.MemberRealEmoji;
-import com.oing.domain.Post;
-import com.oing.domain.RealEmoji;
+import com.oing.domain.*;
 import com.oing.dto.request.PostRealEmojiRequest;
 import com.oing.dto.response.ArrayResponse;
 import com.oing.dto.response.PostRealEmojiMemberResponse;
@@ -46,7 +43,7 @@ public class RealEmojiControllerTest {
         String familyId = "1";
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
-        Post post = new Post("1", memberId, familyId, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
 
@@ -67,7 +64,7 @@ public class RealEmojiControllerTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji realEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -84,7 +81,7 @@ public class RealEmojiControllerTest {
     void 게시물_리얼이모지_요약_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, "1", Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);
@@ -100,7 +97,7 @@ public class RealEmojiControllerTest {
     void 게시물_리얼이모지_목록_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, "1", Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);
@@ -117,7 +114,7 @@ public class RealEmojiControllerTest {
     void 게시물_리얼이모지_멤버_조회_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, "1", Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         when(postService.getMemberPostById(post.getId())).thenReturn(post);
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);

--- a/post/src/test/java/com/oing/domain/model/PostCommentTest.java
+++ b/post/src/test/java/com/oing/domain/model/PostCommentTest.java
@@ -23,7 +23,7 @@ public class PostCommentTest {
         String content = "밥 맛있다!";
         String commentId = "sampleCommentId";
         String commentContents = "sampleCommentContents";
-        Post post = new Post(postId, memberId, familyId, null, Type.FEED, imageUrl, imageKey, content, 0,
+        Post post = new Post(postId, memberId, familyId, null, Type.SURVIVAL, imageUrl, imageKey, content, 0,
                 0, 0, null, null, null);
 
         // When

--- a/post/src/test/java/com/oing/domain/model/PostCommentTest.java
+++ b/post/src/test/java/com/oing/domain/model/PostCommentTest.java
@@ -2,7 +2,7 @@ package com.oing.domain.model;
 
 import com.oing.domain.Comment;
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +23,7 @@ public class PostCommentTest {
         String content = "밥 맛있다!";
         String commentId = "sampleCommentId";
         String commentContents = "sampleCommentContents";
-        Post post = new Post(postId, memberId, familyId, null, Type.SURVIVAL, imageUrl, imageKey, content, 0,
+        Post post = new Post(postId, memberId, familyId, null, PostType.SURVIVAL, imageUrl, imageKey, content, 0,
                 0, 0, null, null, null);
 
         // When

--- a/post/src/test/java/com/oing/domain/model/PostReactionTest.java
+++ b/post/src/test/java/com/oing/domain/model/PostReactionTest.java
@@ -2,8 +2,8 @@ package com.oing.domain.model;
 
 import com.oing.domain.Emoji;
 import com.oing.domain.Post;
+import com.oing.domain.PostType;
 import com.oing.domain.Reaction;
-import com.oing.domain.Type;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +24,7 @@ public class PostReactionTest {
         String content = "밥 맛있다!";
         String reactionId = "sampleCommentId";
         Emoji emoji = Emoji.EMOJI_1;
-        Post post = new Post(postId, memberId, familyId, null, Type.SURVIVAL, imageUrl, imageKey, content, 0,
+        Post post = new Post(postId, memberId, familyId, null, PostType.SURVIVAL, imageUrl, imageKey, content, 0,
                 0, 0, null, null, null);
 
         // When

--- a/post/src/test/java/com/oing/domain/model/PostReactionTest.java
+++ b/post/src/test/java/com/oing/domain/model/PostReactionTest.java
@@ -24,7 +24,7 @@ public class PostReactionTest {
         String content = "밥 맛있다!";
         String reactionId = "sampleCommentId";
         Emoji emoji = Emoji.EMOJI_1;
-        Post post = new Post(postId, memberId, familyId, null, Type.FEED, imageUrl, imageKey, content, 0,
+        Post post = new Post(postId, memberId, familyId, null, Type.SURVIVAL, imageUrl, imageKey, content, 0,
                 0, 0, null, null, null);
 
         // When

--- a/post/src/test/java/com/oing/domain/model/PostTest.java
+++ b/post/src/test/java/com/oing/domain/model/PostTest.java
@@ -22,7 +22,7 @@ public class PostTest {
         String content = "밥 맛있다!";
 
         // When
-        Post post = new Post(postId, memberId, familyId, null, Type.FEED, imageUrl, imageKey, content, 0,
+        Post post = new Post(postId, memberId, familyId, null, Type.SURVIVAL, imageUrl, imageKey, content, 0,
                 0, 0, null, null, null);
 
         // Then

--- a/post/src/test/java/com/oing/domain/model/PostTest.java
+++ b/post/src/test/java/com/oing/domain/model/PostTest.java
@@ -1,7 +1,7 @@
 package com.oing.domain.model;
 
 import com.oing.domain.Post;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class PostTest {
         String content = "밥 맛있다!";
 
         // When
-        Post post = new Post(postId, memberId, familyId, null, Type.SURVIVAL, imageUrl, imageKey, content, 0,
+        Post post = new Post(postId, memberId, familyId, null, PostType.SURVIVAL, imageUrl, imageKey, content, 0,
                 0, 0, null, null, null);
 
         // Then

--- a/post/src/test/java/com/oing/dto/response/PostFeedResponseTest.java
+++ b/post/src/test/java/com/oing/dto/response/PostFeedResponseTest.java
@@ -1,5 +1,6 @@
 package com.oing.dto.response;
 
+import com.oing.domain.Type;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
@@ -26,7 +27,7 @@ public class PostFeedResponseTest {
         ZonedDateTime createdAt = ZonedDateTime.parse("2021-12-05T12:30:00.000+09:00");
 
         // When
-        PostResponse postFeedResponse = new PostResponse(postId, authorId, commentCount, emojiCount, imageUrl,
+        PostResponse postFeedResponse = new PostResponse(postId, authorId, Type.FEED.getTypeKey(), null, commentCount, emojiCount, imageUrl,
                 content, createdAt);
 
         // Then

--- a/post/src/test/java/com/oing/dto/response/PostFeedResponseTest.java
+++ b/post/src/test/java/com/oing/dto/response/PostFeedResponseTest.java
@@ -1,6 +1,6 @@
 package com.oing.dto.response;
 
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
@@ -27,7 +27,7 @@ public class PostFeedResponseTest {
         ZonedDateTime createdAt = ZonedDateTime.parse("2021-12-05T12:30:00.000+09:00");
 
         // When
-        PostResponse postFeedResponse = new PostResponse(postId, authorId, Type.SURVIVAL.getTypeKey(), null, commentCount, emojiCount, imageUrl,
+        PostResponse postFeedResponse = new PostResponse(postId, authorId, PostType.SURVIVAL.getTypeKey(), null, commentCount, emojiCount, imageUrl,
                 content, createdAt);
 
         // Then

--- a/post/src/test/java/com/oing/dto/response/PostFeedResponseTest.java
+++ b/post/src/test/java/com/oing/dto/response/PostFeedResponseTest.java
@@ -27,7 +27,7 @@ public class PostFeedResponseTest {
         ZonedDateTime createdAt = ZonedDateTime.parse("2021-12-05T12:30:00.000+09:00");
 
         // When
-        PostResponse postFeedResponse = new PostResponse(postId, authorId, Type.FEED.getTypeKey(), null, commentCount, emojiCount, imageUrl,
+        PostResponse postFeedResponse = new PostResponse(postId, authorId, Type.SURVIVAL.getTypeKey(), null, commentCount, emojiCount, imageUrl,
                 content, createdAt);
 
         // Then

--- a/post/src/test/java/com/oing/service/CommentServiceTest.java
+++ b/post/src/test/java/com/oing/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.oing.service;
 import com.oing.domain.Comment;
 import com.oing.domain.Post;
 import com.oing.domain.PaginationDTO;
+import com.oing.domain.Type;
 import com.oing.dto.request.CreatePostCommentRequest;
 import com.oing.dto.request.UpdatePostCommentRequest;
 import com.oing.exception.AuthorizationFailedException;
@@ -42,7 +43,7 @@ public class CommentServiceTest {
     void 게시물_댓글_저장_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.FEED,  "1", "1", "1");
         CreatePostCommentRequest request = new CreatePostCommentRequest("1");
         Comment comment = new Comment("1", null, "1", "1");
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);
@@ -59,7 +60,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_생성_내_가족이_아닌_경우_테스트() {
         //given
-        Post post = new Post("1", "1", "1", "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         CreatePostCommentRequest request = new CreatePostCommentRequest(comment.getContent());
 
@@ -74,7 +75,7 @@ public class CommentServiceTest {
     void 게시물_삭제_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
         when(commentRepository.findById("1")).thenReturn(Optional.of(new Comment("1", post, "1", "1")));
 
         //when
@@ -87,7 +88,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_삭제_내가_작성하지_않은경우_테스트() {
         //given
-        Post post = new Post("1", "1", "1", "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
         Comment othersComment = new Comment("1", post, "2", "1");
         when(commentRepository.findById("1")).thenReturn(Optional.of(othersComment));
 
@@ -101,7 +102,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_수정_테스트() {
         //given
-        Post post = new Post("1", "1", "1", "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         UpdatePostCommentRequest updateRequest = new UpdatePostCommentRequest(comment.getContent());
         when(commentRepository.findById("1")).thenReturn(Optional.of(comment));
@@ -121,7 +122,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_수정_내가_작성하지_않은경우_테스트() {
         //given
-        Post post = new Post("1", "1", "1", "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
         Comment othersComment = new Comment("1", post, "2", "1");
         UpdatePostCommentRequest request = new UpdatePostCommentRequest(othersComment.getContent());
         when(commentRepository.findById("1")).thenReturn(Optional.of(othersComment));
@@ -136,7 +137,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_조회_테스트() {
         //given
-        Post post = new Post("1", "1", "1", "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
         Comment comment = new Comment("1", post, "1", "1");
         when(commentRepository.findById("1")).thenReturn(java.util.Optional.of(comment));
 
@@ -151,7 +152,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_조회_게시물ID_댓글ID_불일치_테스트() {
         //given
-        Post post = new Post("1", "1", "1", "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
         Comment comment = new Comment("1", post, "1", "1");
         when(commentRepository.findById("2")).thenReturn(java.util.Optional.of(comment));
 
@@ -181,6 +182,7 @@ public class CommentServiceTest {
                 "1",
                 "1",
                 "1",
+                Type.FEED,
                 "1",
                 "1",
                 "1"

--- a/post/src/test/java/com/oing/service/CommentServiceTest.java
+++ b/post/src/test/java/com/oing/service/CommentServiceTest.java
@@ -43,7 +43,7 @@ public class CommentServiceTest {
     void 게시물_댓글_저장_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED,  "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL,  "1", "1", "1");
         CreatePostCommentRequest request = new CreatePostCommentRequest("1");
         Comment comment = new Comment("1", null, "1", "1");
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);
@@ -60,7 +60,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_생성_내_가족이_아닌_경우_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         CreatePostCommentRequest request = new CreatePostCommentRequest(comment.getContent());
 
@@ -75,7 +75,7 @@ public class CommentServiceTest {
     void 게시물_삭제_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
         when(commentRepository.findById("1")).thenReturn(Optional.of(new Comment("1", post, "1", "1")));
 
         //when
@@ -88,7 +88,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_삭제_내가_작성하지_않은경우_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
         Comment othersComment = new Comment("1", post, "2", "1");
         when(commentRepository.findById("1")).thenReturn(Optional.of(othersComment));
 
@@ -102,7 +102,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_수정_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         UpdatePostCommentRequest updateRequest = new UpdatePostCommentRequest(comment.getContent());
         when(commentRepository.findById("1")).thenReturn(Optional.of(comment));
@@ -122,7 +122,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_수정_내가_작성하지_않은경우_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
         Comment othersComment = new Comment("1", post, "2", "1");
         UpdatePostCommentRequest request = new UpdatePostCommentRequest(othersComment.getContent());
         when(commentRepository.findById("1")).thenReturn(Optional.of(othersComment));
@@ -137,7 +137,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_조회_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
         Comment comment = new Comment("1", post, "1", "1");
         when(commentRepository.findById("1")).thenReturn(java.util.Optional.of(comment));
 
@@ -152,7 +152,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_조회_게시물ID_댓글ID_불일치_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
         Comment comment = new Comment("1", post, "1", "1");
         when(commentRepository.findById("2")).thenReturn(java.util.Optional.of(comment));
 
@@ -182,7 +182,7 @@ public class CommentServiceTest {
                 "1",
                 "1",
                 "1",
-                Type.FEED,
+                Type.SURVIVAL,
                 "1",
                 "1",
                 "1"

--- a/post/src/test/java/com/oing/service/CommentServiceTest.java
+++ b/post/src/test/java/com/oing/service/CommentServiceTest.java
@@ -3,7 +3,7 @@ package com.oing.service;
 import com.oing.domain.Comment;
 import com.oing.domain.Post;
 import com.oing.domain.PaginationDTO;
-import com.oing.domain.Type;
+import com.oing.domain.PostType;
 import com.oing.dto.request.CreatePostCommentRequest;
 import com.oing.dto.request.UpdatePostCommentRequest;
 import com.oing.exception.AuthorizationFailedException;
@@ -43,7 +43,7 @@ public class CommentServiceTest {
     void 게시물_댓글_저장_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL,  "1", "1", "1");
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL,  "1", "1", "1");
         CreatePostCommentRequest request = new CreatePostCommentRequest("1");
         Comment comment = new Comment("1", null, "1", "1");
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);
@@ -60,7 +60,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_생성_내_가족이_아닌_경우_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", "1", "1", PostType.SURVIVAL, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         CreatePostCommentRequest request = new CreatePostCommentRequest(comment.getContent());
 
@@ -75,7 +75,7 @@ public class CommentServiceTest {
     void 게시물_삭제_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "1", "1", "1");
         when(commentRepository.findById("1")).thenReturn(Optional.of(new Comment("1", post, "1", "1")));
 
         //when
@@ -88,7 +88,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_삭제_내가_작성하지_않은경우_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", "1", "1", PostType.SURVIVAL, "1", "1", "1");
         Comment othersComment = new Comment("1", post, "2", "1");
         when(commentRepository.findById("1")).thenReturn(Optional.of(othersComment));
 
@@ -102,7 +102,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_수정_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", "1", "1", PostType.SURVIVAL, "1", "1", "1");
         Comment comment = spy(new Comment("1", post, "1", "1"));
         UpdatePostCommentRequest updateRequest = new UpdatePostCommentRequest(comment.getContent());
         when(commentRepository.findById("1")).thenReturn(Optional.of(comment));
@@ -122,7 +122,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_수정_내가_작성하지_않은경우_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", "1", "1", PostType.SURVIVAL, "1", "1", "1");
         Comment othersComment = new Comment("1", post, "2", "1");
         UpdatePostCommentRequest request = new UpdatePostCommentRequest(othersComment.getContent());
         when(commentRepository.findById("1")).thenReturn(Optional.of(othersComment));
@@ -137,7 +137,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_조회_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", "1", "1", PostType.SURVIVAL, "1", "1", "1");
         Comment comment = new Comment("1", post, "1", "1");
         when(commentRepository.findById("1")).thenReturn(java.util.Optional.of(comment));
 
@@ -152,7 +152,7 @@ public class CommentServiceTest {
     @Test
     void 게시물_댓글_조회_게시물ID_댓글ID_불일치_테스트() {
         //given
-        Post post = new Post("1", "1", "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", "1", "1", PostType.SURVIVAL, "1", "1", "1");
         Comment comment = new Comment("1", post, "1", "1");
         when(commentRepository.findById("2")).thenReturn(java.util.Optional.of(comment));
 
@@ -182,7 +182,7 @@ public class CommentServiceTest {
                 "1",
                 "1",
                 "1",
-                Type.SURVIVAL,
+                PostType.SURVIVAL,
                 "1",
                 "1",
                 "1"

--- a/post/src/test/java/com/oing/service/ReactionServiceTest.java
+++ b/post/src/test/java/com/oing/service/ReactionServiceTest.java
@@ -3,6 +3,7 @@ package com.oing.service;
 import com.oing.domain.Emoji;
 import com.oing.domain.Post;
 import com.oing.domain.Reaction;
+import com.oing.domain.Type;
 import com.oing.dto.request.PostReactionRequest;
 import com.oing.exception.EmojiAlreadyExistsException;
 import com.oing.exception.EmojiNotFoundException;
@@ -36,7 +37,7 @@ public class ReactionServiceTest {
     void 게시물_리액션_생성_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
         Reaction reaction = new Reaction("1", post, memberId, Emoji.EMOJI_1);
 
         //when
@@ -54,7 +55,7 @@ public class ReactionServiceTest {
     void 게시물_중복된_리액션_등록_예외_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
 
         //when
         when(reactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(true);
@@ -69,7 +70,7 @@ public class ReactionServiceTest {
     void 게시물_리액션_삭제_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
         Reaction reaction = new Reaction("1", post, memberId, Emoji.EMOJI_1);
         when(reactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(true);
         when(reactionRepository.findReactionByPostAndMemberIdAndEmoji(post, memberId, Emoji.EMOJI_1))
@@ -87,7 +88,7 @@ public class ReactionServiceTest {
     void 게시물_존재하지_않는_리액션_삭제_예외_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
         when(reactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(false);
 
         //when

--- a/post/src/test/java/com/oing/service/ReactionServiceTest.java
+++ b/post/src/test/java/com/oing/service/ReactionServiceTest.java
@@ -37,7 +37,7 @@ public class ReactionServiceTest {
     void 게시물_리액션_생성_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
         Reaction reaction = new Reaction("1", post, memberId, Emoji.EMOJI_1);
 
         //when
@@ -55,7 +55,7 @@ public class ReactionServiceTest {
     void 게시물_중복된_리액션_등록_예외_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
 
         //when
         when(reactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(true);
@@ -70,7 +70,7 @@ public class ReactionServiceTest {
     void 게시물_리액션_삭제_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
         Reaction reaction = new Reaction("1", post, memberId, Emoji.EMOJI_1);
         when(reactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(true);
         when(reactionRepository.findReactionByPostAndMemberIdAndEmoji(post, memberId, Emoji.EMOJI_1))
@@ -88,7 +88,7 @@ public class ReactionServiceTest {
     void 게시물_존재하지_않는_리액션_삭제_예외_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.FEED, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
         when(reactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(false);
 
         //when

--- a/post/src/test/java/com/oing/service/ReactionServiceTest.java
+++ b/post/src/test/java/com/oing/service/ReactionServiceTest.java
@@ -2,8 +2,8 @@ package com.oing.service;
 
 import com.oing.domain.Emoji;
 import com.oing.domain.Post;
+import com.oing.domain.PostType;
 import com.oing.domain.Reaction;
-import com.oing.domain.Type;
 import com.oing.dto.request.PostReactionRequest;
 import com.oing.exception.EmojiAlreadyExistsException;
 import com.oing.exception.EmojiNotFoundException;
@@ -37,7 +37,7 @@ public class ReactionServiceTest {
     void 게시물_리액션_생성_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "1", "1", "1");
         Reaction reaction = new Reaction("1", post, memberId, Emoji.EMOJI_1);
 
         //when
@@ -55,7 +55,7 @@ public class ReactionServiceTest {
     void 게시물_중복된_리액션_등록_예외_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "1", "1", "1");
 
         //when
         when(reactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(true);
@@ -70,7 +70,7 @@ public class ReactionServiceTest {
     void 게시물_리액션_삭제_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "1", "1", "1");
         Reaction reaction = new Reaction("1", post, memberId, Emoji.EMOJI_1);
         when(reactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(true);
         when(reactionRepository.findReactionByPostAndMemberIdAndEmoji(post, memberId, Emoji.EMOJI_1))
@@ -88,7 +88,7 @@ public class ReactionServiceTest {
     void 게시물_존재하지_않는_리액션_삭제_예외_테스트() {
         //given
         String memberId = "1";
-        Post post = new Post("1", memberId, "1", Type.SURVIVAL, "1", "1", "1");
+        Post post = new Post("1", memberId, "1", PostType.SURVIVAL, "1", "1", "1");
         when(reactionService.isMemberPostReactionExists(post, memberId, Emoji.EMOJI_1)).thenReturn(false);
 
         //when

--- a/post/src/test/java/com/oing/service/RealEmojiServiceTest.java
+++ b/post/src/test/java/com/oing/service/RealEmojiServiceTest.java
@@ -41,7 +41,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -66,7 +66,7 @@ public class RealEmojiServiceTest {
         String memberId = "1";
         String familyId = "1";
         String otherFamilyId = "2";
-        Post post = new Post("1", otherFamilyId, otherFamilyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", otherFamilyId, otherFamilyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -85,7 +85,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1",  memberId, familyId, Emoji.EMOJI_1,
                 "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -106,7 +106,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -126,7 +126,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");

--- a/post/src/test/java/com/oing/service/RealEmojiServiceTest.java
+++ b/post/src/test/java/com/oing/service/RealEmojiServiceTest.java
@@ -1,9 +1,6 @@
 package com.oing.service;
 
-import com.oing.domain.Emoji;
-import com.oing.domain.MemberRealEmoji;
-import com.oing.domain.Post;
-import com.oing.domain.RealEmoji;
+import com.oing.domain.*;
 import com.oing.dto.request.PostRealEmojiRequest;
 import com.oing.exception.AuthorizationFailedException;
 import com.oing.exception.RealEmojiAlreadyExistsException;
@@ -44,7 +41,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -69,7 +66,7 @@ public class RealEmojiServiceTest {
         String memberId = "1";
         String familyId = "1";
         String otherFamilyId = "2";
-        Post post = new Post("1", otherFamilyId, otherFamilyId, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", otherFamilyId, otherFamilyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -88,7 +85,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1",  memberId, familyId, Emoji.EMOJI_1,
                 "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -109,7 +106,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -129,7 +126,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId,"https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, Type.FEED, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");

--- a/post/src/test/java/com/oing/service/RealEmojiServiceTest.java
+++ b/post/src/test/java/com/oing/service/RealEmojiServiceTest.java
@@ -41,7 +41,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -66,7 +66,7 @@ public class RealEmojiServiceTest {
         String memberId = "1";
         String familyId = "1";
         String otherFamilyId = "2";
-        Post post = new Post("1", otherFamilyId, otherFamilyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", otherFamilyId, otherFamilyId, PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -85,7 +85,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1",  memberId, familyId, Emoji.EMOJI_1,
                 "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -106,7 +106,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");
@@ -126,7 +126,7 @@ public class RealEmojiServiceTest {
         //given
         String memberId = "1";
         String familyId = "1";
-        Post post = new Post("1", memberId, familyId, Type.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
+        Post post = new Post("1", memberId, familyId, PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
         MemberRealEmoji memberRealEmoji = new MemberRealEmoji("1", memberId, familyId,
                 Emoji.EMOJI_1, "https://oing.com/emoji.jpg", "emoji.jpg");


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
미션 포스트 작성/조회 모킹 API 추가했습니다.

## ➕ 추가/변경된 기능

---
- 미션 포스트 작성/조회 모킹 API 추가

## 🥺 리뷰어에게 하고싶은 말

---
**바뀐 파일이 많습니다. 커밋 별로 봐주세요!**

- 빠른 모킹을 위해 미션 작성/조회에서 별도로 검증 로직 추가하는 부분은 제외했는데 프론트에서 원한다면 추가하겠습니다.

- 기존 포스트 작성/조회 API에 param을 추가해서 미션 포스트도 처리 가능하도록 설계했습니다. 더 좋은 의견이 있다면 알려주세요~
(param이 없거나 feed -> feed post / mission -> mission post)

- 🚨 포스트 조회의 경우, QueryDSL로 페이지네이션을 처리하고 있는데 임의적으로 응답을 모킹하기가 힘들어 일단 **?type=mission 으로 조회해도 기존에 있던 feed type의 포스트가 조회**되도록 했습니다. 만약 지금 로직을 크게 바꾸지 않는 선에서 임의로 응답 모킹이 가능하다면 방법 알려주신다면 그렇게 바꾸겠습니다!


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-302