### PR TITLE
[OING-326] feat: 일일 미션 배치 구현 및 테스트코드 추가

### DIFF
--- a/.github/workflows/dev-cicd.yaml
+++ b/.github/workflows/dev-cicd.yaml
@@ -8,6 +8,7 @@ on:
       - 'common/**' # Common 모듈 변경
       - 'family/**' # Family 모듈 변경
       - 'post/**' # Post 모듈 변경
+      - 'mission/**' # Mission 모듈 변경
       - '.github/workflows/**' # 워크플로우와 관련된 파일이 변경된 경우
       - 'build.gradle' # Parent Gradle 모듈 설정이 변경된 경우
       - 'settings.gradle' # Parent Gradle 설정이 변경된 경우

--- a/.github/workflows/prod-cicd.yaml
+++ b/.github/workflows/prod-cicd.yaml
@@ -8,6 +8,7 @@ on:
       - 'common/**' # Common 모듈 변경
       - 'family/**' # Family 모듈 변경
       - 'post/**' # Post 모듈 변경
+      - 'mission/**' # Mission 모듈 변경
       - '.github/workflows/**' # 워크플로우와 관련된 파일이 변경된 경우
       - 'build.gradle' # Parent Gradle 모듈 설정이 변경된 경우
       - 'settings.gradle' # Parent Gradle 설정이 변경된 경우

--- a/common/src/main/java/com/oing/exception/ErrorCode.java
+++ b/common/src/main/java/com/oing/exception/ErrorCode.java
@@ -75,6 +75,7 @@ public enum ErrorCode {
      */
     MISSION_NOT_FOUND("MI0001", "존재하지 않는 미션입니다."),
     DAILY_MISSION_HISTORY_NOT_FOUND("MI0002", "존재하지 않는 미션 히스토리입니다."),
+    DUPLICATED_DAILY_MISSION_HISTORY("MI0003", "이미 존재하는 미션 히스토리입니다."),
 
     /**
      * Deep Link Related Errors

--- a/gateway/src/test/java/com/oing/job/DailyMissionJobTest.java
+++ b/gateway/src/test/java/com/oing/job/DailyMissionJobTest.java
@@ -171,5 +171,13 @@ public class DailyMissionJobTest {
             // when
             assertThatNoException().isThrownBy(() -> dailyMissionJob.registerDailyMission());
         }
+
+        @Test
+        void 중복된_미션이_생성시도경우_예외핸들링을_한다() {
+            // when
+            assertThatNoException().isThrownBy(() -> dailyMissionJob.registerDailyMission());
+            jdbcTemplate.update("UPDATE shedlock SET lock_until = locked_at WHERE name = 'DailyMissionRegistrationJob'");
+            assertThatNoException().isThrownBy(() -> dailyMissionJob.registerDailyMission());
+        }
     }
 }

--- a/gateway/src/test/java/com/oing/job/DailyMissionJobTest.java
+++ b/gateway/src/test/java/com/oing/job/DailyMissionJobTest.java
@@ -1,0 +1,175 @@
+package com.oing.job;
+
+import com.oing.domain.DailyMissionHistory;
+import com.oing.domain.Mission;
+import com.oing.repository.DailyMissionHistoryRepository;
+import com.oing.repository.MissionRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class DailyMissionJobTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private DailyMissionJob dailyMissionJob;
+    @Autowired
+    private MissionRepository missionRepository;
+    @Autowired
+    private DailyMissionHistoryRepository dailyMissionHistoryRepository;
+
+
+    private Mission testMission1;
+    private Mission testMission2;
+    private Mission testMission3;
+    private Mission testMission4;
+    private Mission testMission5;
+    private Mission testMission6;
+    private Mission testMission7;
+
+
+    @BeforeEach
+    void setUp() {
+        testMission1 = missionRepository.save(Mission.builder()
+                .id("testMission1")
+                .content("testMission1")
+                .build());
+
+        testMission2 = missionRepository.save(Mission.builder()
+                .id("testMission2")
+                .content("testMission2")
+                .build());
+
+        testMission3 = missionRepository.save(Mission.builder()
+                .id("testMission3")
+                .content("testMission3")
+                .build());
+
+        testMission4 = missionRepository.save(Mission.builder()
+                .id("testMission4")
+                .content("testMission4")
+                .build());
+
+        testMission5 = missionRepository.save(Mission.builder()
+                .id("testMission5")
+                .content("testMission5")
+                .build());
+
+        testMission6 = missionRepository.save(Mission.builder()
+                .id("testMission6")
+                .content("testMission6")
+                .build());
+
+        testMission7 = missionRepository.save(Mission.builder()
+                .id("testMission7")
+                .content("testMission7")
+                .build());
+
+        // Table Lock 용 테이블 생성
+        jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS shedlock\n" +
+                "(\n" +
+                "    name       VARCHAR(64)  NOT NULL,\n" +
+                "    lock_until TIMESTAMP(3) NOT NULL,\n" +
+                "    locked_at  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),\n" +
+                "    locked_by  VARCHAR(255) NOT NULL,\n" +
+                "    PRIMARY KEY (name)\n" +
+                ") DEFAULT CHARSET = utf8mb4\n" +
+                "  COLLATE = utf8mb4_unicode_ci COMMENT 'ShedLock 테이블';");
+        // Table Lock 비활성화
+        jdbcTemplate.update("UPDATE shedlock SET lock_until = locked_at WHERE name = 'DailyMissionRegistrationJob'");
+    }
+
+
+    @Nested
+    class registerDailyMission {
+        @Test
+        void 정상_등록_테스트() {
+            // given
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(1))
+                    .mission(testMission1)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(2))
+                    .mission(testMission2)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(3))
+                    .mission(testMission3)
+                    .build());
+
+            // when
+            dailyMissionJob.registerDailyMission();
+
+            // then
+            Optional<DailyMissionHistory> dailyMissionHistory = dailyMissionHistoryRepository.findById(LocalDate.now());
+            assertThat(dailyMissionHistory).isPresent();
+            assertThat(dailyMissionHistory.get().getMission().getId())
+                    .isNotIn(testMission1.getId(), testMission2.getId(), testMission3.getId())
+                    .isIn(testMission4.getId(), testMission5.getId(), testMission6.getId(), testMission7.getId());
+        }
+
+        @Test
+        void 제외된_미션_외_미션이_없는경우_가장_오래된_미션을_선출한다() {
+            // given
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(1))
+                    .mission(testMission1)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(2))
+                    .mission(testMission2)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(3))
+                    .mission(testMission3)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(4))
+                    .mission(testMission4)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(5))
+                    .mission(testMission5)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(6))
+                    .mission(testMission6)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.now().minusDays(7))
+                    .mission(testMission7)
+                    .build());
+
+            // when
+            dailyMissionJob.registerDailyMission();
+
+            // then
+            Optional<DailyMissionHistory> dailyMissionHistory = dailyMissionHistoryRepository.findById(LocalDate.now());
+            assertThat(dailyMissionHistory).isPresent();
+            assertThat(dailyMissionHistory.get().getMission().getId()).isEqualTo(testMission7.getId());
+        }
+
+        @Test
+        void 등록된_미션이_없는경우_예외핸들링을_한다() {
+            // when
+            assertThatNoException().isThrownBy(() -> dailyMissionJob.registerDailyMission());
+        }
+    }
+}

--- a/gateway/src/test/java/com/oing/repository/DailyMissionHistoryRepositoryTest.java
+++ b/gateway/src/test/java/com/oing/repository/DailyMissionHistoryRepositoryTest.java
@@ -77,7 +77,7 @@ public class DailyMissionHistoryRepositoryTest {
 
 
     @Nested
-    class FindRecentDailyMissionIdsOrderByDateAsc {
+    class findRecentDailyMissionIdsOrderByDateAsc {
         @Test
         void 정상_조회_테스트() {
             // given

--- a/gateway/src/test/java/com/oing/repository/DailyMissionHistoryRepositoryTest.java
+++ b/gateway/src/test/java/com/oing/repository/DailyMissionHistoryRepositoryTest.java
@@ -1,0 +1,131 @@
+package com.oing.repository;
+
+import com.oing.config.QuerydslConfig;
+import com.oing.domain.DailyMissionHistory;
+import com.oing.domain.Mission;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // application-test.yaml의 데이터베이스 설정을 적용하기 위해서 필수
+@ActiveProfiles("test")
+@Import(QuerydslConfig.class)
+public class DailyMissionHistoryRepositoryTest {
+
+    @Autowired
+    private MissionRepository missionRepository;
+    @Autowired
+    private DailyMissionHistoryRepository dailyMissionHistoryRepository;
+//    @Autowired
+//    private DailyMissionHistoryRepositoryCustomImpl dailyMissionHistoryRepositoryCustomIml;
+
+    private Mission testMission1;
+    private Mission testMission2;
+    private Mission testMission3;
+    private Mission testMission4;
+    private Mission testMission5;
+    private Mission testMission6;
+    private Mission testMission7;
+
+
+    @BeforeEach
+    void setUp() {
+        testMission1 = missionRepository.save(Mission.builder()
+                .id("testMission1")
+                .content("testMission1")
+                .build());
+
+        testMission2 = missionRepository.save(Mission.builder()
+                .id("testMission2")
+                .content("testMission2")
+                .build());
+
+        testMission3 = missionRepository.save(Mission.builder()
+                .id("testMission3")
+                .content("testMission3")
+                .build());
+
+        testMission4 = missionRepository.save(Mission.builder()
+                .id("testMission4")
+                .content("testMission4")
+                .build());
+
+        testMission5 = missionRepository.save(Mission.builder()
+                .id("testMission5")
+                .content("testMission5")
+                .build());
+
+        testMission6 = missionRepository.save(Mission.builder()
+                .id("testMission6")
+                .content("testMission6")
+                .build());
+
+        testMission7 = missionRepository.save(Mission.builder()
+                .id("testMission7")
+                .content("testMission7")
+                .build());
+    }
+
+
+    @Nested
+    class FindRecentDailyMissionIdsOrderByDateAsc {
+        @Test
+        void 정상_조회_테스트() {
+            // given
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.of(2021, 10, 1))
+                    .mission(testMission5)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.of(2021, 10, 2))
+                    .mission(testMission6)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.of(2021, 10, 3))
+                    .mission(testMission7)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.of(2021, 10, 4))
+                    .mission(testMission1)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.of(2021, 10, 5))
+                    .mission(testMission2)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.of(2021, 10, 6))
+                    .mission(testMission3)
+                    .build());
+            dailyMissionHistoryRepository.save(DailyMissionHistory.builder()
+                    .date(LocalDate.of(2021, 10, 7))
+                    .mission(testMission4)
+                    .build());
+
+            // when
+            List<String> recentDailyMissionIds = dailyMissionHistoryRepository.findRecentDailyMissionIdsOrderByDateAsc(7);
+
+            // then
+            assertThat(recentDailyMissionIds)
+                    .containsExactly(
+                            testMission5.getId(),
+                            testMission6.getId(),
+                            testMission7.getId(),
+                            testMission1.getId(),
+                            testMission2.getId(),
+                            testMission3.getId(),
+                            testMission4.getId()
+                    );
+        }
+    }
+}

--- a/gateway/src/test/java/com/oing/repository/MissionRepositoryTest.java
+++ b/gateway/src/test/java/com/oing/repository/MissionRepositoryTest.java
@@ -82,7 +82,7 @@ public class MissionRepositoryTest {
             List<String> excludingIds = List.of(testMission1.getId(), testMission2.getId(), testMission3.getId());
 
             // when
-            Optional<Mission> randomMissionId = missionRepository.getRandomMissionExcludingIds(excludingIds);
+            Optional<Mission> randomMissionId = missionRepository.findRandomMissionExcludingIds(excludingIds);
 
             // then
             assertThat(randomMissionId).isPresent();
@@ -97,7 +97,7 @@ public class MissionRepositoryTest {
             List<String> excludingIds = List.of(testMission1.getId(), testMission2.getId(), testMission3.getId(), testMission4.getId(), testMission5.getId(), testMission6.getId(), testMission7.getId());
 
             // when
-            Optional<Mission> randomMissionId = missionRepository.getRandomMissionExcludingIds(excludingIds);
+            Optional<Mission> randomMissionId = missionRepository.findRandomMissionExcludingIds(excludingIds);
 
             // then
             assertThat(randomMissionId).isNotPresent();

--- a/mission/src/main/java/com/oing/exception/DuplicatedDailyMissionHistoryException.java
+++ b/mission/src/main/java/com/oing/exception/DuplicatedDailyMissionHistoryException.java
@@ -1,0 +1,8 @@
+package com.oing.exception;
+
+public class DuplicatedDailyMissionHistoryException extends DomainException {
+
+    public DuplicatedDailyMissionHistoryException() {
+        super(ErrorCode.DUPLICATED_DAILY_MISSION_HISTORY);
+    }
+}

--- a/mission/src/main/java/com/oing/job/DailyMissionJob.java
+++ b/mission/src/main/java/com/oing/job/DailyMissionJob.java
@@ -29,7 +29,7 @@ public class DailyMissionJob {
 
         try {
             List<String> recentDailyMissionIds = dailyMissionHistoryService.getRecentSevenDailyMissionIdsOrderByDateAsc();
-            Mission newDailyMission = missionService.getRandomMissionExcludingIds(recentDailyMissionIds)
+            Mission newDailyMission = missionService.findRandomMissionExcludingIds(recentDailyMissionIds)
                     .orElse(missionService.getMissionByMissionId(recentDailyMissionIds.get(0))); // 최근 7일 동안 등록된 일일 미션 제외했을 때, 미션이 없다면 가장 오래된 미션을 가져옴
 
             DailyMissionHistoryResponse dailyMissionHistoryResponse = dailyMissionHistoryService.registerTodayDailyMission(newDailyMission);

--- a/mission/src/main/java/com/oing/job/DailyMissionJob.java
+++ b/mission/src/main/java/com/oing/job/DailyMissionJob.java
@@ -2,6 +2,7 @@ package com.oing.job;
 
 import com.oing.domain.Mission;
 import com.oing.dto.response.DailyMissionHistoryResponse;
+import com.oing.exception.DuplicatedDailyMissionHistoryException;
 import com.oing.service.DailyMissionHistoryService;
 import com.oing.service.MissionService;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +36,9 @@ public class DailyMissionJob {
             log.info("[DailyMissionRegistrationJob] 일일 미션 등록 성공 - {}, registeredMissionId = {}", dailyMissionHistoryResponse.date(), dailyMissionHistoryResponse.missionId());
 
         } catch (IndexOutOfBoundsException e) {
-            log.error("[DailyMissionRegistrationJob] 일일 미션 등록 실패 - 등록된 미션이 없습니다.");
+            log.error("[DailyMissionRegistrationJob] 일일 미션 등록 실패 - 등록된 일일 미션이 없습니다.");
+        } catch (DuplicatedDailyMissionHistoryException e) {
+            log.error("[DailyMissionRegistrationJob] 일일 미션 등록 실패 - 이미 등록된 일일 미션이 존재합니다.");
         } catch (Exception e) {
             log.error("[DailyMissionRegistrationJob] 일일 미션 등록 실패 - 스케줄링 배치에 알 수 없는 문제가 발생했습니다.");
         }

--- a/mission/src/main/java/com/oing/job/DailyMissionJob.java
+++ b/mission/src/main/java/com/oing/job/DailyMissionJob.java
@@ -26,11 +26,18 @@ public class DailyMissionJob {
     public void registerDailyMission() {
         log.info("[DailyMissionRegistrationJob] 일일 미션 등록 시작");
 
-        List<String> recentDailyMissionIds = dailyMissionHistoryService.getRecentSevenDailyMissionIdsOrderByDateAsc();
-        Mission newDailyMission = missionService.getRandomMissionExcludingIds(recentDailyMissionIds)
-                .orElse(missionService.getMissionByMissionId(recentDailyMissionIds.get(0))); // 최근 7일 동안 등록된 일일 미션 제외했을 때, 미션이 없다면 가장 오래된 미션을 가져옴
+        try {
+            List<String> recentDailyMissionIds = dailyMissionHistoryService.getRecentSevenDailyMissionIdsOrderByDateAsc();
+            Mission newDailyMission = missionService.getRandomMissionExcludingIds(recentDailyMissionIds)
+                    .orElse(missionService.getMissionByMissionId(recentDailyMissionIds.get(0))); // 최근 7일 동안 등록된 일일 미션 제외했을 때, 미션이 없다면 가장 오래된 미션을 가져옴
 
-        DailyMissionHistoryResponse dailyMissionHistoryResponse = dailyMissionHistoryService.registerTodayDailyMission(newDailyMission);
-        log.info("[DailyMissionRegistrationJob] 일일 미션 등록 성공 - {}, registeredMissionId = {}", dailyMissionHistoryResponse.date(), dailyMissionHistoryResponse.missionId());
+            DailyMissionHistoryResponse dailyMissionHistoryResponse = dailyMissionHistoryService.registerTodayDailyMission(newDailyMission);
+            log.info("[DailyMissionRegistrationJob] 일일 미션 등록 성공 - {}, registeredMissionId = {}", dailyMissionHistoryResponse.date(), dailyMissionHistoryResponse.missionId());
+
+        } catch (IndexOutOfBoundsException e) {
+            log.error("[DailyMissionRegistrationJob] 일일 미션 등록 실패 - 등록된 미션이 없습니다.");
+        } catch (Exception e) {
+            log.error("[DailyMissionRegistrationJob] 일일 미션 등록 실패 - 스케줄링 배치에 알 수 없는 문제가 발생했습니다.");
+        }
     }
 }

--- a/mission/src/main/java/com/oing/job/DailyMissionJob.java
+++ b/mission/src/main/java/com/oing/job/DailyMissionJob.java
@@ -1,0 +1,36 @@
+package com.oing.job;
+
+import com.oing.domain.Mission;
+import com.oing.dto.response.DailyMissionHistoryResponse;
+import com.oing.service.DailyMissionHistoryService;
+import com.oing.service.MissionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyMissionJob {
+
+    private final MissionService missionService;
+    private final DailyMissionHistoryService dailyMissionHistoryService;
+
+
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul") // 매일 01시
+    @SchedulerLock(name = "DailyMissionRegistrationJob", lockAtMostFor = "PT30S", lockAtLeastFor = "PT30S")
+    public void registerDailyMission() {
+        log.info("[DailyMissionRegistrationJob] 일일 미션 등록 시작");
+
+        List<String> recentDailyMissionIds = dailyMissionHistoryService.getRecentSevenDailyMissionIdsOrderByDateAsc();
+        Mission newDailyMission = missionService.getRandomMissionExcludingIds(recentDailyMissionIds)
+                .orElse(missionService.getMissionByMissionId(recentDailyMissionIds.get(0))); // 최근 7일 동안 등록된 일일 미션 제외했을 때, 미션이 없다면 가장 오래된 미션을 가져옴
+
+        DailyMissionHistoryResponse dailyMissionHistoryResponse = dailyMissionHistoryService.registerTodayDailyMission(newDailyMission);
+        log.info("[DailyMissionRegistrationJob] 일일 미션 등록 성공 - {}, registeredMissionId = {}", dailyMissionHistoryResponse.date(), dailyMissionHistoryResponse.missionId());
+    }
+}

--- a/mission/src/main/java/com/oing/repository/DailyMissionHistoryRepository.java
+++ b/mission/src/main/java/com/oing/repository/DailyMissionHistoryRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 
-public interface DailyMissionHistoryRepository extends JpaRepository<DailyMissionHistory, LocalDate> {
+public interface DailyMissionHistoryRepository extends JpaRepository<DailyMissionHistory, LocalDate>, DailyMissionHistoryRepositoryCustom {
 }

--- a/mission/src/main/java/com/oing/repository/DailyMissionHistoryRepositoryCustom.java
+++ b/mission/src/main/java/com/oing/repository/DailyMissionHistoryRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.oing.repository;
+
+import java.util.List;
+
+public interface DailyMissionHistoryRepositoryCustom {
+
+    List<String> findRecentDailyMissionIdsOrderByDateAsc(long count);
+}

--- a/mission/src/main/java/com/oing/repository/DailyMissionHistoryRepositoryCustomImpl.java
+++ b/mission/src/main/java/com/oing/repository/DailyMissionHistoryRepositoryCustomImpl.java
@@ -9,7 +9,6 @@ import java.util.List;
 import static com.oing.domain.QDailyMissionHistory.*;
 
 @RequiredArgsConstructor
-@Repository
 public class DailyMissionHistoryRepositoryCustomImpl implements DailyMissionHistoryRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 

--- a/mission/src/main/java/com/oing/repository/DailyMissionHistoryRepositoryCustomImpl.java
+++ b/mission/src/main/java/com/oing/repository/DailyMissionHistoryRepositoryCustomImpl.java
@@ -1,0 +1,25 @@
+package com.oing.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.oing.domain.QDailyMissionHistory.*;
+
+@RequiredArgsConstructor
+@Repository
+public class DailyMissionHistoryRepositoryCustomImpl implements DailyMissionHistoryRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<String> findRecentDailyMissionIdsOrderByDateAsc(long count) {
+        return queryFactory
+                .selectDistinct(dailyMissionHistory.mission.id)
+                .from(dailyMissionHistory)
+                .orderBy(dailyMissionHistory.date.asc())
+                .limit(count)
+                .fetch();
+    }
+}

--- a/mission/src/main/java/com/oing/repository/MissionRepository.java
+++ b/mission/src/main/java/com/oing/repository/MissionRepository.java
@@ -2,6 +2,13 @@ package com.oing.repository;
 
 import com.oing.domain.Mission;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface MissionRepository extends JpaRepository<Mission, String>  {
+
+    @Query(value = "SELECT * FROM mission WHERE id NOT IN :excludedIds ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    Optional<Mission> getRandomMissionExcludingIds(List<String> excludedIds);
 }

--- a/mission/src/main/java/com/oing/repository/MissionRepository.java
+++ b/mission/src/main/java/com/oing/repository/MissionRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 public interface MissionRepository extends JpaRepository<Mission, String>  {
 
-    @Query(value = "SELECT * FROM mission WHERE mission_id NOT IN :excludedIds ORDER BY RAND() LIMIT 1", nativeQuery = true)
-    Optional<Mission> getRandomMissionExcludingIds(List<String> excludedIds);
+    @Query(value = "SELECT * FROM mission WHERE mission_id NOT IN :excludingMissionIds ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    Optional<Mission> findRandomMissionExcludingIds(List<String> excludingMissionIds);
 }

--- a/mission/src/main/java/com/oing/repository/MissionRepository.java
+++ b/mission/src/main/java/com/oing/repository/MissionRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 public interface MissionRepository extends JpaRepository<Mission, String>  {
 
-    @Query(value = "SELECT * FROM mission WHERE id NOT IN :excludedIds ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    @Query(value = "SELECT * FROM mission WHERE mission_id NOT IN :excludedIds ORDER BY RAND() LIMIT 1", nativeQuery = true)
     Optional<Mission> getRandomMissionExcludingIds(List<String> excludedIds);
 }

--- a/mission/src/main/java/com/oing/service/DailyMissionHistoryService.java
+++ b/mission/src/main/java/com/oing/service/DailyMissionHistoryService.java
@@ -3,13 +3,14 @@ package com.oing.service;
 import com.oing.domain.DailyMissionHistory;
 import com.oing.domain.Mission;
 import com.oing.dto.response.DailyMissionHistoryResponse;
-import com.oing.exception.DailyMissionHistoryNotFoundException;
 import com.oing.repository.DailyMissionHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -20,7 +21,7 @@ public class DailyMissionHistoryService {
 
 
     public DailyMissionHistoryResponse createDailyMissionHistory(LocalDate date, Mission mission) {
-        log.info("Create daily mission history request: {}, missionId = {}", date, mission.getId());
+        log.info("Create daily mission history : {}, missionId = {}", date, mission.getId());
 
         DailyMissionHistory dailyMissionHistory = DailyMissionHistory.builder()
                 .date(date)
@@ -29,6 +30,13 @@ public class DailyMissionHistoryService {
         dailyMissionHistory = dailyMissionHistoryRepository.save(dailyMissionHistory);
 
         return DailyMissionHistoryResponse.from(dailyMissionHistory);
+    }
+
+    public DailyMissionHistoryResponse registerTodayDailyMission(Mission mission) {
+        LocalDate today = ZonedDateTime.now().toLocalDate();
+        log.info("Create today's daily mission history: {}, missionId = {}", today, mission.getId());
+
+        return createDailyMissionHistory(today, mission);
     }
 
     public DailyMissionHistory getDailyMissionHistoryByDate(LocalDate date) {
@@ -41,5 +49,9 @@ public class DailyMissionHistoryService {
         // TODO: Mocking 제거 시, 주석 해제
 //        return dailyMissionHistoryRepository.findById(date)
 //            .orElseThrow(DailyMissionHistoryNotFoundException::new);
+    }
+
+    public List<String> getRecentSevenDailyMissionIdsOrderByDateAsc() {
+        return dailyMissionHistoryRepository.findRecentDailyMissionIdsOrderByDateAsc(7);
     }
 }

--- a/mission/src/main/java/com/oing/service/DailyMissionHistoryService.java
+++ b/mission/src/main/java/com/oing/service/DailyMissionHistoryService.java
@@ -4,6 +4,7 @@ import com.oing.domain.DailyMissionHistory;
 import com.oing.domain.Mission;
 import com.oing.dto.response.DailyMissionHistoryResponse;
 import com.oing.exception.DailyMissionHistoryNotFoundException;
+import com.oing.exception.DuplicatedDailyMissionHistoryException;
 import com.oing.repository.DailyMissionHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,10 +34,15 @@ public class DailyMissionHistoryService {
         return DailyMissionHistoryResponse.from(dailyMissionHistory);
     }
 
-    public DailyMissionHistoryResponse registerTodayDailyMission(Mission mission) {
+    public DailyMissionHistoryResponse registerTodayDailyMission(Mission mission) throws DuplicatedDailyMissionHistoryException {
         LocalDate today = ZonedDateTime.now().toLocalDate();
-        log.info("Create today's daily mission history: {}, missionId = {}", today, mission.getId());
 
+        if (dailyMissionHistoryRepository.existsById(today)) {
+            log.error("Today's daily mission history already exists: {}", today);
+            throw new DuplicatedDailyMissionHistoryException();
+        }
+
+        log.info("Create today's daily mission : {}, missionId = {}", today, mission.getId());
         return createDailyMissionHistory(today, mission);
     }
 

--- a/mission/src/main/java/com/oing/service/DailyMissionHistoryService.java
+++ b/mission/src/main/java/com/oing/service/DailyMissionHistoryService.java
@@ -3,6 +3,7 @@ package com.oing.service;
 import com.oing.domain.DailyMissionHistory;
 import com.oing.domain.Mission;
 import com.oing.dto.response.DailyMissionHistoryResponse;
+import com.oing.exception.DailyMissionHistoryNotFoundException;
 import com.oing.repository.DailyMissionHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,15 +41,8 @@ public class DailyMissionHistoryService {
     }
 
     public DailyMissionHistory getDailyMissionHistoryByDate(LocalDate date) {
-        // TODO: DailyMissionHistoryService 의 Feature Mocking 입니다.
-        Mission mockMission = new Mission("1", "오늘의 기분을 나타내는 사진 찍기.");
-        DailyMissionHistory mockDailyMissionHistory = new DailyMissionHistory(date, mockMission);
-
-        return mockDailyMissionHistory;
-
-        // TODO: Mocking 제거 시, 주석 해제
-//        return dailyMissionHistoryRepository.findById(date)
-//            .orElseThrow(DailyMissionHistoryNotFoundException::new);
+        return dailyMissionHistoryRepository.findById(date)
+            .orElseThrow(DailyMissionHistoryNotFoundException::new);
     }
 
     public List<String> getRecentSevenDailyMissionIdsOrderByDateAsc() {

--- a/mission/src/main/java/com/oing/service/MissionService.java
+++ b/mission/src/main/java/com/oing/service/MissionService.java
@@ -3,6 +3,7 @@ package com.oing.service;
 import com.oing.domain.Mission;
 import com.oing.dto.request.CreateMissionRequest;
 import com.oing.dto.response.MissionResponse;
+import com.oing.exception.MissionNotFoundException;
 import com.oing.repository.MissionRepository;
 import com.oing.util.IdentityGenerator;
 import jakarta.transaction.Transactional;
@@ -38,22 +39,14 @@ public class MissionService {
     }
 
     public Mission getMissionByMissionId(String missionId) {
-        // TODO: MissionService 의 Feature Mocking 입니다.
-        Mission mockMission = new Mission(missionId, "오늘의 기분을 나타내는 사진 찍기.");
-        return mockMission;
-
-        // TODO: Mocking 제거 시, 주석 해제
-//        return missionRepository.findById(missionId)
-//            .orElseThrow(MissionNotFoundException::new);
+        return missionRepository.findById(missionId)
+            .orElseThrow(MissionNotFoundException::new);
     }
 
     public MissionResponse getMissionByDate(LocalDate date) {
-        return new MissionResponse("1", "오늘의 기분을 나타내는 사진 찍기.");
+        Mission mission = dailyMissionHistoryService.getDailyMissionHistoryByDate(date).getMission();
 
-        // TODO: Mocking 제거 시, 주석 해제
-//        Mission mission = dailyMissionHistoryService.getDailyMissionHistoryByDate(date).getMission();
-//
-//        return MissionResponse.from(mission);
+        return MissionResponse.from(mission);
     }
 
     public Optional<Mission> getRandomMissionExcludingIds(List<String> excludedIds) {

--- a/mission/src/main/java/com/oing/service/MissionService.java
+++ b/mission/src/main/java/com/oing/service/MissionService.java
@@ -49,8 +49,8 @@ public class MissionService {
         return MissionResponse.from(mission);
     }
 
-    public Optional<Mission> getRandomMissionExcludingIds(List<String> excludedIds) {
-        return missionRepository.getRandomMissionExcludingIds(excludedIds);
+    public Optional<Mission> findRandomMissionExcludingIds(List<String> excludingMissionIds) {
+        return missionRepository.findRandomMissionExcludingIds(excludingMissionIds);
     }
 
     @Transactional

--- a/mission/src/main/java/com/oing/service/MissionService.java
+++ b/mission/src/main/java/com/oing/service/MissionService.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -54,6 +56,9 @@ public class MissionService {
 //        return MissionResponse.from(mission);
     }
 
+    public Optional<Mission> getRandomMissionExcludingIds(List<String> excludedIds) {
+        return missionRepository.getRandomMissionExcludingIds(excludedIds);
+    }
 
     @Transactional
     public void updateMission(String missionId, CreateMissionRequest request) {

--- a/mission/src/test/java/com/oing/service/DailyMissionHistoryServiceTest.java
+++ b/mission/src/test/java/com/oing/service/DailyMissionHistoryServiceTest.java
@@ -1,0 +1,71 @@
+package com.oing.service;
+
+import com.oing.domain.DailyMissionHistory;
+import com.oing.domain.Mission;
+import com.oing.dto.response.DailyMissionHistoryResponse;
+import com.oing.exception.DuplicatedDailyMissionHistoryException;
+import com.oing.repository.DailyMissionHistoryRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DailyMissionHistoryServiceTest {
+
+    @InjectMocks
+    private DailyMissionHistoryService dailyMissionHistoryService;
+
+    @Mock
+    private DailyMissionHistoryRepository dailyMissionHistoryRepository;
+
+
+    @Nested
+    class registerTodayDailyMission {
+        @Test
+        void 정상_생성_테스트() {
+            // given
+            Mission mission = Mission.builder()
+                    .id("testMission1")
+                    .content("testMission1")
+                    .build();
+
+            when(dailyMissionHistoryRepository.existsById(any(LocalDate.class))).thenReturn(false);
+            when(dailyMissionHistoryRepository.save(any(DailyMissionHistory.class))).thenReturn(DailyMissionHistory.builder()
+                    .date(LocalDate.now())
+                    .mission(mission)
+                    .build());
+
+            // when
+            DailyMissionHistoryResponse dailyMissionHistoryResponse = dailyMissionHistoryService.registerTodayDailyMission(mission);
+
+            // then
+            assertThat(dailyMissionHistoryResponse)
+                    .extracting(DailyMissionHistoryResponse::date, DailyMissionHistoryResponse::missionId)
+                    .containsExactly(LocalDate.now(), mission.getId());
+        }
+
+        @Test
+        void 이미_일일미션이_존재하는경우_예외를_던진다() {
+            // given
+            Mission mission = Mission.builder()
+                    .id("testMission1")
+                    .content("testMission1")
+                    .build();
+
+            when(dailyMissionHistoryRepository.existsById(any(LocalDate.class))).thenReturn(true);
+
+            // when & then
+            assertThatExceptionOfType(DuplicatedDailyMissionHistoryException.class)
+                    .isThrownBy(() -> dailyMissionHistoryService.registerTodayDailyMission(mission));
+        }
+    }
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
임시로 API response와 Service code가 모킹되어 있던 것을 구현하였습니다. 스케줄러로 돌아가는 배치이기 때문에 검증하기 어렵고 비즈니스 상 중요한 로직이므로 새로운 형태의 테스트 코드들도 추가했습니다.

ps. 현재는 Spring Scheduler로 배치를 구현하였지만, 추후 Spring Batch로 리팩토링하게 될 예정입니다.

## ➕ 추가/변경된 기능

---
- 스케줄러와 테이블 락을 통한 일일 미션 선출 배치 구현
- Repository, Service, Job 에 대한 테스트 코드 추가

## 🥺 리뷰어에게 하고싶은 말

---
통합 테스트의 경우, 저희 멀티모듈 구조 상 Context loading을 할 수가 없어 에러가 발생하네요. 구글링을 통해 찾은 여러 우회 방법이 저의 케이스에서 동작하지 않아, 일단은 Gateway 모듈에 구현하였습니다. 혹시 이에 도움이 될만한 케이스가 있으면 공유 부탁드려요 🥲 @Ji-soo708 @CChuYong 



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-326