### PR TITLE
[OING-336] feat: 푸쉬 알림 메세지 변경 및 미션 업로드 시 노티 발송

### DIFF
--- a/gateway/src/main/java/com/oing/event/FamilyNotificationEventListener.java
+++ b/gateway/src/main/java/com/oing/event/FamilyNotificationEventListener.java
@@ -57,29 +57,31 @@ public class FamilyNotificationEventListener {
                         .setAndroidConfig(FCMNotificationUtil.buildAndroidConfig())
                         .build();
                 fcmNotificationService.sendMulticastMessage(multicastMessage);
-            }
 
-            if (post.getType() == PostType.SURVIVAL &&
-                    memberPostService.isNewPostMadeMissionUnlocked(familyId)) {
-                // 방금 막 미션이 언락 되었다면..
-                HashSet<String> missionTargetFcmTokens = new HashSet<>();
-                for (String familyMemberId : familyMemberIds) {
-                    missionTargetFcmTokens.addAll(memberDeviceService.getFcmTokensByMemberId(familyMemberId));
+                if(memberPostService.isNewPostMadeMissionUnlocked(familyId)) {
+                    sendMissionUnlockedMessages(familyMemberIds);
                 }
-
-                MulticastMessage missionUnlockedMessage = MulticastMessage.builder()
-                        .setNotification(
-                                FCMNotificationUtil.buildNotification("열쇠를 획득해 미션 잠금이 해제되었어요!",
-                                        "사진 한 장을 더 찍을 수 있어요.")
-                        )
-                        .addAllTokens(missionTargetFcmTokens)
-                        .setApnsConfig(FCMNotificationUtil.buildApnsConfig())
-                        .setAndroidConfig(FCMNotificationUtil.buildAndroidConfig())
-                        .build();
-                fcmNotificationService.sendMulticastMessage(missionUnlockedMessage);
             }
-
         }
+    }
+
+    private void sendMissionUnlockedMessages(List<String> familyMemberIds) {
+        // 방금 막 미션이 언락 되었다면..
+        HashSet<String> missionTargetFcmTokens = new HashSet<>();
+        for (String familyMemberId : familyMemberIds) {
+            missionTargetFcmTokens.addAll(memberDeviceService.getFcmTokensByMemberId(familyMemberId));
+        }
+
+        MulticastMessage missionUnlockedMessage = MulticastMessage.builder()
+                .setNotification(
+                        FCMNotificationUtil.buildNotification("열쇠를 획득해 미션 잠금이 해제되었어요!",
+                                "사진 한 장을 더 찍을 수 있어요.")
+                )
+                .addAllTokens(missionTargetFcmTokens)
+                .setApnsConfig(FCMNotificationUtil.buildApnsConfig())
+                .setAndroidConfig(FCMNotificationUtil.buildAndroidConfig())
+                .build();
+        fcmNotificationService.sendMulticastMessage(missionUnlockedMessage);
     }
 
     @Transactional(Transactional.TxType.REQUIRES_NEW)

--- a/gateway/src/main/java/com/oing/event/FamilyNotificationEventListener.java
+++ b/gateway/src/main/java/com/oing/event/FamilyNotificationEventListener.java
@@ -43,19 +43,21 @@ public class FamilyNotificationEventListener {
             }
 
             if(targetFcmTokens.isEmpty()) return;
-            MulticastMessage multicastMessage = MulticastMessage.builder()
-                    .setNotification(
-                            FCMNotificationUtil.buildNotification("삐삐",
-                                    String.format("%s님이 생존신고를 완료했어요.", author.getName()))
-                    )
-                    .putData("aosDeepLink", "post/view/" + post.getId())
-                    .putData("iosDeepLink", "post/view/" + post.getId() + "?openComment=false&dateOfPost="
-                            + post.getCreatedAt().toLocalDate().toString())
-                    .addAllTokens(targetFcmTokens)
-                    .setApnsConfig(FCMNotificationUtil.buildApnsConfig())
-                    .setAndroidConfig(FCMNotificationUtil.buildAndroidConfig())
-                    .build();
-            fcmNotificationService.sendMulticastMessage(multicastMessage);
+            if(post.getType() == PostType.SURVIVAL) {
+                MulticastMessage multicastMessage = MulticastMessage.builder()
+                        .setNotification(
+                                FCMNotificationUtil.buildNotification("삐삐",
+                                        String.format("%s님이 생존신고를 완료했어요.", author.getName()))
+                        )
+                        .putData("aosDeepLink", "post/view/" + post.getId())
+                        .putData("iosDeepLink", "post/view/" + post.getId() + "?openComment=false&dateOfPost="
+                                + post.getCreatedAt().toLocalDate().toString())
+                        .addAllTokens(targetFcmTokens)
+                        .setApnsConfig(FCMNotificationUtil.buildApnsConfig())
+                        .setAndroidConfig(FCMNotificationUtil.buildAndroidConfig())
+                        .build();
+                fcmNotificationService.sendMulticastMessage(multicastMessage);
+            }
 
             if (post.getType() == PostType.SURVIVAL &&
                     memberPostService.isNewPostMadeMissionUnlocked(familyId)) {

--- a/gateway/src/main/java/com/oing/event/FamilyNotificationEventListener.java
+++ b/gateway/src/main/java/com/oing/event/FamilyNotificationEventListener.java
@@ -4,9 +4,11 @@ import com.google.firebase.messaging.MulticastMessage;
 import com.oing.domain.Comment;
 import com.oing.domain.Member;
 import com.oing.domain.Post;
+import com.oing.domain.PostType;
 import com.oing.service.FCMNotificationService;
 import com.oing.service.MemberDeviceService;
 import com.oing.service.MemberService;
+import com.oing.service.PostService;
 import com.oing.util.FCMNotificationUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ public class FamilyNotificationEventListener {
     public final MemberService memberService;
     private final MemberDeviceService memberDeviceService;
     private final FCMNotificationService fcmNotificationService;
+    private final PostService memberPostService;
 
     @Transactional(Transactional.TxType.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -53,6 +56,27 @@ public class FamilyNotificationEventListener {
                     .setAndroidConfig(FCMNotificationUtil.buildAndroidConfig())
                     .build();
             fcmNotificationService.sendMulticastMessage(multicastMessage);
+
+            if (post.getType() == PostType.SURVIVAL &&
+                    memberPostService.isNewPostMadeMissionUnlocked(familyId)) {
+                // 방금 막 미션이 언락 되었다면..
+                HashSet<String> missionTargetFcmTokens = new HashSet<>();
+                for (String familyMemberId : familyMemberIds) {
+                    missionTargetFcmTokens.addAll(memberDeviceService.getFcmTokensByMemberId(familyMemberId));
+                }
+
+                MulticastMessage missionUnlockedMessage = MulticastMessage.builder()
+                        .setNotification(
+                                FCMNotificationUtil.buildNotification("열쇠를 획득해 미션 잠금이 해제되었어요!",
+                                        "사진 한 장을 더 찍을 수 있어요.")
+                        )
+                        .addAllTokens(missionTargetFcmTokens)
+                        .setApnsConfig(FCMNotificationUtil.buildApnsConfig())
+                        .setAndroidConfig(FCMNotificationUtil.buildAndroidConfig())
+                        .build();
+                fcmNotificationService.sendMulticastMessage(missionUnlockedMessage);
+            }
+
         }
     }
 

--- a/member/src/main/java/com/oing/controller/MemberController.java
+++ b/member/src/main/java/com/oing/controller/MemberController.java
@@ -54,7 +54,7 @@ public class MemberController implements MemberApi {
     @Override
     public MemberResponse getMember(String memberId, String loginFamilyId) {
         validateFamilyMember(memberId, loginFamilyId);
-        
+
         Member member = memberService.getMemberByMemberId(memberId);
         return MemberResponse.of(member);
     }
@@ -118,7 +118,7 @@ public class MemberController implements MemberApi {
         List<String> tokens = memberDeviceService.getFcmTokensByMemberId(toMember.getId());
         if (!tokens.isEmpty()) {
             Notification notification = FCMNotificationUtil
-                    .buildNotification(String.format("%s님, 살아있나요?", toMember.getName()),
+                    .buildNotification(String.format("%s님, 바쁘신가요?", toMember.getName()),
                         String.format("%s님이 당신의 생존을 궁금해해요.", fromMember.getName()));
             MulticastMessage message = MulticastMessage.builder()
                     .setNotification(notification)

--- a/post/src/main/java/com/oing/service/PostService.java
+++ b/post/src/main/java/com/oing/service/PostService.java
@@ -176,6 +176,13 @@ public class PostService {
         return survivalPostCount >= totalFamilyMembers / 2;
     }
 
+    public boolean isNewPostMadeMissionUnlocked(String familyId) {
+        int totalFamilyMembers = postRepository.countFamilyMembersByFamilyIdAtYesterday(familyId);
+        int survivalPostCount = postRepository.countTodaySurvivalPostsByFamilyId(familyId);
+        return ((survivalPostCount - 1) < totalFamilyMembers / 2) // 방금 글 올리기 전에는 조건 만족 X but,
+                && (survivalPostCount >= totalFamilyMembers / 2); //올리고 나서는 조건 만족
+    }
+
     public int calculateRemainingSurvivalPostCountUntilMissionUnlocked(String familyId) {
         int familyMemberCount = postRepository.countFamilyMembersByFamilyIdAtYesterday(familyId);
         int requiredSurvivalPostCount = familyMemberCount / 2;


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
- 푸쉬 알림 컨텐츠 변경 및 경로 추가

## ➕ 추가/변경된 기능

---
- 푸쉬 알림 (콕 찌르기) 컨텐츠 변경
- 미션 업로드 시 노티 발송

## 🥺 리뷰어에게 하고싶은 말

---
백엔드 PR 엄청 오랜만이네요 ㄷㄷ

따로 일별로 미션 푸쉬 발송 여부를 디비에 쌓는것도 이상해보여서 로직과 같이 바로 "이전 게시물은 조건 미만족 && 새 게시물 포함하면 미션 조건 만족" 일때 푸쉬 발송하게 해놨는데.. 이론상은 맞는데 혹시 엣지케이스 떠오르는거 있으면 코멘트 부탁드립니다.


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-336