### PR TITLE
[OING-329] refactor: 미션 검증 로직 중에서 가족 구성원 수 계산할 때, 어제 날짜 기준으로 세도록 수정

### DIFF
--- a/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
@@ -119,10 +119,12 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
 
     @Override
     public boolean isCreatedSurvivalPostByMajority(LocalDate date, String familyId) {
+        LocalDate today = ZonedDateTime.now().toLocalDate();
         long totalFamilyMembers = queryFactory
                 .select(member.count())
                 .from(member)
                 .where(member.familyId.eq(familyId)
+                        .and(dateExpr(member.familyJoinAt).before(today))
                         .and(isActiveMember()))
                 .fetchFirst();
 
@@ -140,11 +142,13 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public int countFamilyMembersByFamilyId(String familyId) {
+    public int countFamilyMembersByFamilyIdAtYesterday(String familyId) {
+        LocalDate today = ZonedDateTime.now().toLocalDate();
         Long count = queryFactory
                 .select(member.id.count())
                 .from(member)
                 .where(member.familyId.eq(familyId)
+                        .and(dateExpr(member.familyJoinAt).before(today))
                         .and(isActiveMember()))
                 .fetchFirst();
         return count.intValue();

--- a/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
@@ -118,30 +118,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public boolean isCreatedSurvivalPostByMajority(LocalDate date, String familyId) {
-        LocalDate today = ZonedDateTime.now().toLocalDate();
-        long totalFamilyMembers = queryFactory
-                .select(member.count())
-                .from(member)
-                .where(member.familyId.eq(familyId)
-                        .and(dateExpr(member.familyJoinAt).before(today))
-                        .and(isActiveMember()))
-                .fetchFirst();
-
-        long survivalPostCount = queryFactory
-                .select(post.count())
-                .from(post)
-                .where(
-                        post.familyId.eq(familyId),
-                        post.type.eq(PostType.SURVIVAL),
-                        dateExpr(post.createdAt).eq(date)
-                )
-                .fetchFirst();
-
-        return survivalPostCount >= totalFamilyMembers / 2;
-    }
-
-    @Override
     public int countFamilyMembersByFamilyIdAtYesterday(String familyId) {
         LocalDate today = ZonedDateTime.now().toLocalDate();
         Long count = queryFactory

--- a/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
@@ -46,7 +46,7 @@ class PostRepositoryCustomTest {
             "testMember1",
             "profile.com/1",
             "1",
-            LocalDateTime.now()
+            LocalDateTime.now().minusDays(1)
     );
 
     private final Member testMember2 = new Member(
@@ -56,7 +56,7 @@ class PostRepositoryCustomTest {
             "testMember2",
             "profile.com/2",
             "2",
-            LocalDateTime.now()
+            LocalDateTime.now().minusDays(1)
     );
 
     private final Member testMember3 = new Member(
@@ -65,7 +65,17 @@ class PostRepositoryCustomTest {
             LocalDate.of(1999, 10, 18),
             "testMember3",
             "profile.com/3",
-            "2",
+            "3",
+            LocalDateTime.now().minusDays(1)
+    );
+
+    private final Member testMember4 = new Member(
+            "testMember4",
+            "testFamily",
+            LocalDate.of(1999, 10, 18),
+            "testMember4",
+            "profile.com/4",
+            "4",
             LocalDateTime.now()
     );
 
@@ -167,12 +177,12 @@ class PostRepositoryCustomTest {
     }
 
     @Test
-    void 가족_구성원_수를_조회한다() {
+    void 어제_날짜를_기준으로_가족_구성원_수를_조회한다() {
         // given
         String familyId = testMember1.getFamilyId();
 
         // when
-        int familyMemberCount = postRepositoryCustomImpl.countFamilyMembersByFamilyId(familyId);
+        int familyMemberCount = postRepositoryCustomImpl.countFamilyMembersByFamilyIdAtYesterday(familyId);
 
         // then
         assertThat(familyMemberCount).isEqualTo(2);

--- a/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
@@ -139,32 +139,6 @@ class PostRepositoryCustomTest {
     }
 
     @Test
-    void 미션_키_획득한_날짜에_가족의_미션_키_획득_여부를_조회한다() {
-        // given
-        String familyId = testMember1.getFamilyId();
-        LocalDate today = LocalDate.of(2023, 11, 1);
-
-        // when
-        boolean exists = postRepositoryCustomImpl.isCreatedSurvivalPostByMajority(today, familyId);
-
-        // then
-        assertThat(exists).isTrue();
-    }
-
-    @Test
-    void 미션_키_획득하지_못한_날짜에_가족의_미션_키_획득_여부를_조회한다() {
-        // given
-        String familyId = testMember1.getFamilyId();
-        LocalDate today = LocalDate.of(2024, 4, 1);
-
-        // when
-        boolean exists = postRepositoryCustomImpl.isCreatedSurvivalPostByMajority(today, familyId);
-
-        // then
-        assertThat(exists).isFalse();
-    }
-
-    @Test
     void 해당_가족_구성원이_오늘_올린_생존신고_게시글_수를_조회한다() {
         // given
         String familyId = testMember1.getFamilyId();

--- a/gateway/src/test/java/com/oing/restapi/PostApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/PostApiTest.java
@@ -61,7 +61,7 @@ class PostApiTest {
                         TEST_FAMILY_ID,
                         LocalDate.now(),
                         "", "", "",
-                        LocalDateTime.now()
+                        LocalDateTime.now().minusDays(1)
                 )
         );
         TEST_MEMBER1_TOKEN = tokenGenerator
@@ -73,7 +73,7 @@ class PostApiTest {
                         TEST_FAMILY_ID,
                         LocalDate.now(),
                         "", "", "",
-                        LocalDateTime.now()
+                        LocalDateTime.now().minusDays(1)
                 )
         );
         TEST_MEMBER2_TOKEN = tokenGenerator

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
 
 /**
  * no5ing-server
@@ -114,9 +113,8 @@ public class PostController implements PostApi {
     @Override
     public MissionAvailableStatusResponse getMissionAvailableStatus(String memberId, String loginMemberId, String loginFamilyId) {
         validateMemberId(loginMemberId, memberId);
-        LocalDate today = ZonedDateTime.now().toLocalDate();
 
-        if (postService.isCreatedSurvivalPostByMajority(today, loginFamilyId)) {
+        if (postService.isCreatedSurvivalPostByMajority(loginFamilyId)) {
             return new MissionAvailableStatusResponse(true);
         }
         return new MissionAvailableStatusResponse(false);

--- a/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
@@ -24,7 +24,7 @@ public interface PostRepositoryCustom {
 
     boolean isCreatedSurvivalPostByMajority(LocalDate date, String familyId);
 
-    int countFamilyMembersByFamilyId(String familyId);
+    int countFamilyMembersByFamilyIdAtYesterday(String familyId);
 
     int countTodaySurvivalPostsByFamilyId(String familyId);
 }

--- a/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
@@ -22,8 +22,6 @@ public interface PostRepositoryCustom {
 
     boolean existsByMemberIdAndFamilyIdAndTypeAndCreatedAt(String memberId, String familyId, PostType type, LocalDate postDate);
 
-    boolean isCreatedSurvivalPostByMajority(LocalDate date, String familyId);
-
     int countFamilyMembersByFamilyIdAtYesterday(String familyId);
 
     int countTodaySurvivalPostsByFamilyId(String familyId);

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -146,7 +146,7 @@ public interface PostApi {
             String loginFamilyId
     );
 
-    @Operation(summary = "회원 미션 참여 가능 여부 응답 조회", description = "회원 미션 참여 가능 여부를 조회합니다.")
+    @Operation(summary = "가족 미션 키 획득 여부 응답 조회", description = "가족 미션 키 획득 여부를 조회합니다.")
     @GetMapping("/{memberId}/mission-available")
     MissionAvailableStatusResponse getMissionAvailableStatus(
             @PathVariable

--- a/post/src/main/java/com/oing/service/PostService.java
+++ b/post/src/main/java/com/oing/service/PostService.java
@@ -166,7 +166,7 @@ public class PostService {
     }
 
     public int calculateRemainingSurvivalPostCountUntilMissionUnlocked(String familyId) {
-        int familyMemberCount = postRepository.countFamilyMembersByFamilyId(familyId);
+        int familyMemberCount = postRepository.countFamilyMembersByFamilyIdAtYesterday(familyId);
         int requiredSurvivalPostCount = familyMemberCount / 2;
         int todaySurvivalPostCount = postRepository.countTodaySurvivalPostsByFamilyId(familyId);
 

--- a/post/src/main/java/com/oing/service/PostService.java
+++ b/post/src/main/java/com/oing/service/PostService.java
@@ -161,8 +161,11 @@ public class PostService {
         return postRepository.existsByMemberIdAndFamilyIdAndTypeAndCreatedAt(memberId, familyId, type, postDate);
     }
 
-    public boolean isCreatedSurvivalPostByMajority(LocalDate date, String familyId) {
-        return postRepository.isCreatedSurvivalPostByMajority(date, familyId);
+    public boolean isCreatedSurvivalPostByMajority(String familyId) {
+        int totalFamilyMembers = postRepository.countFamilyMembersByFamilyIdAtYesterday(familyId);
+        int survivalPostCount = postRepository.countTodaySurvivalPostsByFamilyId(familyId);
+
+        return survivalPostCount >= totalFamilyMembers / 2;
     }
 
     public int calculateRemainingSurvivalPostCountUntilMissionUnlocked(String familyId) {

--- a/post/src/test/java/com/oing/service/PostServiceTest.java
+++ b/post/src/test/java/com/oing/service/PostServiceTest.java
@@ -42,7 +42,7 @@ public class PostServiceTest {
         String familyId = "1";
 
         //when
-        when(postRepository.countFamilyMembersByFamilyId(familyId)).thenReturn(1);
+        when(postRepository.countFamilyMembersByFamilyIdAtYesterday(familyId)).thenReturn(1);
         when(postRepository.countTodaySurvivalPostsByFamilyId(familyId)).thenReturn(0);
 
         //then


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
오늘 날짜 기준으로 가족 구성원 수를 계산하는 기존 미션 키 관련 검증 로직이 문제가 될 수 있어, 가족 구성원 수를 어제 날짜 기준으로 세도록 수정했습니다.

## ➕ 추가/변경된 기능

---
- 미션 검증 로직 중, 가족 구성원 수를 어제 날짜 기준으로 세도록 수정

## 🥺 리뷰어에게 하고싶은 말

---
추가적으로 수정해야 할 부분이 있다면 알려주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-329