### PR TITLE
[OING-383] refact: saveVoiceComment RequestBody 변경

### DIFF
--- a/post/src/main/java/com/oing/controller/VoiceCommentController.java
+++ b/post/src/main/java/com/oing/controller/VoiceCommentController.java
@@ -4,6 +4,7 @@ import com.oing.domain.CommentType;
 import com.oing.domain.Post;
 import com.oing.domain.VoiceComment;
 import com.oing.dto.request.CreatePostCommentRequest;
+import com.oing.dto.request.CreatePostVoiceCommentRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.response.DefaultResponse;
 import com.oing.dto.response.PostCommentResponseV2;
@@ -34,7 +35,7 @@ public class VoiceCommentController implements VoiceCommentApi {
     @Override
     @Transactional
     public PostCommentResponseV2 createPostVoiceComment(String postId,
-                                                        CreatePostCommentRequest request, String loginMemberId) {
+                                                        CreatePostVoiceCommentRequest request, String loginMemberId) {
         log.info("Member {} is trying to create voice-comment", loginMemberId);
         Post post = postService.getMemberPostById(postId);
 

--- a/post/src/main/java/com/oing/controller/VoiceCommentController.java
+++ b/post/src/main/java/com/oing/controller/VoiceCommentController.java
@@ -3,7 +3,6 @@ package com.oing.controller;
 import com.oing.domain.CommentType;
 import com.oing.domain.Post;
 import com.oing.domain.VoiceComment;
-import com.oing.dto.request.CreatePostCommentRequest;
 import com.oing.dto.request.CreatePostVoiceCommentRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.response.DefaultResponse;

--- a/post/src/main/java/com/oing/dto/request/CreatePostVoiceCommentRequest.java
+++ b/post/src/main/java/com/oing/dto/request/CreatePostVoiceCommentRequest.java
@@ -1,0 +1,14 @@
+package com.oing.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "피드 게시물 음성 댓글 생성 요청")
+public record CreatePostVoiceCommentRequest(
+        @NotBlank
+        @Size(max = 255)
+        @Schema(description = "fileUrl", example = "음성 댓글 파일 주소", maxLength = 255)
+        String fileUrl
+) {
+}

--- a/post/src/main/java/com/oing/restapi/VoiceCommentApi.java
+++ b/post/src/main/java/com/oing/restapi/VoiceCommentApi.java
@@ -1,6 +1,6 @@
 package com.oing.restapi;
 
-import com.oing.dto.request.CreatePostCommentRequest;
+import com.oing.dto.request.CreatePostVoiceCommentRequest;
 import com.oing.dto.request.PreSignedUrlRequest;
 import com.oing.dto.response.DefaultResponse;
 import com.oing.dto.response.PostCommentResponseV2;
@@ -38,7 +38,7 @@ public interface VoiceCommentApi {
 
             @Valid
             @RequestBody
-            CreatePostCommentRequest request,
+            CreatePostVoiceCommentRequest request,
 
             @Parameter(hidden = true)
             @LoginMemberId

--- a/post/src/main/java/com/oing/service/VoiceCommentService.java
+++ b/post/src/main/java/com/oing/service/VoiceCommentService.java
@@ -2,7 +2,7 @@ package com.oing.service;
 
 import com.oing.domain.Post;
 import com.oing.domain.VoiceComment;
-import com.oing.dto.request.CreatePostCommentRequest;
+import com.oing.dto.request.CreatePostVoiceCommentRequest;
 import com.oing.dto.response.PreSignedUrlResponse;
 import com.oing.exception.AuthorizationFailedException;
 import com.oing.exception.MemberVoiceCommentNotFoundException;
@@ -37,14 +37,14 @@ public class VoiceCommentService {
     }
 
     @Transactional
-    public VoiceComment saveVoiceComment(Post post, CreatePostCommentRequest request, String loginMemberId) {
+    public VoiceComment saveVoiceComment(Post post, CreatePostVoiceCommentRequest request, String loginMemberId) {
         validateFamilyMember(loginMemberId, post);
 
         VoiceComment voiceComment = new VoiceComment(
                 identityGenerator.generateIdentity(),
                 post,
                 loginMemberId,
-                request.content()
+                request.fileUrl()
         );
         VoiceComment savedVoiceComment = voiceCommentRepository.save(voiceComment);
         post.addVoiceComment(savedVoiceComment);

--- a/post/src/test/java/com/oing/service/VoiceCommentServiceTest.java
+++ b/post/src/test/java/com/oing/service/VoiceCommentServiceTest.java
@@ -3,7 +3,7 @@ package com.oing.service;
 import com.oing.domain.Post;
 import com.oing.domain.PostType;
 import com.oing.domain.VoiceComment;
-import com.oing.dto.request.CreatePostCommentRequest;
+import com.oing.dto.request.CreatePostVoiceCommentRequest;
 import com.oing.repository.VoiceCommentRepository;
 import com.oing.util.IdentityGenerator;
 import com.oing.util.PreSignedUrlGenerator;
@@ -42,7 +42,7 @@ public class VoiceCommentServiceTest {
         String familyId = "1";
         Post post = new Post("1", memberId, familyId, PostType.SURVIVAL, "https://oing.com/post.jpg", "post.jpg",
                 "안녕.오잉.");
-        CreatePostCommentRequest request = new CreatePostCommentRequest("1");
+        CreatePostVoiceCommentRequest request = new CreatePostVoiceCommentRequest("1");
         VoiceComment comment = new VoiceComment("1", null, "1", "https://oing.com/audio.mp3");
 
         when(memberBridge.isInSameFamily(memberId, post.getMemberId())).thenReturn(true);


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
프론트의 요청으로 기존에 사용하던 `CreatePostCommentRequest` 대신 `CreatePostVoiceCommentRequest`로 수정했습니다

## ➕ 추가/변경된 기능

---
- saveVoiceComment RequestBody 변경

## 🥺 리뷰어에게 하고싶은 말

---
확인해주세요~



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-383

## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-383