### PR TITLE
[OING-343] refactor: 가족 이름 컬럼 타입 및 검증 로직 수정

### DIFF
--- a/family/src/main/java/com/oing/domain/Family.java
+++ b/family/src/main/java/com/oing/domain/Family.java
@@ -19,7 +19,7 @@ public class Family extends BaseEntity {
     @Column(name = "family_id", columnDefinition = "CHAR(26)", nullable = false)
     private String id;
 
-    @Column(name = "family_name", columnDefinition = "CHAR(10)")
+    @Column(name = "family_name", columnDefinition = "CHAR(9)")
     private String familyName;
 
     @Column(name = "family_name_editor_id", columnDefinition = "CHAR(26)")
@@ -105,7 +105,7 @@ public class Family extends BaseEntity {
     }
 
     private void validateFamilyName(String familyName) {
-        if ((familyName.codePoints().count() > 10) || familyName.isBlank()) {
+        if ((familyName.codePoints().count() > 9) || familyName.isBlank()) {
             throw new InvalidParameterException();
         }
     }

--- a/family/src/main/java/com/oing/domain/Family.java
+++ b/family/src/main/java/com/oing/domain/Family.java
@@ -86,14 +86,11 @@ public class Family extends BaseEntity {
     }
 
     public void updateFamilyName(String familyName, String loginFamilyId) {
-        if (familyName == null) {
-            this.familyName = null;
-            this.familyNameEditorId = null;
-        } else {
+        if (familyName != null) {
             validateFamilyName(familyName);
-            this.familyName = familyName;
-            this.familyNameEditorId = loginFamilyId;
         }
+        this.familyName = familyName;
+        this.familyNameEditorId = loginFamilyId;
     }
 
     private void validateFamilyName(String familyName) {

--- a/family/src/main/java/com/oing/domain/Family.java
+++ b/family/src/main/java/com/oing/domain/Family.java
@@ -85,12 +85,12 @@ public class Family extends BaseEntity {
         this.score = 0;
     }
 
-    public void updateFamilyName(String familyName, String loginFamilyId) {
+    public void updateFamilyName(String familyName, String familyNameEditorId) {
         if (familyName != null) {
             validateFamilyName(familyName);
         }
         this.familyName = familyName;
-        this.familyNameEditorId = loginFamilyId;
+        this.familyNameEditorId = familyNameEditorId;
     }
 
     private void validateFamilyName(String familyName) {

--- a/family/src/main/java/com/oing/domain/Family.java
+++ b/family/src/main/java/com/oing/domain/Family.java
@@ -49,14 +49,6 @@ public class Family extends BaseEntity {
         subtractScore(NEW_POST_SCORE);
     }
 
-    public void addAllFamilyMembersPostsUploadedScore() {
-        addScore(ALL_FAMILY_MEMBERS_POSTS_UPLOADED_SCORE);
-    }
-
-    public void subtractAllFamilyMembersPostsUploadedScore() {
-        subtractScore(ALL_FAMILY_MEMBERS_POSTS_UPLOADED_SCORE);
-    }
-
     public void addNewCommentScore() {
         addScore(NEW_COMMENT_SCORE);
     }

--- a/family/src/main/java/com/oing/dto/request/UpdateFamilyNameRequest.java
+++ b/family/src/main/java/com/oing/dto/request/UpdateFamilyNameRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "가족 이름 수정 요청")
 public record UpdateFamilyNameRequest(
 
-        @Size(max = 10)
+        @Size(max = 9)
         @Schema(description = "가족 이름", example = "오잉")
         String familyName
 ) {

--- a/family/src/test/java/com/oing/service/FamilyServiceTest.java
+++ b/family/src/test/java/com/oing/service/FamilyServiceTest.java
@@ -51,9 +51,9 @@ public class FamilyServiceTest {
     }
 
     @Test
-    void 열_자_초과_가족_이름_수정_예외_검증() {
+    void 아홉_자_초과_가족_이름_수정_예외_검증() {
         // given
-        String newName = "wrong-length-name";
+        String newName = "wrong-length-nam";
         String memberId = "1";
         String familyId = "1";
 

--- a/gateway/src/main/resources/V202406261718__alter_family_name_column_type.sql
+++ b/gateway/src/main/resources/V202406261718__alter_family_name_column_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `family` MODIFY `family_name` VARCHAR(9);


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
`family_name` 컬럼을 아홉자까지 허용하도록 수정하고 `familyName`을 초기화해도 수정자가 기록되도록 수정했습니다.

## ➕ 추가/변경된 기능

---
- `family_name` 컬럼을 아홉자까지 허용
- `familyName`을 초기화해도 수정자가 기록되도록 수정

## 🥺 리뷰어에게 하고싶은 말

---
확인해주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-343