### PR TITLE
feat: member_notification_history 테이블 receiver_member_id, created_at 인덱스 추가

### DIFF
--- a/gateway/src/main/resources/db/migration/V202503281417__add_index_receiver_created_at_to_member_notification_history.sql
+++ b/gateway/src/main/resources/db/migration/V202503281417__add_index_receiver_created_at_to_member_notification_history.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_receiver_created_at
+    ON member_notification_history (receiver_member_id, created_at DESC);


### PR DESCRIPTION
## ❓ 기능 추가 배경

---
`member_notification_history` 테이블 `receiver_member_id`, `created_at` 인덱스 추가

## ➕ 추가/변경된 기능

---
- `member_notification_history` 테이블 `receiver_member_id`, `created_at` 인덱스 추가

## 🥺 리뷰어에게 하고싶은 말

---
인덱스 추가 작업이라 바로 머지하겠습니다



## 🔗 참조 or 관련된 이슈

---
https://no5ing.atlassian.net/browse/OING-391