### PR TITLE
[OING-328] feat: DailyCalendarResponse에 PostResponse 필드 추가 (프론트 요청)

### DIFF
--- a/gateway/src/main/java/com/oing/controller/CalendarController.java
+++ b/gateway/src/main/java/com/oing/controller/CalendarController.java
@@ -60,8 +60,8 @@ public class CalendarController implements CalendarApi {
 
     private List<DailyCalendarResponse> convertToDailyCalendarResponse(Collection<PostResponse> posts, String missionContent, boolean allFamilyMembersUploaded) {
         return posts.stream().map(post -> switch (PostType.fromString(post.type())) {
-            case MISSION -> new DailyCalendarResponse(post.createdAt().toLocalDate(), MISSION, post.postId(), post.imageUrl(), missionContent, allFamilyMembersUploaded);
-            case SURVIVAL -> new DailyCalendarResponse(post.createdAt().toLocalDate(), SURVIVAL, post.postId(), post.imageUrl(), null, allFamilyMembersUploaded);
+            case MISSION -> DailyCalendarResponse.of(post, missionContent, allFamilyMembersUploaded);
+            case SURVIVAL -> DailyCalendarResponse.of(post, null, allFamilyMembersUploaded);
         }).toList();
     }
 

--- a/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
@@ -187,7 +187,6 @@ class CalendarApiTest {
                 .andExpect(jsonPath("$.results[0].commentCount").value(0))
                 .andExpect(jsonPath("$.results[0].emojiCount").value(0))
                 .andExpect(jsonPath("$.results[0].allFamilyMembersUploaded").value(true))
-                .andExpect(jsonPath("$.results[0].createdAt").value("2023-11-02T14:00:00+09:00"))
                 .andExpect(jsonPath("$.results[1].date").value("2023-11-02"))
                 .andExpect(jsonPath("$.results[1].type").value("survival"))
                 .andExpect(jsonPath("$.results[1].postId").value("4"))
@@ -198,7 +197,6 @@ class CalendarApiTest {
                 .andExpect(jsonPath("$.results[1].commentCount").value(0))
                 .andExpect(jsonPath("$.results[1].emojiCount").value(0))
                 .andExpect(jsonPath("$.results[1].allFamilyMembersUploaded").value(true))
-                .andExpect(jsonPath("$.results[1].createdAt").value("2023-11-02T15:00:00+09:00"))
                 .andExpect(jsonPath("$.results[2].date").value("2023-11-02"))
                 .andExpect(jsonPath("$.results[2].type").value("mission"))
                 .andExpect(jsonPath("$.results[2].postId").value("7"))
@@ -209,7 +207,6 @@ class CalendarApiTest {
                 .andExpect(jsonPath("$.results[2].commentCount").value(0))
                 .andExpect(jsonPath("$.results[2].emojiCount").value(0))
                 .andExpect(jsonPath("$.results[2].allFamilyMembersUploaded").value(true))
-                .andExpect(jsonPath("$.results[2].createdAt").value("2023-11-02T14:00:00+09:00"))
                 .andExpect(jsonPath("$.results[3].date").value("2023-11-02"))
                 .andExpect(jsonPath("$.results[3].type").value("mission"))
                 .andExpect(jsonPath("$.results[3].postId").value("8"))
@@ -219,8 +216,7 @@ class CalendarApiTest {
                 .andExpect(jsonPath("$.results[3].authorId").value(TEST_MEMBER2_ID))
                 .andExpect(jsonPath("$.results[3].commentCount").value(0))
                 .andExpect(jsonPath("$.results[3].emojiCount").value(0))
-                .andExpect(jsonPath("$.results[3].allFamilyMembersUploaded").value(true))
-                .andExpect(jsonPath("$.results[3].createdAt").value("2023-11-02T15:00:00+09:00"));
+                .andExpect(jsonPath("$.results[3].allFamilyMembersUploaded").value(true));
 
     }
 

--- a/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/CalendarApiTest.java
@@ -146,22 +146,22 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/1", 0, 0, "2023-11-01 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/1", 0, 0, "2023-11-01 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/2", 0, 0, "2023-11-01 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/2", 0, 0, "2023-11-01 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "3", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/3", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "3", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/3", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "4", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/4", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "4", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/4", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "5", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/5", 0, 0, "2023-11-03 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "5", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/5", 0, 0, "2023-11-03 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "6", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/6", 0, 0, "2023-11-03 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "6", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/6", 0, 0, "2023-11-03 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "7", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "MISSION", "https://storage.com/images/7", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "7", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "mission", "https://storage.com/images/7", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "8", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "MISSION", "https://storage.com/images/8", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "8", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "mission", "https://storage.com/images/8", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
 
         // mission
         String missionId = missionService.createMission(new CreateMissionRequest("오늘의 기분을 나타내는 사진 찍기.")).id();
@@ -170,8 +170,7 @@ class CalendarApiTest {
 
 
         // When
-        ResultActions result = mockMvc.perform(get("/v1/calendar")
-                .param("type", "DAILY")
+        ResultActions result = mockMvc.perform(get("/v1/calendar/daily")
                 .param("yearMonthDay", yearMonthDay)
                 .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
         );
@@ -179,25 +178,49 @@ class CalendarApiTest {
         // Then
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.results[0].date").value("2023-11-02"))
-                .andExpect(jsonPath("$.results[0].type").value("SURVIVAL"))
+                .andExpect(jsonPath("$.results[0].type").value("survival"))
                 .andExpect(jsonPath("$.results[0].postId").value("3"))
+                .andExpect(jsonPath("$.results[0].postImgUrl").value("https://storage.com/images/3"))
+                .andExpect(jsonPath("$.results[0].postContent").value("post1111"))
                 .andExpect(jsonPath("$.results[0].missionContent").isEmpty())
+                .andExpect(jsonPath("$.results[0].authorId").value(TEST_MEMBER1_ID))
+                .andExpect(jsonPath("$.results[0].commentCount").value(0))
+                .andExpect(jsonPath("$.results[0].emojiCount").value(0))
                 .andExpect(jsonPath("$.results[0].allFamilyMembersUploaded").value(true))
+                .andExpect(jsonPath("$.results[0].createdAt").value("2023-11-02T14:00:00+09:00"))
                 .andExpect(jsonPath("$.results[1].date").value("2023-11-02"))
-                .andExpect(jsonPath("$.results[1].type").value("SURVIVAL"))
+                .andExpect(jsonPath("$.results[1].type").value("survival"))
                 .andExpect(jsonPath("$.results[1].postId").value("4"))
+                .andExpect(jsonPath("$.results[1].postImgUrl").value("https://storage.com/images/4"))
+                .andExpect(jsonPath("$.results[1].postContent").value("post2222"))
                 .andExpect(jsonPath("$.results[1].missionContent").isEmpty())
+                .andExpect(jsonPath("$.results[1].authorId").value(TEST_MEMBER2_ID))
+                .andExpect(jsonPath("$.results[1].commentCount").value(0))
+                .andExpect(jsonPath("$.results[1].emojiCount").value(0))
                 .andExpect(jsonPath("$.results[1].allFamilyMembersUploaded").value(true))
+                .andExpect(jsonPath("$.results[1].createdAt").value("2023-11-02T15:00:00+09:00"))
                 .andExpect(jsonPath("$.results[2].date").value("2023-11-02"))
-                .andExpect(jsonPath("$.results[2].type").value("MISSION"))
+                .andExpect(jsonPath("$.results[2].type").value("mission"))
                 .andExpect(jsonPath("$.results[2].postId").value("7"))
+                .andExpect(jsonPath("$.results[2].postImgUrl").value("https://storage.com/images/7"))
+                .andExpect(jsonPath("$.results[2].postContent").value("post1111"))
                 .andExpect(jsonPath("$.results[2].missionContent").value("오늘의 기분을 나타내는 사진 찍기."))
+                .andExpect(jsonPath("$.results[2].authorId").value(TEST_MEMBER1_ID))
+                .andExpect(jsonPath("$.results[2].commentCount").value(0))
+                .andExpect(jsonPath("$.results[2].emojiCount").value(0))
                 .andExpect(jsonPath("$.results[2].allFamilyMembersUploaded").value(true))
+                .andExpect(jsonPath("$.results[2].createdAt").value("2023-11-02T14:00:00+09:00"))
                 .andExpect(jsonPath("$.results[3].date").value("2023-11-02"))
-                .andExpect(jsonPath("$.results[3].type").value("MISSION"))
+                .andExpect(jsonPath("$.results[3].type").value("mission"))
                 .andExpect(jsonPath("$.results[3].postId").value("8"))
+                .andExpect(jsonPath("$.results[3].postImgUrl").value("https://storage.com/images/8"))
+                .andExpect(jsonPath("$.results[3].postContent").value("post2222"))
                 .andExpect(jsonPath("$.results[3].missionContent").value("오늘의 기분을 나타내는 사진 찍기."))
-                .andExpect(jsonPath("$.results[3].allFamilyMembersUploaded").value(true));
+                .andExpect(jsonPath("$.results[3].authorId").value(TEST_MEMBER2_ID))
+                .andExpect(jsonPath("$.results[3].commentCount").value(0))
+                .andExpect(jsonPath("$.results[3].emojiCount").value(0))
+                .andExpect(jsonPath("$.results[3].allFamilyMembersUploaded").value(true))
+                .andExpect(jsonPath("$.results[3].createdAt").value("2023-11-02T15:00:00+09:00"));
 
     }
 
@@ -209,15 +232,15 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/3", 0, 0, "2023-11-02 14:01:00", "2023-11-02 14:01:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/3", 0, 0, "2023-11-02 14:01:00", "2023-11-02 14:01:00", "post1111", "1");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "MISSION", "https://storage.com/images/7", 0, 0, "2023-11-02 14:02:00", "2023-11-02 14:02:00", "post1111", "1");
+                "2", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "mission", "https://storage.com/images/7", 0, 0, "2023-11-02 14:02:00", "2023-11-02 14:02:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "3", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "MISSION", "https://storage.com/images/8", 0, 0, "2023-11-02 15:03:00", "2023-11-02 15:03:00", "post2222", "2");
+                "3", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "mission", "https://storage.com/images/8", 0, 0, "2023-11-02 15:03:00", "2023-11-02 15:03:00", "post2222", "2");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "4", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/4", 0, 0, "2023-11-02 15:04:00", "2023-11-02 15:04:00", "post2222", "2");
+                "4", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/4", 0, 0, "2023-11-02 15:04:00", "2023-11-02 15:04:00", "post2222", "2");
 
         // mission
         String missionId = missionService.createMission(new CreateMissionRequest("오늘의 기분을 나타내는 사진 찍기.")).id();
@@ -226,34 +249,17 @@ class CalendarApiTest {
 
 
         // When
-        ResultActions result = mockMvc.perform(get("/v1/calendar")
-                .param("type", "DAILY")
+        ResultActions result = mockMvc.perform(get("/v1/calendar/daily")
                 .param("yearMonthDay", yearMonthDay)
                 .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
         );
 
         // Then
         result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.results[0].date").value("2023-11-02"))
-                .andExpect(jsonPath("$.results[0].type").value("SURVIVAL"))
                 .andExpect(jsonPath("$.results[0].postId").value("1"))
-                .andExpect(jsonPath("$.results[0].missionContent").isEmpty())
-                .andExpect(jsonPath("$.results[0].allFamilyMembersUploaded").value(true))
-                .andExpect(jsonPath("$.results[1].date").value("2023-11-02"))
-                .andExpect(jsonPath("$.results[1].type").value("SURVIVAL"))
                 .andExpect(jsonPath("$.results[1].postId").value("4"))
-                .andExpect(jsonPath("$.results[1].missionContent").isEmpty())
-                .andExpect(jsonPath("$.results[1].allFamilyMembersUploaded").value(true))
-                .andExpect(jsonPath("$.results[2].date").value("2023-11-02"))
-                .andExpect(jsonPath("$.results[2].type").value("MISSION"))
                 .andExpect(jsonPath("$.results[2].postId").value("2"))
-                .andExpect(jsonPath("$.results[2].missionContent").value("오늘의 기분을 나타내는 사진 찍기."))
-                .andExpect(jsonPath("$.results[2].allFamilyMembersUploaded").value(true))
-                .andExpect(jsonPath("$.results[3].date").value("2023-11-02"))
-                .andExpect(jsonPath("$.results[3].type").value("MISSION"))
-                .andExpect(jsonPath("$.results[3].postId").value("3"))
-                .andExpect(jsonPath("$.results[3].missionContent").value("오늘의 기분을 나타내는 사진 찍기."))
-                .andExpect(jsonPath("$.results[3].allFamilyMembersUploaded").value(true));
+                .andExpect(jsonPath("$.results[3].postId").value("3"));
 
     }
 
@@ -265,7 +271,7 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/3", 0, 0, "2023-11-02 14:01:00", "2023-11-02 14:01:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/3", 0, 0, "2023-11-02 14:01:00", "2023-11-02 14:01:00", "post1111", "1");
 
         // mission
         String missionId = missionService.createMission(new CreateMissionRequest("오늘의 기분을 나타내는 사진 찍기.")).id();
@@ -274,18 +280,14 @@ class CalendarApiTest {
 
 
         // When
-        ResultActions result = mockMvc.perform(get("/v1/calendar")
-                .param("type", "DAILY")
+        ResultActions result = mockMvc.perform(get("/v1/calendar/daily")
                 .param("yearMonthDay", yearMonthDay)
                 .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
         );
 
         // Then
         result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.results[0].date").value("2023-11-02"))
-                .andExpect(jsonPath("$.results[0].type").value("SURVIVAL"))
                 .andExpect(jsonPath("$.results[0].postId").value("1"))
-                .andExpect(jsonPath("$.results[0].missionContent").isEmpty())
                 .andExpect(jsonPath("$.results[0].allFamilyMembersUploaded").value(false));
 
     }
@@ -299,19 +301,18 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "3", TEST_MEMBER3_ID, "something_other", 1, "SURVIVAL", "https://storage.com/images/3", 0, 0, "2023-11-02 17:00:00", "2023-11-02 17:00:00", "post3333", "3");
+                "3", TEST_MEMBER3_ID, "something_other", 1, "survival", "https://storage.com/images/3", 0, 0, "2023-11-02 17:00:00", "2023-11-02 17:00:00", "post3333", "3");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "4", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/4", 0, 0, "2023-11-03 14:00:00", "2023-11-03 14:00:00", "post4444", "4");
+                "4", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/4", 0, 0, "2023-11-03 14:00:00", "2023-11-03 14:00:00", "post4444", "4");
 
 
         // When & Then
-        mockMvc.perform(get("/v1/calendar")
-                        .param("type", "MONTHLY")
+        mockMvc.perform(get("/v1/calendar/monthly")
                         .param("yearMonth", yearMonth)
                         .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
                 )
@@ -335,20 +336,19 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "0", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/0", 0, 0, "2023-11-01 14:00:00", "2023-11-01 14:00:00", "post0000", "0");
+                "0", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/0", 0, 0, "2023-11-01 14:00:00", "2023-11-01 14:00:00", "post0000", "0");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "3", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/3", 0, 0, "2023-11-03 13:00:00", "2023-11-03 13:00:00", "post3333", "3");
+                "3", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/3", 0, 0, "2023-11-03 13:00:00", "2023-11-03 13:00:00", "post3333", "3");
 
 
         // When & Then
-        mockMvc.perform(get("/v1/calendar")
-                        .param("type", "MONTHLY")
+        mockMvc.perform(get("/v1/calendar/monthly")
                         .param("yearMonth", yearMonth)
                         .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
                 )
@@ -375,9 +375,9 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/1", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
+                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/2", 0, 0, "2023-11-02 15:00:00", "2023-11-02 15:00:00", "post2222", "2");
 
         // Member2 가족 탈퇴
         mockMvc.perform(post("/v1/me/quit-family")
@@ -401,8 +401,7 @@ class CalendarApiTest {
 
 
         // When & Then
-        mockMvc.perform(get("/v1/calendar")
-                        .param("type", "MONTHLY")
+        mockMvc.perform(get("/v1/calendar/monthly")
                         .param("yearMonth", yearMonth)
                         .header("X-AUTH-TOKEN", TEST_MEMBER1_TOKEN)
                 )
@@ -421,24 +420,24 @@ class CalendarApiTest {
 
         // posts
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/1", 0, 0, "2023-11-01 14:00:00", "2023-11-01 14:00:00", "post1111", "1");
+                "1", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/1", 0, 0, "2023-11-01 14:00:00", "2023-11-01 14:00:00", "post1111", "1");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/2", 0, 0, "2023-11-01 15:00:00", "2023-11-01 15:00:00", "post2222", "2");
+                "2", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/2", 0, 0, "2023-11-01 15:00:00", "2023-11-01 15:00:00", "post2222", "2");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "3", TEST_MEMBER3_ID, "something_other", 1, "SURVIVAL", "https://storage.com/images/3", 0, 0, "2023-11-01 17:00:00", "2023-11-01 17:00:00", "post3333", "3");
+                "3", TEST_MEMBER3_ID, "something_other", 1, "survival", "https://storage.com/images/3", 0, 0, "2023-11-01 17:00:00", "2023-11-01 17:00:00", "post3333", "3");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "4", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/4", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post4444", "4");
+                "4", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/4", 0, 0, "2023-11-02 14:00:00", "2023-11-02 14:00:00", "post4444", "4");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "5", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/5", 0, 0, "2023-11-29 14:00:00", "2023-11-29 14:00:00", "post5555", "5");
+                "5", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/5", 0, 0, "2023-11-29 14:00:00", "2023-11-29 14:00:00", "post5555", "5");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "6", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/6", 0, 0, "2023-11-29 15:00:00", "2023-11-29 15:00:00", "post6666", "6");
+                "6", TEST_MEMBER2_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/6", 0, 0, "2023-11-29 15:00:00", "2023-11-29 15:00:00", "post6666", "6");
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "7", TEST_MEMBER3_ID, "something_other", 1, "SURVIVAL", "https://storage.com/images/7", 0, 0, "2023-11-29 17:00:00", "2023-11-29 17:00:00", "post7777", "7");
+                "7", TEST_MEMBER3_ID, "something_other", 1, "survival", "https://storage.com/images/7", 0, 0, "2023-11-29 17:00:00", "2023-11-29 17:00:00", "post7777", "7");
 
         jdbcTemplate.update("insert into post (post_id, member_id, family_id, mission_id, type, post_img_url, comment_cnt, reaction_cnt, created_at, updated_at, content, post_img_key) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
-                "8", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "SURVIVAL", "https://storage.com/images/8", 0, 0, "2023-11-30 14:00:00", "2023-11-30 14:00:00", "post8888", "8");
+                "8", TEST_MEMBER1_ID, TEST_FAMILY_ID, 1, "survival", "https://storage.com/images/8", 0, 0, "2023-11-30 14:00:00", "2023-11-30 14:00:00", "post8888", "8");
 
 
         // When & Then

--- a/post/src/main/java/com/oing/dto/response/DailyCalendarResponse.java
+++ b/post/src/main/java/com/oing/dto/response/DailyCalendarResponse.java
@@ -1,11 +1,11 @@
 package com.oing.dto.response;
 
-import com.oing.domain.PostType;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 @Schema(description = "일간 캘린더 응답")
 public record DailyCalendarResponse(
@@ -14,7 +14,7 @@ public record DailyCalendarResponse(
         LocalDate date,
 
         @Schema(description = "게시글 유형", example = "SURVIVAL")
-        PostType type,
+        String type,
 
         @Schema(description = "게시글 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
         String postId,
@@ -22,10 +22,41 @@ public record DailyCalendarResponse(
         @Schema(description = "게시글 사진 url", example = "https://j1ansx15683.edge.naverncp.com/image/absc45j/image.jpg?type=f&w=96&h=96")
         String postImgUrl,
 
-        @Schema(description = "미션 내용 (생존신고 게시글이랑 null 반환)", example = "오늘의 기분을 나타내는 사진 찍기.")
+        @Schema(description = "게시물 내용", example = "맛있는 밥!")
+        String postContent,
+
+        @Schema(description = "미션 내용 (생존신고 게시글이라면 null 반환)", example = "오늘의 기분을 나타내는 사진 찍기.")
         String missionContent,
 
+        @Schema(description = "게시물 작성자 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String authorId,
+
+        @Schema(description = "게시물 댓글 수", example = "3")
+        Integer commentCount,
+
+        @Schema(description = "게시물 반응 수", example = "2")
+        Integer emojiCount,
+
         @Schema(description = "모든 가족 구성원이 업로드 했는지 여부", example = "true")
-        boolean allFamilyMembersUploaded
+        boolean allFamilyMembersUploaded,
+
+        @Schema(description = "피드 작성 시간", example = "2023-12-23T01:53:21.577347+09:00")
+        ZonedDateTime createdAt
 ) {
+
+        public static DailyCalendarResponse of(PostResponse postResponse, String missionContent, boolean allFamilyMembersUploaded) {
+                return new DailyCalendarResponse(
+                        postResponse.createdAt().toLocalDate(),
+                        postResponse.type(),
+                        postResponse.postId(),
+                        postResponse.imageUrl(),
+                        postResponse.content(),
+                        missionContent,
+                        postResponse.authorId(),
+                        postResponse.commentCount(),
+                        postResponse.emojiCount(),
+                        allFamilyMembersUploaded,
+                        postResponse.createdAt()
+                );
+        }
 }


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
DailyCalendarResponse에 PostResponse 필드를 추가해달라는 프론트 요청이 있었습니다.

## ➕ 추가/변경된 기능

---
- DailyCalendarResponse에 (postContent, authorId, commentCount, emojiCount, allFamilyMembersUploaded, createdAt) 필드 추가

## 🥺 리뷰어에게 하고싶은 말

---




## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-328