### PR TITLE
[OING-386] refactor: NotificationResponse에 발송자 memberId 추가

### DIFF
--- a/gateway/src/main/java/com/oing/dto/response/NotificationResponse.java
+++ b/gateway/src/main/java/com/oing/dto/response/NotificationResponse.java
@@ -12,6 +12,9 @@ public record NotificationResponse(
         @Schema(description = "노티 ID", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
         String notificationId,
 
+        @Schema(description = "발송자 memberId", example = "01HGW2N7EHJVJ4CJ999RRS2E97")
+        String senderMemberId,
+
         @Schema(description = "발송자 프로필 이미지 url", example = "https://..")
         String senderProfileImageUrl,
 
@@ -33,9 +36,10 @@ public record NotificationResponse(
         @Schema(description = "알림 생성 시간", example = "2023-12-23T01:53:21.577347+09:00")
         ZonedDateTime createdAt
 ) {
-    public static NotificationResponse of(MemberNotificationHistory memberNotificationHistory, String senderProfileImageUrl, ProfileStyle profileStyle) {
+    public static NotificationResponse of(MemberNotificationHistory memberNotificationHistory, String senderMemberId, String senderProfileImageUrl, ProfileStyle profileStyle) {
         return new NotificationResponse(
                 memberNotificationHistory.getId(),
+                senderMemberId,
                 senderProfileImageUrl,
                 profileStyle,
                 memberNotificationHistory.getTitle(),

--- a/gateway/src/main/java/com/oing/service/MemberNotificationHistoryService.java
+++ b/gateway/src/main/java/com/oing/service/MemberNotificationHistoryService.java
@@ -123,9 +123,10 @@ public class MemberNotificationHistoryService {
                         senderProfileStyle = ProfileStyle.BIRTHDAY;
                     }
 
-                    String senderProfileImageUrl = memberBridge.getMemberProfileImgUrlByMemberId(userNotificationHistory.getSenderMemberId());
+                    String senderMemberId = userNotificationHistory.getSenderMemberId();
+                    String senderProfileImageUrl = memberBridge.getMemberProfileImgUrlByMemberId(senderMemberId);
 
-                    return NotificationResponse.of(userNotificationHistory, senderProfileImageUrl, senderProfileStyle);
+                    return NotificationResponse.of(userNotificationHistory, senderMemberId, senderProfileImageUrl, senderProfileStyle);
 
                 })
                 .toList();


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
프론트의 요청으로 NotificationResponse에 발송자 memberId를 추가했습니다

## ➕ 추가/변경된 기능

---
- NotificationResponse에 발송자 memberId 추가

## 🥺 리뷰어에게 하고싶은 말

---
< 여기에 하고싶은 말 >



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-386