### PR TITLE
[OING-313] hotfix: 기존 post의 데이터들이 type값이 FEED로 저장되어 있는 이슈 해결

### DIFF
--- a/gateway/src/main/resources/db/migration/V202404171338__set_type_column_default_value_in_Post.sql
+++ b/gateway/src/main/resources/db/migration/V202404171338__set_type_column_default_value_in_Post.sql
@@ -1,0 +1,1 @@
+UPDATE `post` SET `type` = 'SURVIVAL' WHERE `type` = 'FEED';


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
기존 post의 데이터들이 type값이 FEED로 저장되어 있는 이슈가 생겨 SURVIVAL로 다시 바꾸는 sql문을 추가했습니다.

## ➕ 추가/변경된 기능

---
- 기존 post의 데이터들이 type값이 FEED로 저장되어 있는 이슈 해결

## 🥺 리뷰어에게 하고싶은 말

---
이전 PR이 배포가 성공하면 해당 PR 머지하겠습니다.


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-313