### PR TITLE
[OING-330] feat: 가족 구성원 랭킹에서 '지난 날 생존신고 보기'에 대한 보충 정책 반영

### DIFF
--- a/gateway/src/main/java/com/oing/controller/MainViewController.java
+++ b/gateway/src/main/java/com/oing/controller/MainViewController.java
@@ -183,9 +183,11 @@ public class MainViewController implements MainViewApi {
         }
 
         LocalDate mostRecentSurvivalPostDate = null;
-        List<PostResponse> mostRecentPosts = postController.fetchDailyFeeds(1, 1, null, null, "desc", PostType.SURVIVAL, loginMemberId, false).results().stream().toList();
-        if (!mostRecentPosts.isEmpty()) {
-            mostRecentSurvivalPostDate = mostRecentPosts.get(0).createdAt().toLocalDate();
+        LocalDate startOfMonth = ZonedDateTime.now().withDayOfMonth(1).toLocalDate();
+        LocalDate tomorrow = ZonedDateTime.now().plusDays(1).toLocalDate();
+        PostResponse mostRecentPost = postController.findLatestPost(startOfMonth, tomorrow, loginFamilyId);
+        if (mostRecentPost != null) {
+            mostRecentSurvivalPostDate = mostRecentPost.createdAt().toLocalDate();
         }
 
         return new FamilyMemberMonthlyRankingResponse(

--- a/gateway/src/main/java/com/oing/controller/MainViewController.java
+++ b/gateway/src/main/java/com/oing/controller/MainViewController.java
@@ -185,7 +185,7 @@ public class MainViewController implements MainViewApi {
         LocalDate mostRecentSurvivalPostDate = null;
         LocalDate startOfMonth = ZonedDateTime.now().withDayOfMonth(1).toLocalDate();
         LocalDate tomorrow = ZonedDateTime.now().plusDays(1).toLocalDate();
-        PostResponse mostRecentPost = postController.findLatestPost(startOfMonth, tomorrow, loginFamilyId);
+        PostResponse mostRecentPost = postController.findLatestPost(startOfMonth, tomorrow, PostType.SURVIVAL, loginFamilyId);
         if (mostRecentPost != null) {
             mostRecentSurvivalPostDate = mostRecentPost.createdAt().toLocalDate();
         }

--- a/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
@@ -51,7 +51,17 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 ))
                 .orderBy(post.createdAt.asc())
                 .fetch();
+    }
 
+    @Override
+    public Post findLatestPost(LocalDateTime startDate, LocalDateTime endDate, String familyId) {
+        return queryFactory
+                .selectFrom(post)
+                .where(post.familyId.eq(familyId)
+                        .and(post.createdAt.between(startDate, endDate))
+                )
+                .orderBy(post.createdAt.desc())
+                .fetchFirst();
     }
 
     @Override

--- a/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
@@ -54,11 +54,13 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public Post findLatestPost(LocalDateTime startDate, LocalDateTime endDate, String familyId) {
+    public Post findLatestPost(LocalDateTime startDate, LocalDateTime endDate, PostType postType, String familyId) {
         return queryFactory
                 .selectFrom(post)
-                .where(post.familyId.eq(familyId)
-                        .and(post.createdAt.between(startDate, endDate))
+                .where(
+                        post.type.eq(postType),
+                        post.familyId.eq(familyId),
+                        post.createdAt.between(startDate, endDate)
                 )
                 .orderBy(post.createdAt.desc())
                 .fetchFirst();

--- a/gateway/src/main/resources/db/migration/V202405092310__add_createdAt_idx_in_post_tbl.sql
+++ b/gateway/src/main/resources/db/migration/V202405092310__add_createdAt_idx_in_post_tbl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE post ADD INDEX post_idx2 (created_at);

--- a/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
@@ -6,6 +6,7 @@ import com.oing.domain.Member;
 import com.oing.domain.Post;
 import com.oing.domain.PostType;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -110,6 +111,51 @@ class PostRepositoryCustomTest {
         assertThat(posts)
                 .extracting(Post::getId)
                 .containsExactly("2", "4");
+    }
+
+    @Nested
+    class findLatestPost {
+        @Test
+        void 정상_조회_테스트() {
+            // given
+            String familyId = testMember1.getFamilyId();
+            LocalDateTime inclusiveStart = LocalDate.of(2023, 11, 1).atStartOfDay();
+            LocalDateTime exclusiveEnd = LocalDate.of(2023, 11, 2).atStartOfDay();
+
+            // when
+            Post post = postRepositoryCustomImpl.findLatestPost(inclusiveStart, exclusiveEnd, familyId);
+
+            // then
+            assertThat(post.getId()).isEqualTo("2");
+        }
+
+        @Test
+        void 시작날짜는_포함하고_종료날짜는_포함하지_않는다() {
+            // given
+            String familyId = testMember1.getFamilyId();
+            LocalDateTime inclusiveStart = LocalDate.of(2023, 11, 1).atStartOfDay();
+            LocalDateTime exclusiveEnd = LocalDate.of(2023, 11, 1).atStartOfDay();
+
+            // when
+            Post post = postRepositoryCustomImpl.findLatestPost(inclusiveStart, exclusiveEnd, familyId);
+
+            // then
+            assertThat(post).isNull();
+        }
+
+        @Test
+        void 해당_날짜에_게시글이_없는_경우_null을_반환한다() {
+            // given
+            String familyId = testMember1.getFamilyId();
+            LocalDateTime inclusiveStart = LocalDate.of(9999, 11, 3).atStartOfDay();
+            LocalDateTime exclusiveEnd = LocalDate.of(9999, 11, 4).atStartOfDay();
+
+            // when
+            Post post = postRepositoryCustomImpl.findLatestPost(inclusiveStart, exclusiveEnd, familyId);
+
+            // then
+            assertThat(post).isNull();
+        }
     }
 
     @Test

--- a/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.oing.domain.PostType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
@@ -116,14 +117,14 @@ class PostRepositoryCustomTest {
     @Nested
     class findLatestPost {
         @Test
-        void 정상_조회_테스트() {
+        void 생존신고_게시물_정상_조회_테스트() {
             // given
             String familyId = testMember1.getFamilyId();
             LocalDateTime inclusiveStart = LocalDate.of(2023, 11, 1).atStartOfDay();
             LocalDateTime exclusiveEnd = LocalDate.of(2023, 11, 2).atStartOfDay();
 
             // when
-            Post post = postRepositoryCustomImpl.findLatestPost(inclusiveStart, exclusiveEnd, familyId);
+            Post post = postRepositoryCustomImpl.findLatestPost(inclusiveStart, exclusiveEnd, SURVIVAL, familyId);
 
             // then
             assertThat(post.getId()).isEqualTo("2");
@@ -137,7 +138,7 @@ class PostRepositoryCustomTest {
             LocalDateTime exclusiveEnd = LocalDate.of(2023, 11, 1).atStartOfDay();
 
             // when
-            Post post = postRepositoryCustomImpl.findLatestPost(inclusiveStart, exclusiveEnd, familyId);
+            Post post = postRepositoryCustomImpl.findLatestPost(inclusiveStart, exclusiveEnd, SURVIVAL, familyId);
 
             // then
             assertThat(post).isNull();
@@ -151,7 +152,7 @@ class PostRepositoryCustomTest {
             LocalDateTime exclusiveEnd = LocalDate.of(9999, 11, 4).atStartOfDay();
 
             // when
-            Post post = postRepositoryCustomImpl.findLatestPost(inclusiveStart, exclusiveEnd, familyId);
+            Post post = postRepositoryCustomImpl.findLatestPost(inclusiveStart, exclusiveEnd, SURVIVAL, familyId);
 
             // then
             assertThat(post).isNull();
@@ -165,7 +166,7 @@ class PostRepositoryCustomTest {
 
         // when
         boolean exists = postRepositoryCustomImpl.existsByMemberIdAndFamilyIdAndTypeAndCreatedAt(testMember1.getId(),
-                testMember1.getFamilyId(), PostType.SURVIVAL, postDate);
+                testMember1.getFamilyId(), SURVIVAL, postDate);
 
         // then
         assertThat(exists).isTrue();
@@ -178,7 +179,7 @@ class PostRepositoryCustomTest {
 
         // when
         boolean exists = postRepositoryCustomImpl.existsByMemberIdAndFamilyIdAndTypeAndCreatedAt(testMember1.getId(),
-                testMember1.getFamilyId(), PostType.SURVIVAL, postDate);
+                testMember1.getFamilyId(), SURVIVAL, postDate);
 
         // then
         assertThat(exists).isFalse();

--- a/gateway/src/test/java/com/oing/restapi/MainViewApiTest.java
+++ b/gateway/src/test/java/com/oing/restapi/MainViewApiTest.java
@@ -104,7 +104,7 @@ class MainViewApiTest {
 
 
     @Nested
-    class 금월의_가족구성원_월간_랭킹_조회 {
+    class getFamilyMemberMonthlyRanking {
         @Test
         void 정상_조회() throws Exception {
             // given

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -98,8 +98,9 @@ public class PostController implements PostApi {
     }
 
     @Override
-    public PostResponse getLatestPost(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, String loginFamilyId) {
+    public PostResponse findLatestPost(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, String loginFamilyId) {
         Post latestPost = postService.findLatestPost(inclusiveStartDate, exclusiveEndDate, loginFamilyId);
+        if (latestPost == null) return null;
 
         return PostResponse.from(latestPost);
     }

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -98,8 +98,8 @@ public class PostController implements PostApi {
     }
 
     @Override
-    public PostResponse findLatestPost(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, String loginFamilyId) {
-        Post latestPost = postService.findLatestPost(inclusiveStartDate, exclusiveEndDate, loginFamilyId);
+    public PostResponse findLatestPost(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, PostType postType, String loginFamilyId) {
+        Post latestPost = postService.findLatestPost(inclusiveStartDate, exclusiveEndDate, postType, loginFamilyId);
         if (latestPost == null) return null;
 
         return PostResponse.from(latestPost);

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -98,6 +98,13 @@ public class PostController implements PostApi {
     }
 
     @Override
+    public PostResponse getLatestPost(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, String loginFamilyId) {
+        Post latestPost = postService.findLatestPost(inclusiveStartDate, exclusiveEndDate, loginFamilyId);
+
+        return PostResponse.from(latestPost);
+    }
+
+    @Override
     public SurvivalUploadStatusResponse getSurvivalUploadStatus(String memberId, String loginMemberId, String loginFamilyId) {
         validateMemberId(loginMemberId, memberId);
 

--- a/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
@@ -13,6 +13,8 @@ public interface PostRepositoryCustom {
 
     List<Post> findLatestPostOfEveryday(LocalDateTime startDate, LocalDateTime endDate, String familyId);
 
+    Post findLatestPost(LocalDateTime startDate, LocalDateTime endDate, String familyId);
+
     QueryResults<Post> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId,
                                    String familyId, boolean asc, PostType type);
 

--- a/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
@@ -13,7 +13,7 @@ public interface PostRepositoryCustom {
 
     List<Post> findLatestPostOfEveryday(LocalDateTime startDate, LocalDateTime endDate, String familyId);
 
-    Post findLatestPost(LocalDateTime startDate, LocalDateTime endDate, String familyId);
+    Post findLatestPost(LocalDateTime startDate, LocalDateTime endDate, PostType postType, String familyId);
 
     QueryResults<Post> searchPosts(int page, int size, LocalDate date, String memberId, String requesterMemberId,
                                    String familyId, boolean asc, PostType type);

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -126,6 +126,10 @@ public interface PostApi {
             @Parameter(description = "조회 종료 날짜", example = "2023-12-05")
             LocalDate exclusiveEndDate,
 
+            @RequestParam
+            @Parameter(description = "게시물 타입", example = "SURVIVAL")
+            PostType type,
+
             @Parameter(hidden = true)
             @LoginFamilyId
             String loginFamilyId

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -8,7 +8,6 @@ import com.oing.util.security.LoginFamilyId;
 import com.oing.util.security.LoginMemberId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -115,8 +114,8 @@ public interface PostApi {
             String loginMemberId
     );
 
-    @Operation(summary = "가장 최근 게시물 조회", description = "특정 기간 안에서 가장 최근에 업로드된 게시물을 조회합니다.")
-    PostResponse getLatestPost(
+    @Operation(summary = "가장 최근 게시물 조회", description = "(결과가 없을시, null 반환)\n 특정 기간 안에서 가장 최근에 업로드된 게시물을 조회합니다.")
+    PostResponse findLatestPost(
             @RequestParam
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             @Parameter(description = "조회 시작 날짜", example = "2023-12-05")

--- a/post/src/main/java/com/oing/restapi/PostApi.java
+++ b/post/src/main/java/com/oing/restapi/PostApi.java
@@ -115,6 +115,23 @@ public interface PostApi {
             String loginMemberId
     );
 
+    @Operation(summary = "가장 최근 게시물 조회", description = "특정 기간 안에서 가장 최근에 업로드된 게시물을 조회합니다.")
+    PostResponse getLatestPost(
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "조회 시작 날짜", example = "2023-12-05")
+            LocalDate inclusiveStartDate,
+
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "조회 종료 날짜", example = "2023-12-05")
+            LocalDate exclusiveEndDate,
+
+            @Parameter(hidden = true)
+            @LoginFamilyId
+            String loginFamilyId
+    );
+
     @Operation(summary = "회원 생존신고 게시글 업로드 여부 응답 조회", description = "회원 생존신고 게시글 업로드 여부를 조회합니다.")
     @GetMapping("/{memberId}/survival-uploaded")
     SurvivalUploadStatusResponse getSurvivalUploadStatus(

--- a/post/src/main/java/com/oing/service/PostService.java
+++ b/post/src/main/java/com/oing/service/PostService.java
@@ -116,6 +116,10 @@ public class PostService {
         return postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
     }
 
+    public Post findLatestPost(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, String loginFamilyId) {
+        return postRepository.findLatestPost(inclusiveStartDate.atStartOfDay(), exclusiveEndDate.atStartOfDay(), loginFamilyId);
+    }
+
     public PaginationDTO<Post> searchMemberPost(int page, int size, LocalDate date, String memberId, String requesterMemberId,
                                                 String familyId, boolean asc, PostType type) {
         QueryResults<Post> results = null;

--- a/post/src/main/java/com/oing/service/PostService.java
+++ b/post/src/main/java/com/oing/service/PostService.java
@@ -116,8 +116,8 @@ public class PostService {
         return postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
     }
 
-    public Post findLatestPost(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, String loginFamilyId) {
-        return postRepository.findLatestPost(inclusiveStartDate.atStartOfDay(), exclusiveEndDate.atStartOfDay(), loginFamilyId);
+    public Post findLatestPost(LocalDate inclusiveStartDate, LocalDate exclusiveEndDate, PostType postType, String loginFamilyId) {
+        return postRepository.findLatestPost(inclusiveStartDate.atStartOfDay(), exclusiveEndDate.atStartOfDay(), postType, loginFamilyId);
     }
 
     public PaginationDTO<Post> searchMemberPost(int page, int size, LocalDate date, String memberId, String requesterMemberId,


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
가족 구성원 랭킹에서 '지난 날 생존신고 보기' 버튼이 금월에 해당하며 금월에 업로드된 생존신고가 없다면 비활성화(null)된다는 정책이 확정되어, 이를 반영하는 PR입니다.

## ➕ 추가/변경된 기능

---
- 정해진 기간동안 가장 최근 생존신고를 조회하는 findRecentPost API 추가
- findRecentPost를 이용해 가족 구성원 랭킹 수정
- findRecentPost 쿼리에 대한 테스트 코드 추가

## 🥺 리뷰어에게 하고싶은 말

---




## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-330