### PR TITLE
[OING-332] fix: getMissionByMissionId에 입력 파라미터에 @PathVariable 누락 해결

### DIFF
--- a/mission/src/main/java/com/oing/restapi/MissionApi.java
+++ b/mission/src/main/java/com/oing/restapi/MissionApi.java
@@ -3,9 +3,11 @@ package com.oing.restapi;
 import com.oing.dto.response.DailyMissionResponse;
 import com.oing.dto.response.MissionResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +19,11 @@ public interface MissionApi {
 
     @Operation(summary = "ID를 통한 미션 조회", description = "미션 ID를 통해 미션 정보르 조회합니다.")
     @GetMapping("/{missionId}")
-    MissionResponse getMissionByMissionId(String missionId);
+    MissionResponse getMissionByMissionId(
+            @PathVariable
+            @Parameter(description = "미션 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            String missionId
+    );
 
     @Operation(summary = "금일의 일일 미션 조회", description = "오늘 선정된 일일 미션을 조회합니다.")
     @GetMapping("/today")


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
버그 리포트되서 파악된 getMissionByMissionId에 입력 파라미터에 @PathVariable 누락을 해결했습니다.

## ➕ 추가/변경된 기능

---
- getMissionByMissionId에 입력 파라미터에 @PathVariable 누락 해결

## 🥺 리뷰어에게 하고싶은 말

---




## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-332