### PR TITLE
feature: 가족 이름 수정 API 추가 및 조회 API 응답 수정

### DIFF
--- a/family/src/main/java/com/oing/controller/FamilyController.java
+++ b/family/src/main/java/com/oing/controller/FamilyController.java
@@ -1,6 +1,7 @@
 package com.oing.controller;
 
 import com.oing.domain.Family;
+import com.oing.dto.request.UpdateFamilyNameRequest;
 import com.oing.dto.response.FamilyResponse;
 import com.oing.exception.AuthorizationFailedException;
 import com.oing.restapi.FamilyApi;
@@ -26,6 +27,16 @@ public class FamilyController implements FamilyApi {
         }
 
         Family family = familyService.getFamilyById(familyId);
+        return FamilyResponse.of(family);
+    }
+
+    @Override
+    public FamilyResponse updateFamilyName(String familyId, String loginFamilyId, String loginMemberId, UpdateFamilyNameRequest request) {
+        if (!familyId.equals(loginFamilyId)) {
+            throw new AuthorizationFailedException();
+        }
+
+        Family family = familyService.updateFamilyName(familyId, loginMemberId, request.familyName());
         return FamilyResponse.of(family);
     }
 }

--- a/family/src/main/java/com/oing/domain/Family.java
+++ b/family/src/main/java/com/oing/domain/Family.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.security.InvalidParameterException;
+
 @Entity(name = "family")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -20,13 +22,17 @@ public class Family extends BaseEntity {
     @Column(name = "family_name", columnDefinition = "CHAR(10)")
     private String familyName;
 
+    @Column(name = "family_name_editor_id", columnDefinition = "CHAR(26)")
+    private String familyNameEditorId;
+
     @Column(name = "score", nullable = false)
     private Integer score = 0;
 
 
-    public Family(String id, String familyName) {
+    public Family(String id, String familyName, String familyNameEditorId) {
         this.id = id;
         this.familyName = familyName;
+        this.familyNameEditorId = familyNameEditorId;
     }
 
     public static final int NEW_POST_SCORE = 20;
@@ -85,5 +91,22 @@ public class Family extends BaseEntity {
 
     public void resetScore() {
         this.score = 0;
+    }
+
+    public void updateFamilyName(String familyName, String loginFamilyId) {
+        if (familyName == null) {
+            this.familyName = null;
+            this.familyNameEditorId = null;
+        } else {
+            validateFamilyName(familyName);
+            this.familyName = familyName;
+            this.familyNameEditorId = loginFamilyId;
+        }
+    }
+
+    private void validateFamilyName(String familyName) {
+        if ((familyName.codePoints().count() > 10) || familyName.isBlank()) {
+            throw new InvalidParameterException();
+        }
     }
 }

--- a/family/src/main/java/com/oing/dto/request/UpdateFamilyNameRequest.java
+++ b/family/src/main/java/com/oing/dto/request/UpdateFamilyNameRequest.java
@@ -1,0 +1,13 @@
+package com.oing.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "가족 이름 수정 요청")
+public record UpdateFamilyNameRequest(
+
+        @Size(max = 10)
+        @Schema(description = "가족 이름", example = "오잉")
+        String familyName
+) {
+}

--- a/family/src/main/java/com/oing/dto/response/FamilyResponse.java
+++ b/family/src/main/java/com/oing/dto/response/FamilyResponse.java
@@ -14,6 +14,9 @@ public record FamilyResponse(
         @Schema(description = "가족 이름", example = "미밍이네")
         String familyName,
 
+        @Schema(description = "가족 이름 마지막 수정자 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String familyNameEditorId,
+
         @Schema(description = "가족 생성 시간", example = "2021-12-05T12:30:00.000+09:00")
         ZonedDateTime createdAt
 ) {
@@ -21,6 +24,7 @@ public record FamilyResponse(
         return new FamilyResponse(
                 family.getId(),
                 family.getFamilyName(),
+                family.getFamilyNameEditorId(),
                 family.getCreatedAt().atZone(ZoneId.systemDefault())
         );
     }

--- a/family/src/main/java/com/oing/dto/response/FamilyResponse.java
+++ b/family/src/main/java/com/oing/dto/response/FamilyResponse.java
@@ -11,12 +11,16 @@ public record FamilyResponse(
         @Schema(description = "가족 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
         String familyId,
 
+        @Schema(description = "가족 이름", example = "미밍이네")
+        String familyName,
+
         @Schema(description = "가족 생성 시간", example = "2021-12-05T12:30:00.000+09:00")
         ZonedDateTime createdAt
 ) {
     public static FamilyResponse of(Family family) {
         return new FamilyResponse(
                 family.getId(),
+                family.getFamilyName(),
                 family.getCreatedAt().atZone(ZoneId.systemDefault())
         );
     }

--- a/family/src/main/java/com/oing/restapi/FamilyApi.java
+++ b/family/src/main/java/com/oing/restapi/FamilyApi.java
@@ -1,7 +1,9 @@
 package com.oing.restapi;
 
+import com.oing.dto.request.UpdateFamilyNameRequest;
 import com.oing.dto.response.FamilyResponse;
 import com.oing.util.security.LoginFamilyId;
+import com.oing.util.security.LoginMemberId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,5 +29,24 @@ public interface FamilyApi {
             @Parameter(hidden = true)
             @LoginFamilyId
             String loginFamilyId
+    );
+
+    @Operation(summary = "가족 이름 변경", description = "가족 이름을 변경합니다.")
+    @PutMapping("/{familyId}/name")
+    FamilyResponse updateFamilyName(
+            @Parameter(description = "가족 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+            @PathVariable
+            String familyId,
+
+            @Parameter(hidden = true)
+            @LoginFamilyId
+            String loginFamilyId,
+
+            @Parameter(hidden = true)
+            @LoginMemberId
+            String loginMemberId,
+
+            @RequestBody
+            UpdateFamilyNameRequest request
     );
 }

--- a/family/src/main/java/com/oing/service/FamilyService.java
+++ b/family/src/main/java/com/oing/service/FamilyService.java
@@ -60,7 +60,7 @@ public class FamilyService {
 
     @Transactional
     public Family updateFamilyName(String familyId, String loginMemberId, String familyName) {
-        Family family = getFamilyByIdWithLock(familyId);
+        Family family = getFamilyById(familyId);
         family.updateFamilyName(familyName, loginMemberId);
         return family;
     }

--- a/family/src/main/java/com/oing/service/FamilyService.java
+++ b/family/src/main/java/com/oing/service/FamilyService.java
@@ -24,7 +24,7 @@ public class FamilyService {
 
     @Transactional
     public Family createFamily() {
-        Family family = new Family(identityGenerator.generateIdentity(), null);
+        Family family = new Family(identityGenerator.generateIdentity(), null, null);
         return familyRepository.save(family);
     }
 
@@ -56,5 +56,12 @@ public class FamilyService {
 
         // score 를 통한 순위를 통해 전체 가족들 중 상위 백분율 계산 (1%에 가까울수록 고순위)
         return familyScoreBridge.calculateFamilyTopPercentage(rank, familiesCount);
+    }
+
+    @Transactional
+    public Family updateFamilyName(String familyId, String loginMemberId, String familyName) {
+        Family family = getFamilyByIdWithLock(familyId);
+        family.updateFamilyName(familyName, loginMemberId);
+        return family;
     }
 }

--- a/family/src/test/java/com/oing/service/FamilyServiceTest.java
+++ b/family/src/test/java/com/oing/service/FamilyServiceTest.java
@@ -1,0 +1,80 @@
+package com.oing.service;
+
+import com.oing.domain.Family;
+import com.oing.repository.FamilyRepository;
+import com.oing.util.IdentityGenerator;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.security.InvalidParameterException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@Transactional
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class FamilyServiceTest {
+
+    @InjectMocks
+    private FamilyService familyService;
+    @Mock
+    private FamilyRepository familyRepository;
+    @Mock
+    private FamilyTopPercentageHistoryService familyTopPercentageHistoryService;
+    @Mock
+    private FamilyScoreBridge familyScoreBridge;
+    @Mock
+    private IdentityGenerator identityGenerator;
+
+    @Test
+    void 가족_이름_수정_테스트() {
+        // given
+        String newName = "new-name";
+        String memberId = "1";
+        String familyId = "1";
+
+        // when
+        when(familyRepository.findById(familyId)).thenReturn(Optional.of(new Family(familyId, null, null)));
+        Family family = familyService.updateFamilyName(familyId, memberId, newName);
+
+        // then
+        assertEquals(newName, family.getFamilyName());
+        assertEquals(memberId, family.getFamilyNameEditorId());
+    }
+
+    @Test
+    void 열_자_초과_가족_이름_수정_예외_검증() {
+        // given
+        String newName = "wrong-length-name";
+        String memberId = "1";
+        String familyId = "1";
+
+        // when
+        when(familyRepository.findById(familyId)).thenReturn(Optional.of(new Family(familyId, null, null)));
+
+        // then
+        assertThrows(InvalidParameterException.class, () -> familyService.updateFamilyName(familyId, memberId, newName));
+    }
+
+    @Test
+    void 공백만을_포함한_이름_수정_예외_검증() {
+        // given
+        String newName = " ";
+        String memberId = "1";
+        String familyId = "1";
+
+        // when
+        when(familyRepository.findById(familyId)).thenReturn(Optional.of(new Family(familyId, null, null)));
+
+        // then
+        assertThrows(InvalidParameterException.class, () -> familyService.updateFamilyName(familyId, memberId, newName));
+    }
+}

--- a/gateway/src/main/java/com/oing/controller/MainViewController.java
+++ b/gateway/src/main/java/com/oing/controller/MainViewController.java
@@ -30,6 +30,7 @@ public class MainViewController implements MainViewApi {
     private final MemberBridge memberBridge;
     private final MissionBridge missionBridge;
     private final PostController postController;
+    private final FamilyBridge familyBridge;
 
     private static final int PAGE_FETCH_SIZE = 1000;
 
@@ -75,10 +76,12 @@ public class MainViewController implements MainViewApi {
                 .isMeMissionUploadedToday();
         int leftUploadCountUntilMissionUnlock = postController.getRemainingSurvivalPostCount(loginMemberId, loginMemberId, familyId)
                 .leftUploadCountUntilMissionUnlock();
+        String familyName = familyBridge.findFamilyNameByFamilyId(familyId);
 
         return new DaytimePageResponse(
                 members.stream().sorted(comparator).map((member) -> new MainPageTopBarResponse(
                         member.memberId(),
+                        familyName,
                         member.imageUrl(),
                         String.valueOf(member.name().charAt(0)),
                         member.name(),
@@ -143,8 +146,10 @@ public class MainViewController implements MainViewApi {
     public NighttimePageResponse getNighttimePage(String loginMemberId, String loginFamilyId) {
         Page<FamilyMemberProfileResponse> members = memberService.getFamilyMembersProfilesByFamilyId(loginFamilyId, 1, PAGE_FETCH_SIZE);
         LocalDate today = ZonedDateTime.now().toLocalDate();
+        String familyName = familyBridge.findFamilyNameByFamilyId(loginFamilyId);
         List<MainPageTopBarResponse> mainPageTopBarResponses = members.stream().map((member) -> new MainPageTopBarResponse(
                 member.memberId(),
+                familyName,
                 member.imageUrl(),
                 String.valueOf(member.name().charAt(0)),
                 member.name(),

--- a/gateway/src/main/java/com/oing/dto/response/MainPageTopBarResponse.java
+++ b/gateway/src/main/java/com/oing/dto/response/MainPageTopBarResponse.java
@@ -13,6 +13,9 @@ public record MainPageTopBarResponse(
         @Schema(description = "멤버ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
         String memberId,
 
+        @Schema(description = "가족 이름", example = "미밍이네")
+        String familyName,
+
         @Schema(description = "이미지 URL", example = "https://no5ing.com/image/01HGW2N7EHJVJ4CJ999RRS2E97")
         String imageUrl,
 

--- a/gateway/src/main/resources/db/migration/V202406211527__add_family_name_editor_id_column_to_family_tbl.sql
+++ b/gateway/src/main/resources/db/migration/V202406211527__add_family_name_editor_id_column_to_family_tbl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `family` ADD COLUMN (`family_name_editor_id` CHAR(26) COMMENT 'ULID');

--- a/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
+++ b/gateway/src/test/java/com/oing/event/FamilyScoreEventListenerTest.java
@@ -68,7 +68,7 @@ class FamilyScoreEventListenerTest {
 
     @BeforeEach
     void setUp() {
-        familyRepository.save(new Family(testMember1.getFamilyId(), null));
+        familyRepository.save(new Family(testMember1.getFamilyId(), null, null));
         memberRepository.save(testMember1);
         memberRepository.save(testMember2);
     }

--- a/gateway/src/test/java/com/oing/repository/MemberRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/MemberRepositoryCustomTest.java
@@ -70,7 +70,7 @@ public class MemberRepositoryCustomTest {
     @BeforeEach
     void setup() {
         // Family & Members
-        familyRepository.save(new Family("testFamily", null));
+        familyRepository.save(new Family("testFamily", null, null));
         memberRepository.save(testMember1);
         memberRepository.save(testMember2);
         memberRepository.save(testMember3);

--- a/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
+++ b/gateway/src/test/java/com/oing/repository/PostRepositoryCustomTest.java
@@ -84,7 +84,7 @@ class PostRepositoryCustomTest {
     @BeforeEach
     void setup() {
         // Family & Members
-        familyRepository.save(new Family("testFamily", null));
+        familyRepository.save(new Family("testFamily", null, null));
         memberRepository.save(testMember1);
         memberRepository.save(testMember2);
         memberRepository.save(testMember3);


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
가족 이름 수정 API를 추가하고 조회 API의 응답에 가족 이름/가족 이름 수정자 필드를 추가했습니다

## ➕ 추가/변경된 기능

---
- 가족 이름 조회 API 추가
- 가족 조회 API 및 메인 뷰 API 응답에 가족 이름 관련 필드 추가
- 테스트 코드 추가

## 🥺 리뷰어에게 하고싶은 말

---


