### PR TITLE
[OING-312] fix: OING-307 티켓의 미션 모듈 엔티티들의 테이블 추가 flyway db.migration 중 발생한 에러 해결

### DIFF
--- a/gateway/src/main/resources/db/migration/V202404152221__create_Mission_module_tables.sql
+++ b/gateway/src/main/resources/db/migration/V202404152221__create_Mission_module_tables.sql
@@ -1,19 +1,19 @@
-CREATE TABLE 'mission'
+CREATE TABLE IF NOT EXISTS `mission`
 (
-    'created_at' DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    'updated_at' DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    'content'    VARCHAR(255) NOT NULL,
-    'mission_id' CHAR(26)     NOT NULL COMMENT 'UUID',
-    PRIMARY KEY ('mission_id')
+    `created_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `content`    VARCHAR(255) NOT NULL,
+    `mission_id` CHAR(26)     NOT NULL COMMENT 'UUID',
+    PRIMARY KEY (`mission_id`)
 ) DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci comment '미션테이블';
 
-CREATE TABLE 'daily_mission_history'
+CREATE TABLE IF NOT EXISTS `daily_mission_history`
 (
-    'date'       DATE         NOT NULL,
-    'created_at' DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    'mission_id' CHAR(26)     NOT NULL,
-    FOREIGN KEY 'daily_mission_history_fk1' ('mission_id') REFERENCES 'mission' ('mission_id'),
-    PRIMARY KEY ('date')
+    `date`       DATE         NOT NULL,
+    `created_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `mission_id` CHAR(26)     NOT NULL,
+    FOREIGN KEY `daily_mission_history_fk1` (`mission_id`) REFERENCES `mission` (`mission_id`),
+    PRIMARY KEY (`date`)
 ) DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci comment '일일미션내역테이블';


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
PR #230 이 머지되면서 발생한 "미션 모듈 엔티티들의 테이블 추가 flyway db.migration 중 발생한 에러"를 해결하기 위해서 올립니다.

## ➕ 추가/변경된 기능

---
- flyway db.migration sql 파일에 백틱(`)이 아니라 작은 따옴표(')를 사용한 부분들을 수정

## 🥺 리뷰어에게 하고싶은 말

---
확인 부탁드려요!

## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-312