### PR TITLE
[OING-323] feat: 일간 캘린더 API 추가

### DIFF
--- a/common/src/main/java/com/oing/service/MemberBridge.java
+++ b/common/src/main/java/com/oing/service/MemberBridge.java
@@ -1,5 +1,7 @@
 package com.oing.service;
 
+import java.util.List;
+
 /**
  * no5ing-server
  * User: CChuYong
@@ -31,4 +33,6 @@ public interface MemberBridge {
      * @return 삭제된 사용자인지 여부
      */
     boolean isDeletedMember(String memberId);
+
+    List<String> getFamilyMembersIdsByFamilyId(String familyId);
 }

--- a/common/src/main/java/com/oing/service/MissionBridge.java
+++ b/common/src/main/java/com/oing/service/MissionBridge.java
@@ -1,8 +1,12 @@
 package com.oing.service;
 
+import java.time.LocalDate;
+
 public interface MissionBridge {
 
     String getContentByMissionId(String missionId);
+
+    String getContentByDate(LocalDate date);
 
     String getTodayMissionId();
 }

--- a/gateway/src/main/java/com/oing/controller/CalendarController.java
+++ b/gateway/src/main/java/com/oing/controller/CalendarController.java
@@ -43,11 +43,8 @@ public class CalendarController implements CalendarApi {
         String missionContent = missionBridge.getContentByDate(date);
 
         HashSet<String> uploadedFamilyMembers = survivalPosts.stream().map(PostResponse::authorId).collect(Collectors.toCollection(HashSet::new));
-        System.out.println(uploadedFamilyMembers.toString());
         List<String> familyMembersIds = memberBridge.getFamilyMembersIdsByFamilyId(loginFamilyId);
-        System.out.println(familyMembersIds.toString());
         boolean allFamilyMembersUploaded = uploadedFamilyMembers.containsAll(familyMembersIds);
-        System.out.println(allFamilyMembersUploaded);
 
         survivalPosts.forEach(post -> dailyCalendarResponses.add(new DailyCalendarResponse(date, PostType.SURVIVAL, post.postId(), post.imageUrl(), null, allFamilyMembersUploaded)));
         missionPosts.forEach(post -> dailyCalendarResponses.add(new DailyCalendarResponse(date, PostType.MISSION, post.postId(), post.imageUrl(), missionContent, allFamilyMembersUploaded)));

--- a/gateway/src/main/java/com/oing/controller/CalendarController.java
+++ b/gateway/src/main/java/com/oing/controller/CalendarController.java
@@ -34,23 +34,24 @@ public class CalendarController implements CalendarApi {
 
 
     @Override
-    public ArrayResponse<DailyCalendarResponse> getDailyCalendar(String yearMonthDay, String loginMemberId) {
+    public ArrayResponse<DailyCalendarResponse> getDailyCalendar(String yearMonthDay, String loginMemberId, String loginFamilyId) {
         List<DailyCalendarResponse> dailyCalendarResponses = new ArrayList<>();
         LocalDate date = LocalDate.parse(yearMonthDay, DateTimeFormatter.ISO_DATE);
 
+        Collection<PostResponse> survivalPosts = postController.fetchDailyFeeds(1, 10, date, null, "ASC", PostType.SURVIVAL, loginMemberId, true).results();
+        Collection<PostResponse> missionPosts = postController.fetchDailyFeeds(1, 10, date, null, "ASC", PostType.MISSION, loginMemberId, true).results();
         String missionContent = missionBridge.getContentByDate(date);
-        Collection<PostResponse> survivalPosts = postController.fetchDailyFeeds(1, 10, date, loginMemberId, "ASC", PostType.SURVIVAL, loginMemberId, true).results();
-        Collection<PostResponse> missionPosts = postController.fetchDailyFeeds(1, 10, date, loginMemberId, "ASC", PostType.SURVIVAL, loginMemberId, true).results();
 
         HashSet<String> uploadedFamilyMembers = survivalPosts.stream().map(PostResponse::authorId).collect(Collectors.toCollection(HashSet::new));
-        List<String> familyMembersIds = memberBridge.getFamilyMembersIdsByFamilyId(loginMemberId);
+        System.out.println(uploadedFamilyMembers.toString());
+        List<String> familyMembersIds = memberBridge.getFamilyMembersIdsByFamilyId(loginFamilyId);
+        System.out.println(familyMembersIds.toString());
         boolean allFamilyMembersUploaded = uploadedFamilyMembers.containsAll(familyMembersIds);
+        System.out.println(allFamilyMembersUploaded);
 
-        survivalPosts.forEach(post -> dailyCalendarResponses.add(new DailyCalendarResponse(date, PostType.SURVIVAL, post.postId(), post.imageUrl(), missionContent, allFamilyMembersUploaded)));
-        missionPosts.forEach(post -> dailyCalendarResponses.add(new DailyCalendarResponse(date, PostType.SURVIVAL, post.postId(), post.imageUrl(), missionContent, allFamilyMembersUploaded)));
-
-
-        return null;
+        survivalPosts.forEach(post -> dailyCalendarResponses.add(new DailyCalendarResponse(date, PostType.SURVIVAL, post.postId(), post.imageUrl(), null, allFamilyMembersUploaded)));
+        missionPosts.forEach(post -> dailyCalendarResponses.add(new DailyCalendarResponse(date, PostType.MISSION, post.postId(), post.imageUrl(), missionContent, allFamilyMembersUploaded)));
+        return ArrayResponse.of(dailyCalendarResponses);
     }
 
 

--- a/gateway/src/main/java/com/oing/controller/CalendarController.java
+++ b/gateway/src/main/java/com/oing/controller/CalendarController.java
@@ -59,7 +59,7 @@ public class CalendarController implements CalendarApi {
     }
 
     private List<DailyCalendarResponse> convertToDailyCalendarResponse(Collection<PostResponse> posts, String missionContent, boolean allFamilyMembersUploaded) {
-        return posts.stream().map(post -> switch (PostType.valueOf(post.type())) {
+        return posts.stream().map(post -> switch (PostType.fromString(post.type())) {
             case MISSION -> new DailyCalendarResponse(post.createdAt().toLocalDate(), MISSION, post.postId(), post.imageUrl(), missionContent, allFamilyMembersUploaded);
             case SURVIVAL -> new DailyCalendarResponse(post.createdAt().toLocalDate(), SURVIVAL, post.postId(), post.imageUrl(), null, allFamilyMembersUploaded);
         }).toList();

--- a/gateway/src/main/java/com/oing/restapi/CalendarApi.java
+++ b/gateway/src/main/java/com/oing/restapi/CalendarApi.java
@@ -21,24 +21,28 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/calendar")
 public interface CalendarApi {
 
-    @Operation(summary = "월간 캘린더 조회", description = "월간 캘린더를 조회합니다. 각 날짜의 대표 게시글 정보와 가족 구성원 전부의 업로드 여부가가 조회되며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.")
-    @GetMapping(params = {"type=MONTHLY"})
-    ArrayResponse<MonthlyCalendarResponse> getMonthlyCalendar(
-            @RequestParam
-            @Parameter(description = "조회할 년월", example = "2021-12")
-            String yearMonth,
-
-            @Parameter(hidden = true)
-            @LoginMemberId
-            String loginMemberId
-    );
-
     @Operation(summary = "일간 캘린더 조회", description = "일간 캘린더를 조회합니다. 주어진 날에 업로드된 게시글들이 조회되며 정책에 따라, 게시일자 오름차순 / 생존신고 게시글 → 미션 게시글 순서로 정렬됩니다.")
     @GetMapping(params = {"type=DAILY"})
     ArrayResponse<DailyCalendarResponse> getDailyCalendar(
             @RequestParam
             @Parameter(description = "조회할 년월일", example = "2021-12-25")
             String yearMonthDay,
+
+            @Parameter(hidden = true)
+            @LoginMemberId
+            String loginMemberId,
+
+            @Parameter(hidden = true)
+            @LoginFamilyId
+            String loginFamilyId
+    );
+
+    @Operation(summary = "월간 캘린더 조회", description = "월간 캘린더를 조회합니다. 각 날짜의 대표 게시글 정보와 가족 구성원 전부의 업로드 여부가가 조회되며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.")
+    @GetMapping(params = {"type=MONTHLY"})
+    ArrayResponse<MonthlyCalendarResponse> getMonthlyCalendar(
+            @RequestParam
+            @Parameter(description = "조회할 년월", example = "2021-12")
+            String yearMonth,
 
             @Parameter(hidden = true)
             @LoginFamilyId

--- a/gateway/src/main/java/com/oing/restapi/CalendarApi.java
+++ b/gateway/src/main/java/com/oing/restapi/CalendarApi.java
@@ -21,12 +21,24 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/calendar")
 public interface CalendarApi {
 
-    @Operation(summary = "월별 캘린더 조회", description = "월별로 캘린더를 조회합니다. 각 날짜의 대표 게시글 정보와 가족 구성원 전부의 업로드 여부가가 조회되며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.")
+    @Operation(summary = "월간 캘린더 조회", description = "월간 캘린더를 조회합니다. 각 날짜의 대표 게시글 정보와 가족 구성원 전부의 업로드 여부가가 조회되며, 해당 날짜에 게시글이 있는 경우만 response 에 포함됩니다.")
     @GetMapping(params = {"type=MONTHLY"})
-    ArrayResponse<CalendarResponse> getMonthlyCalendar(
+    ArrayResponse<MonthlyCalendarResponse> getMonthlyCalendar(
             @RequestParam
             @Parameter(description = "조회할 년월", example = "2021-12")
             String yearMonth,
+
+            @Parameter(hidden = true)
+            @LoginMemberId
+            String loginMemberId
+    );
+
+    @Operation(summary = "일간 캘린더 조회", description = "일간 캘린더를 조회합니다. 주어진 날에 업로드된 게시글들이 조회되며 정책에 따라, 게시일자 오름차순 / 생존신고 게시글 → 미션 게시글 순서로 정렬됩니다.")
+    @GetMapping(params = {"type=DAILY"})
+    ArrayResponse<DailyCalendarResponse> getDailyCalendar(
+            @RequestParam
+            @Parameter(description = "조회할 년월일", example = "2021-12-25")
+            String yearMonthDay,
 
             @Parameter(hidden = true)
             @LoginFamilyId

--- a/gateway/src/main/java/com/oing/service/MemberBridgeImpl.java
+++ b/gateway/src/main/java/com/oing/service/MemberBridgeImpl.java
@@ -8,6 +8,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 /**
  * no5ing-server
  * User: CChuYong
@@ -47,5 +49,12 @@ public class MemberBridgeImpl implements MemberBridge {
     @Override
     public boolean isDeletedMember(String memberId) {
         return memberRepository.existsByIdAndDeletedAtNotNull(memberId);
+    }
+
+    @Override
+    public List<String> getFamilyMembersIdsByFamilyId(String familyId) {
+        return memberRepository.findAllByFamilyIdAndDeletedAtIsNull(familyId).stream()
+                .map(Member::getId)
+                .toList();
     }
 }

--- a/gateway/src/main/java/com/oing/service/MissionBridgeImpl.java
+++ b/gateway/src/main/java/com/oing/service/MissionBridgeImpl.java
@@ -20,6 +20,11 @@ public class MissionBridgeImpl implements MissionBridge {
     }
 
     @Override
+    public String getContentByDate(LocalDate date) {
+        return missionService.getMissionByDate(date).content();
+    }
+
+    @Override
     public String getTodayMissionId() {
         LocalDate today = ZonedDateTime.now().toLocalDate();
         DailyMissionHistory todayMission = dailyMissionHistoryService.getDailyMissionHistoryByDate(today);

--- a/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
@@ -4,7 +4,7 @@ import com.oing.domain.Member;
 import com.oing.domain.Post;
 import com.oing.domain.PostType;
 import com.oing.dto.response.ArrayResponse;
-import com.oing.dto.response.CalendarResponse;
+import com.oing.dto.response.MonthlyCalendarResponse;
 import com.oing.service.MemberService;
 import com.oing.service.PostService;
 import com.oing.util.OptimizedImageUrlGenerator;
@@ -111,11 +111,11 @@ class CalendarControllerTest {
         when(postService.findLatestPostOfEveryday(startDate, endDate, familyId)).thenReturn(representativePosts);
 
         // When
-        ArrayResponse<CalendarResponse> weeklyCalendar = calendarController.getMonthlyCalendar(yearMonth, familyId);
+        ArrayResponse<MonthlyCalendarResponse> weeklyCalendar = calendarController.getMonthlyCalendar(yearMonth, familyId);
 
         // Then
         assertThat(weeklyCalendar.results())
-                .extracting(CalendarResponse::representativePostId)
+                .extracting(MonthlyCalendarResponse::representativePostId)
                 .containsExactly("1", "2", "3", "4");
     }
 }

--- a/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
+++ b/gateway/src/test/java/com/oing/controller/CalendarControllerTest.java
@@ -60,7 +60,7 @@ class CalendarControllerTest {
 
 
     @Test
-    void 월별_캘린더_조회_테스트() {
+    void 월간_캘린더_조회_테스트() {
         // Given
         String yearMonth = "2023-11";
         String familyId = testMember1.getFamilyId();

--- a/mission/src/main/java/com/oing/service/MissionService.java
+++ b/mission/src/main/java/com/oing/service/MissionService.java
@@ -46,9 +46,12 @@ public class MissionService {
     }
 
     public MissionResponse getMissionByDate(LocalDate date) {
-        Mission mission = dailyMissionHistoryService.getDailyMissionHistoryByDate(date).getMission();
+        return new MissionResponse("1", "오늘의 기분을 나타내는 사진 찍기.");
 
-        return MissionResponse.from(mission);
+        // TODO: Mocking 제거 시, 주석 해제
+//        Mission mission = dailyMissionHistoryService.getDailyMissionHistoryByDate(date).getMission();
+//
+//        return MissionResponse.from(mission);
     }
 
 

--- a/mission/src/main/java/com/oing/service/MissionService.java
+++ b/mission/src/main/java/com/oing/service/MissionService.java
@@ -10,12 +10,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MissionService {
 
     private final MissionRepository missionRepository;
+    private final DailyMissionHistoryService dailyMissionHistoryService;
+
     private final IdentityGenerator identityGenerator;
 
 
@@ -39,6 +43,12 @@ public class MissionService {
         // TODO: Mocking 제거 시, 주석 해제
 //        return missionRepository.findById(missionId)
 //            .orElseThrow(MissionNotFoundException::new);
+    }
+
+    public MissionResponse getMissionByDate(LocalDate date) {
+        Mission mission = dailyMissionHistoryService.getDailyMissionHistoryByDate(date).getMission();
+
+        return MissionResponse.from(mission);
     }
 
 

--- a/post/src/main/java/com/oing/dto/response/DailyCalendarResponse.java
+++ b/post/src/main/java/com/oing/dto/response/DailyCalendarResponse.java
@@ -1,0 +1,31 @@
+package com.oing.dto.response;
+
+import com.oing.domain.PostType;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Schema(description = "일간 캘린더 응답")
+public record DailyCalendarResponse(
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        @Parameter(description = "오늘의 날짜", example = "2023-12-05")
+        LocalDate date,
+
+        @Schema(description = "게시글 유형", example = "SURVIVAL")
+        PostType type,
+
+        @Schema(description = "게시글 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String postId,
+
+        @Schema(description = "게시글 사진 url", example = "https://j1ansx15683.edge.naverncp.com/image/absc45j/image.jpg?type=f&w=96&h=96")
+        String postImgUrl,
+
+        @Schema(description = "미션 내용 (생존신고 게시글이랑 null 반환)", example = "오늘의 기분을 나타내는 사진 찍기.")
+        String missionContent,
+
+        @Schema(description = "모든 가족 구성원이 업로드 했는지 여부", example = "true")
+        boolean allFamilyMembersUploaded
+) {
+}

--- a/post/src/main/java/com/oing/dto/response/MonthlyCalendarResponse.java
+++ b/post/src/main/java/com/oing/dto/response/MonthlyCalendarResponse.java
@@ -6,8 +6,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
-@Schema(description = "캘린더 응답")
-public record CalendarResponse(
+@Schema(description = "월간 캘린더 응답")
+public record MonthlyCalendarResponse(
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         @Parameter(description = "오늘의 날짜", example = "2023-12-05")
         LocalDate date,


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
미션 게시글이 추가됨에 따라, 주간(일별로 보는) 캘린더에서 생존신고 게시글 다음에 미션 게시글이 나타나는 정책이 추가되었고 미션 게시글 또한 캘린더 DTO에서 대응해야했습니다. 기존에는 프론트가 fetchPosts 공용 API를 이용해 게시글을 조회하고 이를 잘 가공하여 보여주는 방식이었는데, 공용 API의 기능이 이미 비대하고 새로운 기능들이 프론트에서 구현하기 복잡하여 프론트에 맞춘 뷰 기반 API를 추가했습니다.

## ➕ 추가/변경된 기능

---
- getCalendar API를 getMonthlyCalendar와 getDailyCalendar로 분리하고, getDailyCalendar를 구현 (API추가, DTO 추가, 필요한 비즈니스 코드 추가 및 연결)
- 테스트 코드 추가

## 🥺 리뷰어에게 하고싶은 말

---
프론트에서 계속 요청들어오는 부분이라 빠르게 부탁드려요!



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-323