### PR TITLE
[OING-345] hotfix: 가족 초대 링크 잘못된 primary key 변경

### DIFF
--- a/gateway/src/main/resources/db/migration/V202406291302__alter_family_invite_link_pk.sql
+++ b/gateway/src/main/resources/db/migration/V202406291302__alter_family_invite_link_pk.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `family_invite_link` DROP FOREIGN KEY `family_invite_link_fk1`;
+ALTER TABLE `family_invite_link` DROP PRIMARY KEY;
+ALTER TABLE `family_invite_link` ADD PRIMARY KEY (`link_id`);


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
가족 초대 링크 테이블 migration file에서 primary key가 다르게 설정되어 있어 운영서버에서 장애를 일으키는 걸 확인하고 수정했습니다.

## ➕ 추가/변경된 기능

---
- 가족 초대 링크 잘못된 primary key 변경

## 🥺 리뷰어에게 하고싶은 말

---
핫픽스라 바로 머지하겠습니다.



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-345