### PR TITLE
[OING-308] feat: 가족구성원 랭킹 API 모킹

### DIFF
--- a/gateway/src/main/java/com/oing/controller/HomeController.java
+++ b/gateway/src/main/java/com/oing/controller/HomeController.java
@@ -1,0 +1,23 @@
+package com.oing.controller;
+
+import com.oing.dto.response.FamilyMemberMonthlyRankingResponse;
+import com.oing.dto.response.FamilyMemberRankerResponse;
+import com.oing.restapi.HomeApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class HomeController implements HomeApi {
+
+    @Override
+    public FamilyMemberMonthlyRankingResponse getFamilyMemberMonthlyRanking(String loginMemberId, String loginFamilyId) {
+        // TODO: API Response Mocking 입니다.
+
+        FamilyMemberRankerResponse first = new FamilyMemberRankerResponse("https://static01.nyt.com/images/2016/09/28/us/28xp-pepefrog/28xp-pepefrog-superJumbo.jpg", "정신적 지주", 24);
+        FamilyMemberRankerResponse second = new FamilyMemberRankerResponse("https://static01.nyt.com/images/2016/09/28/us/28xp-pepefrog/28xp-pepefrog-superJumbo.jpg", "권순찬", 23);
+        FamilyMemberRankerResponse third = null;
+
+        return new FamilyMemberMonthlyRankingResponse(4, first, second, third);
+    }
+}

--- a/gateway/src/main/java/com/oing/dto/response/FamilyMemberMonthlyRankingResponse.java
+++ b/gateway/src/main/java/com/oing/dto/response/FamilyMemberMonthlyRankingResponse.java
@@ -1,0 +1,20 @@
+package com.oing.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "가족구성원 월간 랭킹 응답")
+public record FamilyMemberMonthlyRankingResponse(
+
+        @Schema(description = "랭킹 기준 월")
+        Integer month,
+
+        @Schema(description = "1등 랭커 Dto")
+        FamilyMemberRankerResponse firstRanker,
+
+        @Schema(description = "2등 랭커 Dto")
+        FamilyMemberRankerResponse secondRanker,
+
+        @Schema(description = "3등 랭커 Dto")
+        FamilyMemberRankerResponse thirdRanker
+) {
+}

--- a/gateway/src/main/java/com/oing/dto/response/FamilyMemberRankerResponse.java
+++ b/gateway/src/main/java/com/oing/dto/response/FamilyMemberRankerResponse.java
@@ -1,0 +1,17 @@
+package com.oing.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "가족구성원 랭커 응답")
+public record FamilyMemberRankerResponse(
+
+        @Schema(description = "랭커의 프로필 사진 Url", example = "https://no5ing.com/profile/1.jpg")
+        String profileImageUrl,
+
+        @Schema(description = "랭커의 이름", example = "권순찬")
+        String name,
+
+        @Schema(description = "랭커의 생존 신고 횟수")
+        Integer survivalCount
+) {
+}

--- a/gateway/src/main/java/com/oing/restapi/HomeApi.java
+++ b/gateway/src/main/java/com/oing/restapi/HomeApi.java
@@ -1,0 +1,29 @@
+package com.oing.restapi;
+
+import com.oing.dto.response.FamilyMemberMonthlyRankingResponse;
+import com.oing.util.security.LoginFamilyId;
+import com.oing.util.security.LoginMemberId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "홈 View API", description = "프론트의 홈 화면 기반으로 작성된 View API")
+@RestController
+@Valid
+@RequestMapping("/v1/home")
+public interface HomeApi {
+
+    @Operation(summary = "금월의 가족 구성원 월간 랭킹 조회", description = "이번 달에 해당하는 가족 구성원 월간 랭킹을 조회합니다.")
+    FamilyMemberMonthlyRankingResponse getFamilyMemberMonthlyRanking(
+            @Parameter(hidden = true)
+            @LoginMemberId
+            String loginMemberId,
+
+            @Parameter(hidden = true)
+            @LoginFamilyId
+            String loginFamilyId
+    );
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
가족구성원 랭킹 API를 프론트에게 우선적으로 요청받았기 때문에, API Mocking을 진행하였습니다.

## ➕ 추가/변경된 기능

---
- HomeAPI, HomeController 추가
- getFamilyMemberMonthlyRanking API spec 구현
- getFamilyMemberMonthlyRanking API controller 모킹

## 🥺 리뷰어에게 하고싶은 말

---
@CChuYong 요청한 사안압니다. 그리고 생성한 HomeAPI에 회의에서 언급된 홈화면 상단 프로필 API를 마이그레이션하면 될 것 같습니다.


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-308