### PR TITLE
[OING-335] fix: 가족구성원 랭킹 API의 생존신고 수가 미션 수를 포함하는 현상 해결

### DIFF
--- a/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import static com.oing.domain.PostType.*;
 import static com.oing.domain.QMember.member;
 import static com.oing.domain.QPost.post;
 
@@ -92,13 +93,16 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public long countMonthlyPostByMemberId(int year, int month, String memberId) {
+    public long countMonthlySurvivalPostByMemberId(int year, int month, String memberId) {
         return queryFactory
                 .select(post.count())
                 .from(post)
-                .where(post.memberId.eq(memberId),
+                .where(
+                        post.type.eq(SURVIVAL),
+                        post.memberId.eq(memberId),
                         post.createdAt.year().eq(year),
-                        post.createdAt.month().eq(month))
+                        post.createdAt.month().eq(month)
+                )
                 .fetchFirst();
     }
 
@@ -150,7 +154,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .select(post.id.count())
                 .from(post)
                 .where(post.familyId.eq(familyId),
-                        post.type.eq(PostType.SURVIVAL),
+                        post.type.eq(SURVIVAL),
                         dateExpr(post.createdAt).eq(today))
                 .fetchFirst();
         return count.intValue();

--- a/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
@@ -83,25 +83,31 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
 
     @Override
     public long countMonthlyPostByFamilyId(int year, int month, String familyId) {
+        LocalDateTime from = LocalDateTime.of(year, month, 1, 0, 0);
+        LocalDateTime to = from.plusMonths(1).minusDays(1);
+
         return queryFactory
                 .select(post.count())
                 .from(post)
-                .where(post.familyId.eq(familyId),
-                        post.createdAt.year().eq(year),
-                        post.createdAt.month().eq(month))
+                .where(
+                        post.familyId.eq(familyId),
+                        post.createdAt.between(from, to)
+                )
                 .fetchFirst();
     }
 
     @Override
     public long countMonthlySurvivalPostByMemberId(int year, int month, String memberId) {
+        LocalDateTime from = LocalDateTime.of(year, month, 1, 0, 0);
+        LocalDateTime to = from.plusMonths(1).minusDays(1);
+
         return queryFactory
                 .select(post.count())
                 .from(post)
                 .where(
                         post.type.eq(SURVIVAL),
                         post.memberId.eq(memberId),
-                        post.createdAt.year().eq(year),
-                        post.createdAt.month().eq(month)
+                        post.createdAt.between(from, to)
                 )
                 .fetchFirst();
     }

--- a/post/src/main/java/com/oing/controller/PostController.java
+++ b/post/src/main/java/com/oing/controller/PostController.java
@@ -142,7 +142,7 @@ public class PostController implements PostApi {
 
         List<PostRankerResponse> postRankerResponses = familyMembersIds.stream().map(familyMemberId -> new PostRankerDTO(
                         familyMemberId,
-                        postService.countMonthlyPostByMemberId(dateTime, familyMemberId),
+                        postService.countMonthlySurvivalPostByMemberId(dateTime, familyMemberId),
                         commentService.countMonthlyCommentByMemberId(dateTime, familyMemberId),
                         reactionService.countMonthlyReactionByMemberId(dateTime, familyMemberId)
 

--- a/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
+++ b/post/src/main/java/com/oing/repository/PostRepositoryCustom.java
@@ -20,7 +20,7 @@ public interface PostRepositoryCustom {
 
     long countMonthlyPostByFamilyId(int year, int month, String familyId);
 
-    long countMonthlyPostByMemberId(int year, int month, String memberId);
+    long countMonthlySurvivalPostByMemberId(int year, int month, String memberId);
 
     boolean existsByFamilyIdAndCreatedAt(String familyId, LocalDate postDate);
 

--- a/post/src/main/java/com/oing/service/PostService.java
+++ b/post/src/main/java/com/oing/service/PostService.java
@@ -180,11 +180,11 @@ public class PostService {
         return Math.max(requiredSurvivalPostCount - todaySurvivalPostCount, 0);
     }
 
-    public long countMonthlyPostByMemberId(LocalDate date, String memberId) {
+    public long countMonthlySurvivalPostByMemberId(LocalDate date, String memberId) {
         int year = date.getYear();
         int month = date.getMonthValue();
 
-        return postRepository.countMonthlyPostByMemberId(year, month, memberId);
+        return postRepository.countMonthlySurvivalPostByMemberId(year, month, memberId);
     }
 
     public boolean isCreatedSurvivalPostToday(String memberId, String familyId) {


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
3.0 QA 에서 가족구성원 랭킹 API의 생존신고 수가 미션 수를 포함하는 현상이 리포트되었습니다.

버그를 고치기 위해 쿼리를 수정하던 중 지난 번에 생성한 Post CreatedAt 인덱스를 탈 수 있도록 비교 쿼리를 리팩토링했습니다.

## ➕ 추가/변경된 기능

---
- 리포트 된 버그를 고치기 위해 PostType.Survival 비교 연산자 추가
- CreatedAt에서 year(), month()를 별도로 추출해서 equals 비교하는 연산자에서 인덱스를 타기 위해 between 연산자로 리팩토링

## 🥺 리뷰어에게 하고싶은 말

---
파이팅

## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-335