### PR TITLE
[OING-333] feature: 탈퇴한 회원 정보 값으로 "UNKNOWN"이 아닌 null 값을 주도록 수정

### DIFF
--- a/gateway/src/main/java/com/oing/controller/MainViewController.java
+++ b/gateway/src/main/java/com/oing/controller/MainViewController.java
@@ -95,8 +95,8 @@ public class MainViewController implements MainViewApi {
                     if (member == null) {
                         return new MainPagePickerResponse(
                                 pickMember.getFromMemberId(),
-                                "UNKNOWN",
-                                "UNKNOWN"
+                                null,
+                                null
                         );
                     }
                     return new MainPagePickerResponse(
@@ -121,7 +121,7 @@ public class MainViewController implements MainViewApi {
                     return new MainPageFeedResponse(
                             post.getId(),
                             post.getPostImgUrl(),
-                            member != null ? member.name() : "UNKNOWN",
+                            member != null ? member.name() : null,
                             post.getCreatedAt().atZone(ZoneId.systemDefault())
                     );
                 }).toList(),
@@ -131,7 +131,7 @@ public class MainViewController implements MainViewApi {
                     return new MainPageFeedResponse(
                             post.getId(),
                             post.getPostImgUrl(),
-                            member != null ? member.name() : "UNKNOWN",
+                            member != null ? member.name() : null,
                             post.getCreatedAt().atZone(ZoneId.systemDefault())
                     );
                 }).toList()


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
프론트의 요청으로 탈퇴한 회원 정보 값을 "UNKNOWN"이 아닌 null 값을 주도록 수정했습니다.

## ➕ 추가/변경된 기능

---
- 탈퇴한 회원 정보 값을 "UNKNOWN"이 아닌 null 값을 주도록 수정

## 🥺 리뷰어에게 하고싶은 말

---
리뷰부탁드림다



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-333