### PR TITLE
[OING-324] refactor: NighttimeMainPage의 displayRank 필드는 늘 NULL이 되도록 수정

### DIFF
--- a/gateway/src/main/java/com/oing/controller/MainViewController.java
+++ b/gateway/src/main/java/com/oing/controller/MainViewController.java
@@ -147,7 +147,7 @@ public class MainViewController implements MainViewApi {
                 member.imageUrl(),
                 String.valueOf(member.name().charAt(0)),
                 member.name(),
-                1,
+                null,
                 member.dayOfBirth().getMonth() == today.getMonth()
                         && member.dayOfBirth().getDayOfMonth() == today.getDayOfMonth(),
                 false

--- a/gateway/src/main/java/com/oing/dto/response/MainPageTopBarResponse.java
+++ b/gateway/src/main/java/com/oing/dto/response/MainPageTopBarResponse.java
@@ -23,7 +23,7 @@ public record MainPageTopBarResponse(
         String displayName,
 
         @Schema(description = "순위 표기 (1부터 시작)" +
-                "\n- 야간의 경우 모두 1입니다."
+                "\n- 야간의 경우 모두 NULL입니다."
                 , example = "1")
         Integer displayRank,
 


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
NighttimeMainPage의 displayRank 필드는 기존 모두 1에서 NULL이 되도록 수정해달라는 프론트엔드의 요청이 있었습니다.

## ➕ 추가/변경된 기능

---
- getNighttimeMainPage에서 displayRank 설정을 늘 전부 NULL이 되도록 수정
- Response DTO에서 displayRank의 야근시 값에 대한 설명 수정

## 🥺 리뷰어에게 하고싶은 말

---
프론트에 사이드이펙트 없도록 빠르게 해주시면 감사하겠습니다..!

## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-324