### PR TITLE
[OING-314] feature: 회원 생존신고 게시글 업로드 여부 / 회원 미션 참여 가능 여부 확인 mock API 추가

### DIFF
--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -6,9 +6,7 @@ import com.oing.domain.Post;
 import com.oing.domain.PostType;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
-import com.oing.dto.response.PaginationResponse;
-import com.oing.dto.response.PostResponse;
-import com.oing.dto.response.PreSignedUrlResponse;
+import com.oing.dto.response.*;
 import com.oing.exception.AuthorizationFailedException;
 import com.oing.restapi.PostApi;
 import com.oing.service.MemberBridge;
@@ -78,11 +76,40 @@ public class PostController implements PostApi {
         return PostResponse.from(memberPostProjection);
     }
 
+    @Override
+    public SurvivalUploadStatusResponse getSurvivalUploadStatus(String memberId, String loginMemberId, boolean valid) {
+        validateMemberId(loginMemberId, memberId);
+        // TODO: 추후 valid 파라미터 삭제
+        // TODO: 해당 회원이 생존신고 글을 올렸는지 검증 로직 추가
+        if (valid) {
+            return new SurvivalUploadStatusResponse(true);
+        }
+        return new SurvivalUploadStatusResponse(false);
+    }
+
+    @Override
+    public MissionEligibleStatusResponse getMissionEligibleStatus(String memberId, String loginMemberId, boolean valid) {
+        validateMemberId(loginMemberId, memberId);
+        // TODO: 추후 valid 파라미터 삭제
+        // TODO: 해당 회원이 미션에 참여 가능한 회원인지 검증 로직 추가
+        if (valid) {
+            return new MissionEligibleStatusResponse(true);
+        }
+        return new MissionEligibleStatusResponse(false);
+    }
+
     private void validateFamilyMember(String loginMemberId, String postId) {
         String postFamilyId = postService.getMemberPostById(postId).getFamilyId();
         String loginFamilyId = memberBridge.getFamilyIdByMemberId(loginMemberId);
         if (!postFamilyId.equals(loginFamilyId)) {
             log.warn("Unauthorized access attempt: Member {} is attempting to access post {}", loginMemberId, postId);
+            throw new AuthorizationFailedException();
+        }
+    }
+
+    private void validateMemberId(String loginMemberId, String memberId) {
+        if (!loginMemberId.equals(memberId)) {
+            log.warn("Unauthorized access attempt: Member {} is attempting to access post", loginMemberId);
             throw new AuthorizationFailedException();
         }
     }

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -88,14 +88,14 @@ public class PostController implements PostApi {
     }
 
     @Override
-    public MissionEligibleStatusResponse getMissionEligibleStatus(String memberId, String loginMemberId, boolean valid) {
+    public MissionAvailableStatusResponse getMissionAvailableStatus(String memberId, String loginMemberId, boolean valid) {
         validateMemberId(loginMemberId, memberId);
         // TODO: 추후 valid 파라미터 삭제
         // TODO: 해당 회원이 미션에 참여 가능한 회원인지 검증 로직 추가
         if (valid) {
-            return new MissionEligibleStatusResponse(true);
+            return new MissionAvailableStatusResponse(true);
         }
-        return new MissionEligibleStatusResponse(false);
+        return new MissionAvailableStatusResponse(false);
     }
 
     private void validateFamilyMember(String loginMemberId, String postId) {

--- a/post/src/main/java/com/oing/dto/response/MissionAvailableStatusResponse.java
+++ b/post/src/main/java/com/oing/dto/response/MissionAvailableStatusResponse.java
@@ -3,8 +3,8 @@ package com.oing.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "회원 미션 참여 가능 여부 응답")
-public record MissionEligibleStatusResponse(
+public record MissionAvailableStatusResponse(
         @Schema(description = "회원 미션 참여 가능 여부", example = "true")
-        boolean isValid
+        boolean isAvailable
 ) {
 }

--- a/post/src/main/java/com/oing/dto/response/MissionEligibleStatusResponse.java
+++ b/post/src/main/java/com/oing/dto/response/MissionEligibleStatusResponse.java
@@ -1,0 +1,10 @@
+package com.oing.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 미션 참여 가능 여부 응답")
+public record MissionEligibleStatusResponse(
+        @Schema(description = "회원 미션 참여 가능 여부", example = "true")
+        boolean isValid
+) {
+}

--- a/post/src/main/java/com/oing/dto/response/SurvivalUploadStatusResponse.java
+++ b/post/src/main/java/com/oing/dto/response/SurvivalUploadStatusResponse.java
@@ -1,0 +1,11 @@
+package com.oing.dto.response;
+
+import com.oing.domain.Reaction;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 생존신고 게시글 업로드 여부 응답")
+public record SurvivalUploadStatusResponse(
+        @Schema(description = "회원 생존신고 게시글 업로드 여부", example = "true")
+        boolean isValid
+) {
+}

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -3,9 +3,7 @@ package com.oing.restapi;
 import com.oing.domain.PostType;
 import com.oing.dto.request.CreatePostRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
-import com.oing.dto.response.PaginationResponse;
-import com.oing.dto.response.PostResponse;
-import com.oing.dto.response.PreSignedUrlResponse;
+import com.oing.dto.response.*;
 import com.oing.util.security.LoginFamilyId;
 import com.oing.util.security.LoginMemberId;
 import io.swagger.v3.oas.annotations.Operation;
@@ -106,5 +104,37 @@ public interface PostApi {
             @Parameter(hidden = true)
             @LoginMemberId
             String loginMemberId
+    );
+
+    @Operation(summary = "회원 생존신고 게시글 업로드 여부 응답 조회", description = "회원 생존신고 게시글 업로드 여부를 조회합니다.")
+    @GetMapping("/{memberId}/survival-uploaded")
+    SurvivalUploadStatusResponse getSurvivalUploadStatus(
+            @PathVariable
+            @Parameter(description = "대상 사용자 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            String memberId,
+
+            @Parameter(hidden = true)
+            @LoginMemberId
+            String loginMemberId,
+
+            @RequestParam
+            @Parameter(description = "응답 값 조작 필드", example = "true")
+            boolean valid
+    );
+
+    @Operation(summary = "회원 미션 참여 가능 여부 응답 조회", description = "회원 미션 참여 가능 여부를 조회합니다.")
+    @GetMapping("/{memberId}/mission-eligible")
+    MissionEligibleStatusResponse getMissionEligibleStatus(
+            @PathVariable
+            @Parameter(description = "대상 사용자 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            String memberId,
+
+            @Parameter(hidden = true)
+            @LoginMemberId
+            String loginMemberId,
+
+            @RequestParam
+            @Parameter(description = "응답 값 조작 필드", example = "true")
+            boolean valid
     );
 }

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -123,8 +123,8 @@ public interface PostApi {
     );
 
     @Operation(summary = "회원 미션 참여 가능 여부 응답 조회", description = "회원 미션 참여 가능 여부를 조회합니다.")
-    @GetMapping("/{memberId}/mission-eligible")
-    MissionEligibleStatusResponse getMissionEligibleStatus(
+    @GetMapping("/{memberId}/mission-available")
+    MissionAvailableStatusResponse getMissionAvailableStatus(
             @PathVariable
             @Parameter(description = "대상 사용자 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
             String memberId,


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
회원 생존신고 게시글 업로드 여부 / 회원 미션 참여 가능 여부 확인하는 mock API를 추가했습니다.

## ➕ 추가/변경된 기능

---
- 회원 생존신고 게시글 업로드 여부 확인 mock API 추가
- 회원 미션 참여 가능 여부 확인 mock API 추가

## 🥺 리뷰어에게 하고싶은 말

---
프론트에서 mock api더라도 query parameter로 응답값 조작이 가능하길 원하셔서 임시적으로 query parameter를 추가했습니다. 추후, 실제 구현 때는 해당 파라미터를 제거할 예정입니다.

uri 결정하면서 고민을 했는데 API의 행동이 더 명확하게 보이는 uri가 있다면 추천해주세요~


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-314