### PR TITLE
[OING-337] fix: 위젯에서 미션글도 보이도록 수정 (PostRepositoryCustomImpl에서 잘못 추가된 PostType 비교절 제거)

### DIFF
--- a/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
+++ b/gateway/src/main/java/com/oing/repository/PostRepositoryCustomImpl.java
@@ -48,7 +48,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                                 .from(post)
                                 .where(
                                         post.familyId.eq(familyId),
-                                        post.type.eq(SURVIVAL),
                                         post.createdAt.between(startDate, endDate)
                                 )
                                 .groupBy(Expressions.dateOperation(LocalDate.class, Ops.DateTimeOps.DATE, post.createdAt))
@@ -67,7 +66,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                                 .from(post)
                                 .where(
                                         post.familyId.eq(familyId),
-                                        post.type.eq(SURVIVAL),
                                         post.createdAt.between(startDate, endDate)
                                 )
                                 .groupBy(Expressions.dateOperation(LocalDate.class, Ops.DateTimeOps.DATE, post.createdAt))


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
위젯에서 미션글은 노출되지 않는 점을 해결하기 위해 작업을 진행하였고, PostRepositoryCustomImpl에서 findLatestPostOfEveryday와 findOldestPostOfEveryday 쿼리에 PostType.eq(SURVIVAL) 절이 의도와 다르게 추가된 점을 발견해 수정하였습니다. 3.0차에 미션을 도입하기 위해 추가한 PostType 컬럼을 도입하며 쿼리들을 리팩토링하는 과정에서 잘못 들어간 것으로 보입니다.

## ➕ 추가/변경된 기능

---
- PostRepositoryCustomImpl의 findOldestPostOfEveryday, findLatestPostOfEveryday 쿼리에서 PostType.eq(SURVIVAL) 비교절 제거

## 🥺 리뷰어에게 하고싶은 말

---


## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-337